### PR TITLE
Bump elixir_sense and sourceror version

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
-  "earmark_parser": {:hex, :earmark_parser, "1.4.30", "0b938aa5b9bafd455056440cdaa2a79197ca5e693830b4a982beada840513c5f", [:mix], [], "hexpm", "3b5385c2d36b0473d0b206927b841343d25adb14f95f0110062506b300cd5a1b"},
-  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "6d1a951bfbfc02e93b410acded82c736e1806df2", []},
-  "ex_doc": {:hex, :ex_doc, "0.29.1", "b1c652fa5f92ee9cf15c75271168027f92039b3877094290a75abcaac82a9f77", [:mix], [{:earmark_parser, "~> 1.4.19", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "b7745fa6374a36daf484e2a2012274950e084815b936b1319aeebcf7809574f6"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.31", "a93921cdc6b9b869f519213d5bc79d9e218ba768d7270d46fdcf1c01bacff9e2", [:mix], [], "hexpm", "317d367ee0335ef037a87e46c91a2269fef6306413f731e8ec11fc45a7efd059"},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "64c4afe4f59cf22fd44302373fa88a606df941c8", []},
+  "ex_doc": {:hex, :ex_doc, "0.29.2", "dfa97532ba66910b2a3016a4bbd796f41a86fc71dd5227e96f4c8581fdf0fdf0", [:mix], [{:earmark_parser, "~> 1.4.19", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "6b5d7139eda18a753e3250e27e4a929f8d2c880dd0d460cb9986305dea3e03af"},
   "jason": {:hex, :jason, "1.4.0", "e855647bc964a44e2f67df589ccf49105ae039d4179db7f6271dfd3843dc27e6", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "79a3791085b2a0f743ca04cec0f7be26443738779d09302e01318f97bdb82121"},
   "logger_file_backend": {:hex, :logger_file_backend, "0.0.13", "df07b14970e9ac1f57362985d76e6f24e3e1ab05c248055b7d223976881977c2", [:mix], [], "hexpm", "71a453a7e6e899ae4549fb147b1c6621f4233f8f48f58ca10a64ec67b6c50018"},
   "makeup": {:hex, :makeup, "1.1.0", "6b67c8bc2882a6b6a445859952a602afc1a41c2e08379ca057c0f525366fc3ca", [:mix], [{:nimble_parsec, "~> 1.2.2 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "0a45ed501f4a8897f580eabf99a2e5234ea3e75a4373c8a52824f6e873be57a6"},
@@ -10,6 +10,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "patch": {:hex, :patch, "0.12.0", "2da8967d382bade20344a3e89d618bfba563b12d4ac93955468e830777f816b0", [:mix], [], "hexpm", "ffd0e9a7f2ad5054f37af84067ee88b1ad337308a1cb227e181e3967127b0235"},
   "path_glob": {:hex, :path_glob, "0.2.0", "b9e34b5045cac5ecb76ef1aa55281a52bf603bf7009002085de40958064ca312", [:mix], [{:nimble_parsec, "~> 1.2.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "be2594cb4553169a1a189f95193d910115f64f15f0d689454bb4e8cfae2e7ebc"},
-  "sourceror": {:hex, :sourceror, "0.11.2", "549ce48be666421ac60cfb7f59c8752e0d393baa0b14d06271d3f6a8c1b027ab", [:mix], [], "hexpm", "9ab659118896a36be6eec68ff7b0674cba372fc8e210b1e9dc8cf2b55bb70dfb"},
+  "sourceror": {:hex, :sourceror, "0.12.1", "239a98ae2ed191528d64e079eaa355f6f1f69318dbb51796e08497dd3b24d10e", [:mix], [], "hexpm", "b5e310385813d0c791e8a481516654a4e10b7a0fdb55b4fc4ef915fbc0899b8f"},
   "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
 }


### PR DESCRIPTION
When I was using `elixir-ls` with lexical, I found that I couldn't `go to definition` and server  would give me an error until I upgraded to the elixir-sense version, which was really annoying.

I suspect that elixir-ls is using the version of elixir-sense of lexical, and recently it upgraded: https://github.com/elixir-lsp/elixir_sense/commit/ed875265f54994911774ac05c3a1b9adb65b80e7#diff-f4e1ec56e59cc972c55522ee3738be948f7edac5a904b4bc91d6f8992cc0df10

So it can not find the correct function:

```
[ERROR][2023-03-16 17:13:43] ...lsp/handlers.lua:533	'** (UndefinedFunctionError) function ElixirSense.Providers.Definition.find/7 is undefined or private\n    (elixir_sense 2.0.0) ElixirSense.Providers.Definition.find("to_protocol", 71, 37, %ElixirSense.Core.State.Env{imports: [], requires: [Logger], aliases: [{CodeUnit, Lexical.CodeUnit}, {Math, Lexical.Math}, {SourceFile, Lexical.SourceFile}, {Project, Lexical.Project}, {Diagnostic, Lexical.Protocol.Types.Diagnostic}, {Position, Lexical.Protocol.Types.Position}, {Range, Lexical.Protocol.Types.Range}, {Compiler, Mix.Task.Compiler}], module: Lexical.Server.Project.Diagnostics.State, module_variants: [Lexical.Server.Project.Diagnostics.State], protocol: nil, protocol_variants: [], vars: [%ElixirSense.Core.State.VarInfo{name: :error, positions: [{68, 51}], scope_id: 4, is_definition: true, type: {:struct, [], {:atom, Mix.Error}, nil}}, %ElixirSense.Core.State.VarInfo{name: :lsp_diagnostic, positions: [{71, 18}], scope_id: 20, is_definition: true, type: {:tuple_nth, {:intersection, [{:local_call, :to_protocol, [variable: :error, variable: :project_uri]}, {:tuple, 2, [{:atom, :ok}, nil]}]}, 1}}, %ElixirSense.Core.State.VarInfo{name: :project_uri, positions: [{69, 7}], scope_id: 19, is_definition: true, type: {:call, {:call, {:variable, :state}, :project, []}, :mix_exs_uri, []}}, %ElixirSense.Core.State.VarInfo{name: :state, positions: [{68, 29}, {69, 21}], scope_id: 4, is_definition: true, type: {:struct, [], {:atom, Lexical.Server.Project.Diagnostics.State}, nil}}], attributes: [], behaviours: [], scope: {:add, 2}, scope_id: 20}, %{{Lexical.Server.Project.Diagnostics, :child_spec, 1} => %ElixirSense.Core.State.ModFunInfo{params: [[{:=, [line: 188, column: 29], [{:%, [line: 188, column: 18], [{:__aliases__, [line: 188, column: 19], [:Project]}, {:%{}, [line: 188, column: 26], []}]}, {:project, [line: 188, column: 31], nil}]}], [{:init_arg, [counter: -576460752303322431, keep: {"lib/gen_server.ex", 762}], GenServer}]], positions: [{188, 7}, {182, 3}], target: nil, type: :def, overridable: {true, GenServer}}, {Lexical.Server.Project.Diagnostics.State, :__info__, 1} => %ElixirSense.Core.State.ModFunInfo{params: [[{:atom, [line: 2, column: 13], nil}]], positions: [{2, 13}], target: nil, type: :def, overridable: false}, {Lexical.Server.Project.Diagnostics, :code_change, nil} => %ElixirSense.Core.State.ModFunInfo{params: [[{:_old, [counter: -576460752303322431, keep: {"lib/gen_server.ex", 845}], GenServer}, {:state, [counter: -576460752303322431, keep: {"lib/gen_server.ex", 845}], GenServer}, {:_extra, [counter: -576460752303322431, keep: {"lib/gen_server.ex", 845}], GenServer}]], positions: [{182, 3}], target: nil, type: :def, overridable: {true, GenServer}}, {Lexical.Server.Project.Diagnostics.State, :add, 2} => %ElixirSense.Core.State.ModFunInfo{params: [[{:=, [line: 97, column: 27], [{:%, [line: 97, column: 13], [{:__MODULE__, [line: 97, column: 14], nil}, {:%{}, [line: 97, column: 24], []}]}, {:state, [line: 97, column: 29], nil}]}, {:other, [line: 97, column: 36], nil}], [{:=, [line: 84, column: 27], [{:%, [line: 84, column: 13], [{:__MODULE__, [line: 84, column: 14], nil}, {:%{}, [line: 84, column: 24], []}]}, {:state, [line: 84, column: 29], nil}]}, {:=, [line: 84, column: 59], [{:%, [line: 84, column: 36], [{:__aliases__, [line: 84, column: 37], [:Compiler, :Diagnostic]}, {:%{}, [line: 84, column: 56], []}]}, {:diagnostic, [line: 84, column: 61], nil}]}], [{:=, [line: 68, column: 27], [{:%, [line: 68, column: 13], [{:__MODULE__, [line: 68, column: 14], nil}, {:%{}, [line: 68, column: 24], []}]}, {:state, [line: 68, column: 29], nil}]}, {:=, [line: 68, column: 49], [{:%, [line: 68, column: 36], [{:__aliases__, [line: 68, column: 37], [:Mix, :Error]}, {:%{}, [line: 68, column: 46], []}]}, {:error, [line: 68, column: 51], nil}]}]], positions: [{97, 9}, {84, 9}, {68, 9}], target: nil, type: :def, overridable: false}, {Lexical.Server.Project.Diagnostics.State, :add, 3} => %ElixirSense.Core.State.ModFunInfo{params: [[{:=, [line: 63, column: 27], [{:%, [line: 63, column: 13], [{:__MODULE__, [line: 63, column: 14], nil}, {:%{}, [line: 63, column: 24], []}]}, {:state, [line: 63, column: 29], nil}]}, {:not_a_diagnostic, [line: 63, column: 36], nil}, {:=, [line: 63, column: 68], [{:%, [line: 63, column: 54], [{:__aliases__, [line: 63, column: 55], [:SourceFile]}, {:%{}, [line: 63, column: 65], []}]}, {:source_file, [line: 63, column: 70], nil}]}], [{:=, [line: 49, column: 27], [{:%, [line: 49, column: 13], [{:__MODULE__, [line: 49, column: 14], nil}, {:%{}, [line: 49, column: 24], []}]}, {:state, [line: 49, column: 29], nil}]}, {:=, [line: 49, column: 59], [{:%, [line: 49, column: 36], [{:__aliases__, [line: 49, column: 37], [:Compiler, :Diagnostic]}, {:%{}, [line: 49, column: 56], []}]}, {:diagnostic, [line: 49, column: 61], nil}]}, {:source_file_uri, [line: 49, column: 73], nil}]], positions: [{63, 9}, {49, 9}], target: nil, type: :def, overridable: false}, {Lexical.Server.Project.Diagnostics, :terminate, nil} => %ElixirSense.Core.State.ModFunInfo{params: [[{:_reason, [counter: -576460752303322431, keep: {"lib/gen_server.ex", 840}], GenServer}, {:_state, [counter: -576460752303322431, keep: {"lib/gen_server.ex", 840}], GenServer}]], positions: [{182, 3}], target: nil, type: :def, overridable: {true, GenServer}}, {Lexical.Server.Project.Diagnostics.State, :__struct__, nil} => %ElixirSense.Core.State.ModFunInfo{params: [[{:kv, [line: 12, column: 5], nil}], []], positions: [{12, 5}, {12, 5}], target: nil, type: :def, overridable: false}, {Lexical.Server.Project.Diagnostics.State, :clear, 2} => %ElixirSense.Core.State.ModFunInfo{params: [[{:=, [line: 24, column: 29], [{:%, [line: 24, column: 15], [{:__MODULE__, [line: 24, column: 16], nil}, {:%{}, [line: 24, column: 26], []}]}, {:state, [line: 24, column: 31], nil}]}, {:source_uri, [line: 24, column: 38], nil}]], positions: [{24, 9}], target: nil, type: :def, overridable: false}, {Lexical.Server.Project.Diagnostics, :handle_cast, nil} => %ElixirSense.Core.State.ModFunInfo{params: [[{:msg, [counter: -576460752303322431, keep: {"lib/gen_server.ex", 822}], GenServer}, {:state, [counter: -576460752303322431, keep: {"lib/gen_server.ex", 822}], GenServer}]], positions: [{182, 3}], target: nil, type: :def, overridable: {true, GenServer}}, {Lexical.Server.Project.Diagnostics, :report_diagnostic_error, 2} => %ElixirSense.Core.State.ModFunInfo{params: [[{:diagnostic, [line: 277, column: 32], nil}, {:reason, [line: 277, column: 44], nil}]], positions: [{277, 8}], target: nil, type: :defp, overridable: false}, {Lexical.Server.Project.Diagnostics.State, :ensure_string, 1} => %ElixirSense.Core.State.ModFunInfo{params: [[{:message, [line: 139, column: 24], nil}], [{:message, [line: 135, column: 24], nil}]], positions: [{139, 10}, {135, 10}], target: nil, type: :defp, overridable: false}, {Lexical.Server.Project.Diagnostics.State, :clear_all_flushed, 1} => %ElixirSense.Core.State.ModFunInfo{params: [[{:=, [line: 33, column: 41], [{:%, [line: 33, column: 27], [{:__MODULE__, [line: 33, column: 28], nil}, {:%{}, [line: 33, column: 38], []}]}, {:state, [line: 33, column: 43], nil}]}]], positions: [{33, 9}], target: nil, type: :def, overridable: false}, {Lexical.Server.Project.Diagnostics, :handle_call, 3} => %ElixirSense.Core.State.ModFunInfo{params: [[{:msg, [counter: -576460752303322431, keep: {"lib/gen_server.ex", 777}], GenServer}, {:_from, [counter: -576460752303322431, keep: {"lib/gen_server.ex", 777}], GenServer}, {:state, [counter: -576460752303322431, keep: {"lib/gen_server.ex", 777}], GenServer}]], positions: [{182, 3}], target: nil, type: :def, overridable: {true, GenServer}}, {Lexical.Server.Project.Diagnostics, :init, nil} => %ElixirSense.Core.State.ModFunInfo{params: [[[{:=, [line: 198, column: 24], [{:%, [line: 198, column: 13], [{:__aliases__, [line: 198, column: 14], [:Project]}, {:%{}, [line: 198, column: 21], []}]}, {:project, [line: 198, column: 26], nil}]}]]], positions: [{198, 7}], target: nil, type: :def, overridable: false}, {Lexical.Server.Project.Diagnostics.State, :position_to_range, 2} => %ElixirSense (truncated)'
```

Elixir-ls and projects that contaminate each other are really annoying.
