### PR TITLE
Added cancel requests

### DIFF
--- a/apps/common/.formatter.exs
+++ b/apps/common/.formatter.exs
@@ -1,4 +1,6 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: [assert_eventually: 1, assert_eventually: 2],
+  export: [locals_without_parens: [assert_eventually: 1, assert_eventually: 2]]
 ]

--- a/apps/common/test/support/eventual_assertions.ex
+++ b/apps/common/test/support/eventual_assertions.ex
@@ -1,0 +1,64 @@
+defmodule Testing.EventualAssertions do
+  @moduledoc """
+  Assertion macros for an eventually consistent world
+  Sometimes, despite our best efforts, we want to assert that some condition holds, but it doesn't
+  hold just _yet_. Enter `eventual_assertions`. This module will repeatedly try your assertions
+  and stop when they're true (or false). It does all of this without using `Elixir.Process.sleep/1`.
+  Use just like you would `assert` or `refute`
+      assert_eventually User.find_by_id(my_id) == %User{short_name: "Stinky"}
+      refute_eventually User.exists?(3)
+  """
+  defmacro __using__(_) do
+    quote do
+      require unquote(__MODULE__)
+      import unquote(__MODULE__)
+    end
+  end
+
+  defp do_eventually(func, {:=, _, [left, _right]} = assertion, timeout) do
+    quote do
+      timer_ref = Process.send_after(self(), :assert_timeout, unquote(timeout))
+
+      asserter = fn ->
+        unquote(func)(unquote(assertion))
+      end
+
+      unquote(left) = apply_assert(asserter, unquote(timeout), timer_ref)
+    end
+  end
+
+  defp do_eventually(func, assertion, timeout) do
+    quote do
+      timer_ref = Process.send_after(self(), :assert_timeout, unquote(timeout))
+
+      asserter = fn ->
+        unquote(func)(unquote(assertion))
+      end
+
+      apply_assert(asserter, unquote(timeout), timer_ref)
+    end
+  end
+
+  def apply_assert(assert, timeout, timer_ref) do
+    rv = assert.()
+    Process.cancel_timer(timer_ref)
+    rv
+  rescue
+    e in ExUnit.AssertionError ->
+      receive do
+        :assert_timeout ->
+          reraise %{e | message: e.message <> " after #{timeout} ms"}, __STACKTRACE__
+      after
+        1 ->
+          apply_assert(assert, timeout, timer_ref)
+      end
+  end
+
+  defmacro assert_eventually(assertion, timeout \\ 100) do
+    do_eventually(:assert, assertion, timeout)
+  end
+
+  defmacro refute_eventually(assertion, timeout \\ 100) do
+    do_eventually(:refute, assertion, timeout)
+  end
+end

--- a/apps/protocol/lib/lexical/protocol/requests.ex
+++ b/apps/protocol/lib/lexical/protocol/requests.ex
@@ -19,6 +19,12 @@ defmodule Lexical.Protocol.Requests do
       workspace_folders: optional(list_of(Types.Workspace.Folder))
   end
 
+  defmodule Cancel do
+    use Proto
+
+    defrequest "$/cancelRequest", :exclusive, id: one_of([string(), integer()])
+  end
+
   defmodule FindReferences do
     use Proto
 

--- a/apps/server/.formatter.exs
+++ b/apps/server/.formatter.exs
@@ -1,9 +1,9 @@
 # Used by "mix format"
 imported_deps =
   if Mix.env() == :test do
-    [:patch]
+    [:patch, :common]
   else
-    []
+    [:common]
   end
 
 [

--- a/apps/server/lib/lexical/server.ex
+++ b/apps/server/lib/lexical/server.ex
@@ -82,6 +82,11 @@ defmodule Lexical.Server do
     end
   end
 
+  def handle_message(%Requests.Cancel{} = cancel_request, %State{} = state) do
+    Provider.Queue.cancel(to_string(cancel_request.id))
+    {:ok, state}
+  end
+
   def handle_message(%message_module{} = message, %State{} = state)
       when message_module in @server_specific_messages do
     case apply_to_state(state, message) do

--- a/apps/server/test/lexical/server/provider/queue_test.exs
+++ b/apps/server/test/lexical/server/provider/queue_test.exs
@@ -1,0 +1,120 @@
+defmodule Lexical.Server.Provider.QueueTest do
+  alias Lexical.Protocol.Requests
+  alias Lexical.Server.Provider.Env
+  alias Lexical.Server.Provider.Queue
+  alias Lexical.Server.Provider.Handlers
+  alias Lexical.Server.Transport
+
+  use ExUnit.Case
+  use Patch
+  use Testing.EventualAssertions
+
+  setup do
+    {:ok, _} = start_supervised(Queue.Supervisor.child_spec())
+    {:ok, _} = start_supervised(Queue)
+    unit_test = self()
+    patch(Transport, :write, &send(unit_test, &1))
+
+    :ok
+  end
+
+  def request(id, func) do
+    patch(Handlers.Completion, :handle, fn request, env -> func.(request, env) end)
+    patch(Handlers, :for_request, fn _ -> {:ok, Handlers.Completion} end)
+    patch(Requests.Completion, :to_elixir, fn req -> {:ok, req} end)
+    Requests.Completion.new(id: id, text_document: nil, position: nil, context: nil)
+  end
+
+  describe "size/0" do
+    test "an empty queue has size 0" do
+      assert 0 == Queue.size()
+    end
+
+    test "adding a request makes the queue grow" do
+      request = request(1, fn _, _ -> Process.sleep(500) end)
+      assert :ok = Queue.add(request, Env.new())
+      assert 1 == Queue.size()
+    end
+  end
+
+  describe "cancel/1" do
+    test "canceling a request stops it" do
+      request = request("1", fn _, _ -> Process.sleep(500) end)
+      assert :ok = Queue.add(request, Env.new())
+
+      :ok = Queue.cancel("1")
+
+      assert_receive %{id: "1", error: error}
+
+      assert Queue.size() == 0
+      assert error.code == :request_cancelled
+      assert error.message == "Request cancelled"
+    end
+
+    test "integers are stringified" do
+      request = request("1", fn _, _ -> Process.sleep(500) end)
+      assert :ok = Queue.add(request, Env.new())
+
+      :ok = Queue.cancel(1)
+
+      assert_receive %{id: "1", error: _}
+    end
+
+    test "passing in a request for cancellation" do
+      request = request("1", fn _, _ -> Process.sleep(500) end)
+      :ok = Queue.add(request, Env.new())
+
+      :ok = Queue.cancel(request)
+
+      assert_receive %{id: "1", error: error}
+      assert Queue.size() == 0
+      assert error.code == :request_cancelled
+      assert error.message == "Request cancelled"
+    end
+
+    test "canceling a non-existing request is a no-op" do
+      assert :ok = Queue.cancel("5")
+      refute_receive %{id: _}
+    end
+  end
+
+  describe "task return values" do
+    test "tasks can reply" do
+      request = request("1", fn _, _ -> {:reply, "great"} end)
+      :ok = Queue.add(request, Env.new())
+
+      assert_receive "great"
+    end
+
+    test "replies are optional" do
+      request = request("1", fn _, _ -> :noreply end)
+      :ok = Queue.add(request, Env.new())
+
+      assert_eventually Queue.size() == 0
+      refute_receive _
+    end
+
+    test "the server can be notified about the request" do
+      unit_test = self()
+      request = request("1", fn _, _ -> {:reply_and_alert, :response} end)
+
+      patch(Lexical.Server, :response_complete, fn request, reply ->
+        send(unit_test, {:request_complete, request, reply})
+      end)
+
+      :ok = Queue.add(request, Env.new())
+
+      assert_receive :response
+      assert_receive {:request_complete, ^request, :response}
+    end
+
+    test "exceptions are handled" do
+      request = request("1", fn _, _ -> raise "Boom!" end)
+      assert :ok = Queue.add(request, Env.new())
+
+      assert_receive %{id: "1", error: error}
+      assert error.code == :internal_error
+      assert error.message =~ "Boom!"
+    end
+  end
+end


### PR DESCRIPTION
The client can cancel a previously made request. Support was almost there (in fact, the queue supported it already), but wasn't quite hooked up.

I also added tests for the queue, which were missing.

Fixes #41 