### PR TITLE
Replace with underscore bugfix

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/code_mod/replace_with_underscore.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_mod/replace_with_underscore.ex
@@ -35,8 +35,8 @@ defmodule Lexical.RemoteControl.CodeMod.ReplaceWithUnderscore do
     leading_indent = leading_indent(line_text)
 
     Macro.postwalk(quoted_ast, fn
-      {^unused_variable_name, meta, context} ->
-        {underscored_variable_name, meta, context}
+      {^unused_variable_name, meta, nil} ->
+        {underscored_variable_name, meta, nil}
 
       other ->
         other

--- a/apps/remote_control/test/lexical/remote_control/code_mod/replace_with_underscore_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_mod/replace_with_underscore_test.exs
@@ -90,6 +90,13 @@ defmodule Lexical.RemoteControl.CodeMod.ReplaceWithUnderscoreTest do
 
       assert result == "def my_func([a, b | _unused]) do"
     end
+
+    test "does not change the name of a function if it is the same as a parameter" do
+      {:ok, result} = ~q{
+          def unused(unused) do
+      } |> modify()
+      assert result == "def unused(_unused) do"
+    end
   end
 
   describe "fixes in variables" do


### PR DESCRIPTION
Replace with underscore would fail if the function name and the variable name were the same. This change detects the difference between a function name and a variable, and only affects variables

Fixes #18