### PR TITLE
feat: Detect rtx and use it to find elixir executable

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control.ex
+++ b/apps/remote_control/lib/lexical/remote_control.ex
@@ -222,7 +222,7 @@ defmodule Lexical.RemoteControl do
     end
   end
 
-  defp asdf?(), do: not is_nil(System.find_executable("asdf"))
+  defp asdf?(), do: is_binary(System.find_executable("asdf"))
 
-  defp rtx?(), do: not is_nil(System.find_executable("rtx"))
+  defp rtx?(), do: is_binary(System.find_executable("rtx"))
 end


### PR DESCRIPTION
Adds [rtx](https://github.com/jdxcode/rtx) detection and invokes `rtx which elixir` to find the path to the correct executable.