### PR TITLE
Fixed invalid range

### DIFF
--- a/apps/server/lib/lexical/server/project/diagnostics.ex
+++ b/apps/server/lib/lexical/server/project/diagnostics.ex
@@ -141,6 +141,12 @@ defmodule Lexical.Server.Project.Diagnostics do
           start: Position.new(line: line_number, character: character),
           end: Position.new(line: line_number + 1, character: 0)
         )
+      else
+        _ ->
+          Range.new(
+            start: Position.new(line: 0, character: 0),
+            end: Position.new(line: 1, character: 0)
+          )
       end
     end
 


### PR DESCRIPTION
It was possible that converting a range could fail, and we'd emit "error" as the range in that case. This commit fixes that possibility, but we should investigate why the conversion failed in the first place.

Fixes #16 