### PR TITLE
Implemented graceful shutdown

### DIFF
--- a/apps/proto/lib/lexical/protocol/proto/notification.ex
+++ b/apps/proto/lib/lexical/protocol/proto/notification.ex
@@ -70,7 +70,7 @@ defmodule Lexical.Protocol.Proto.Notification do
   defp build_parse(method) do
     quote do
       def parse(%{"method" => unquote(method), "jsonrpc" => "2.0"} = request) do
-        params = Map.get(request, "params", %{})
+        params = Map.get(request, "params") || %{}
         flattened_notificaiton = Map.merge(request, params)
 
         case LSP.parse(flattened_notificaiton) do

--- a/apps/proto/lib/lexical/protocol/proto/request.ex
+++ b/apps/proto/lib/lexical/protocol/proto/request.ex
@@ -79,7 +79,7 @@ defmodule Lexical.Protocol.Proto.Request do
   defp build_parse(method) do
     quote do
       def parse(%{"method" => unquote(method), "id" => id, "jsonrpc" => "2.0"} = request) do
-        params = Map.get(request, "params", %{})
+        params = Map.get(request, "params") || %{}
         flattened_request = Map.merge(request, params)
 
         case LSP.parse(flattened_request) do

--- a/apps/protocol/lib/lexical/protocol/notifications.ex
+++ b/apps/protocol/lib/lexical/protocol/notifications.ex
@@ -4,31 +4,37 @@ defmodule Lexical.Protocol.Notifications do
 
   defmodule Initialized do
     use Proto
-    defnotification("initialized", :shared)
+    defnotification "initialized", :shared
+  end
+
+  defmodule Exit do
+    use Proto
+
+    defnotification "exit", :exclusive
   end
 
   defmodule Cancel do
     use Proto
 
-    defnotification("$/cancelRequest", :shared, id: integer())
+    defnotification "$/cancelRequest", :shared, id: integer()
   end
 
   defmodule DidOpen do
     use Proto
 
-    defnotification("textDocument/didOpen", :shared, text_document: Types.TextDocument.Item)
+    defnotification "textDocument/didOpen", :shared, text_document: Types.TextDocument.Item
   end
 
   defmodule DidClose do
     use Proto
 
-    defnotification("textDocument/didClose", :shared, text_document: Types.TextDocument.Identifier)
+    defnotification "textDocument/didClose", :shared, text_document: Types.TextDocument.Identifier
   end
 
   defmodule DidChange do
     use Proto
 
-    defnotification("textDocument/didChange", :shared,
+    defnotification "textDocument/didChange", :shared,
       text_document: Types.TextDocument.Versioned.Identifier,
       content_changes:
         list_of(
@@ -37,45 +43,42 @@ defmodule Lexical.Protocol.Notifications do
             Types.TextDocument.ContentChangeEvent.TextDocumentContentChangeEvent1
           ])
         )
-    )
   end
 
   defmodule DidChangeConfiguration do
     use Proto
 
-    defnotification("workspace/didChangeConfiguration", :shared, settings: map_of(any()))
+    defnotification "workspace/didChangeConfiguration", :shared, settings: map_of(any())
   end
 
   defmodule DidChangeWatchedFiles do
     use Proto
 
-    defnotification("workspace/didChangeWatchedFiles", :shared, changes: list_of(Types.FileEvent))
+    defnotification "workspace/didChangeWatchedFiles", :shared, changes: list_of(Types.FileEvent)
   end
 
   defmodule DidSave do
     use Proto
 
-    defnotification("textDocument/didSave", :shared, text_document: Types.TextDocument.Identifier)
+    defnotification "textDocument/didSave", :shared, text_document: Types.TextDocument.Identifier
   end
 
   defmodule PublishDiagnostics do
     use Proto
 
-    defnotification("textDocument/publishDiagnostics", :shared,
+    defnotification "textDocument/publishDiagnostics", :shared,
       uri: string(),
       version: optional(integer()),
       diagnostics: list_of(Types.Diagnostic)
-    )
   end
 
   defmodule LogMessage do
     use Proto
     require Types.Message.Type
 
-    defnotification("window/logMessage", :shared,
+    defnotification "window/logMessage", :shared,
       message: string(),
       type: Types.Message.Type
-    )
 
     for type <- [:error, :warning, :info, :log] do
       def unquote(type)(message) do
@@ -88,10 +91,9 @@ defmodule Lexical.Protocol.Notifications do
     use Proto
     require Types.Message.Type
 
-    defnotification("window/showMessage", :shared,
+    defnotification "window/showMessage", :shared,
       message: string(),
       type: Types.Message.Type
-    )
 
     for type <- [:error, :warning, :info, :log] do
       def unquote(type)(message) do

--- a/apps/protocol/lib/lexical/protocol/requests.ex
+++ b/apps/protocol/lib/lexical/protocol/requests.ex
@@ -25,6 +25,12 @@ defmodule Lexical.Protocol.Requests do
     defrequest "$/cancelRequest", :exclusive, id: one_of([string(), integer()])
   end
 
+  defmodule Shutdown do
+    use Proto
+
+    defrequest "shutdown", :exclusive, []
+  end
+
   defmodule FindReferences do
     use Proto
 

--- a/apps/protocol/lib/lexical/protocol/responses.ex
+++ b/apps/protocol/lib/lexical/protocol/responses.ex
@@ -31,4 +31,10 @@ defmodule Lexical.Protocol.Responses do
 
     defresponse optional(list_of(one_of([list_of(Types.Completion.Item), Types.Completion.List])))
   end
+
+  defmodule Shutdown do
+    use Proto
+    # yeah, this is odd... it has no params
+    defresponse []
+  end
 end

--- a/apps/server/lib/lexical/server.ex
+++ b/apps/server/lib/lexical/server.ex
@@ -4,6 +4,7 @@ defmodule Lexical.Server do
   alias Lexical.Protocol.Responses
   alias Lexical.Server.Provider
   alias Lexical.Server.State
+
   import Logger
 
   use GenServer
@@ -14,7 +15,9 @@ defmodule Lexical.Server do
     Notifications.DidClose,
     Notifications.DidOpen,
     Notifications.DidSave,
-    Notifications.Initialized
+    Notifications.Exit,
+    Notifications.Initialized,
+    Requests.Shutdown
   ]
 
   @spec response_complete(Requests.request(), Responses.response()) :: :ok


### PR DESCRIPTION
The server now responds to the Shutdown request and the Exit message, which are sent by clients when they want to shut down.

The client i'm using doesn't give much time to shut down, so I didn't implement queue draining or anything like that, I just shut the server down from processing any more messages and halt the VM 50ms after receiving the exit message