### PR TITLE
Support hex config

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control.ex
+++ b/apps/remote_control/lib/lexical/remote_control.ex
@@ -9,7 +9,7 @@ defmodule Lexical.RemoteControl do
   alias Lexical.RemoteControl
   alias Lexical.RemoteControl.Build
 
-  @allowed_apps ~w(hex common path_glob remote_control elixir_sense)a
+  @allowed_apps ~w(common path_glob remote_control elixir_sense)a
 
   @app_globs Enum.map(@allowed_apps, fn app_name -> "/**/#{app_name}*/ebin" end)
 


### PR DESCRIPTION
We need to support hex config for several reasons.

1. some countries do not have direct access to `hex.pm` and they need to set up a proxy: `mix hex.config https_proxy http://127.0.0.1:7890 && mix hex.config http_proxy http://127.0.0.1:7890`
2. Some libraries require an API key, like `oban pro`.


```elixir
iex(1)> project_path = Path.expand("apps/remote_control")
"/Users/user/Code/lexical/apps/remote_control"
iex(2)> project_uri = "file://#{project_path}"
"file:///Users/user/Code/lexical/apps/remote_control"
iex(3)> project = Lexical.Project.new(project_uri)
%Lexical.Project{
  root_uri: "file:///Users/user/Code/lexical/apps/remote_control",
  mix_exs_uri: "file:///Users/user/Code/lexical/apps/remote_control/mix.exs",
  mix_project?: true,
  mix_env: nil,
  mix_target: nil,
  env_variables: %{}
}
iex(4)> {:ok, node} = start_project project
{:ok, #PID<0.334.0>}
iex(manager-34724@127.0.0.1)6> RemoteControl.call(project, Hex.Config, :read, [])
[
  "$write_key": "a-key"
  "$repos": %{
    "oban" => %{
    }
  },
  https_proxy: "http://127.0.0.1:7890",
  http_proxy: "http://127.0.0.1:7890"
]
iex(manager-34724@127.0.0.1)7>
```

And, we do not need `apps/remote_control/.iex.exs` anymore, so I delete it.