### PR TITLE
Fix remote_control cannot be compiled

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control.ex
+++ b/apps/remote_control/lib/lexical/remote_control.ex
@@ -9,7 +9,7 @@ defmodule Lexical.RemoteControl do
   alias Lexical.RemoteControl
   alias Lexical.RemoteControl.Build
 
-  @allowed_apps ~w(common path_glob remote_control elixir_sense)a
+  @allowed_apps ~w(jason common path_glob remote_control elixir_sense)a
 
   @app_globs Enum.map(@allowed_apps, fn app_name -> "/**/#{app_name}*/ebin" end)
 

--- a/apps/remote_control/mix.exs
+++ b/apps/remote_control/mix.exs
@@ -33,6 +33,7 @@ defmodule Lexical.RemoteControl.MixProject do
 
   defp deps do
     [
+      {:jason, "~> 1.4"},
       {:common, in_umbrella: true},
       {:common_protocol, in_umbrella: true},
       {:path_glob, "~> 0.2", optional: true},


### PR DESCRIPTION
```elixir
~/Co/lexical/a/remote_control main !1 ?1 ❯ mix deps.safe_compile                                         13s erl 25.2.1  2.7.2
==> nimble_parsec
Compiling 4 files (.ex)
Generated nimble_parsec app
==> common
Compiling 15 files (.ex)
Generated common app
==> elixir_sense
Compiling 55 files (.ex)
warning: variable "module" is unused (there is a variable with the same name in the context, use the pin operator (^) to match on it or prefix this variable with underscore if it is not meant to be used)
  lib/elixir_sense/core/metadata_builder.ex:115: ElixirSense.Core.MetadataBuilder.post_module/3

Generated elixir_sense app
==> patch
Compiling 41 files (.ex)
Generated patch app
==> proto
Compiling 24 files (.ex)

== Compilation error in file lib/lexical/protocol/proto/lsp_types.ex ==
** (ArgumentError) could not load module Jason.Encoder due to reason :nofile
    (elixir 1.14.3) lib/protocol.ex:323: Protocol.assert_protocol!/2
    lib/lexical/protocol/proto/lsp_types.ex:23: (module)
    lib/lexical/protocol/proto/lsp_types.ex:21: (module)
could not compile dependency :proto, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile proto", update it with "mix deps.update proto" or clean it with "mix deps.clean proto"
```

There are two ways to fix this problem.

One way is just remove the `optional: true` from the json deps of `proto/mix.exs`.

Another way is this pr and must add the app to the allowed app, otherwise, we will encounter this error:


```elixir
19:26:37.316 [error] Child {Lexical.Server.Project.Dispatch, "remote_control"} of Supervisor :"remote_control::supervisor" failed to start
** (exit) an exception was raised:
    ** (MatchError) no match of right hand side value: {:error, {:jason, {'no such file or directory', 'jason.app'}}}
        (server 0.1.0) lib/lexical/server/project/dispatch.ex:98: Lexical.Server.Project.Dispatch.init/1
        (stdlib 4.2) gen_server.erl:851: :gen_server.init_it/2
        (stdlib 4.2) gen_server.erl:814: :gen_server.init_it/6
        (stdlib 4.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```


