### PR TITLE
Added suggestions for behaviours

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion.ex
@@ -141,7 +141,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
     )
   end
 
-  defp translate_completion(%Result.Module{} = module, %Env{} = env) do
+  defp translate_completion(%result_struct{} = module, %Env{} = env)
+       when result_struct in [Result.Module, Result.Behaviour] do
     detail =
       case module.summary do
         nil -> module.name

--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -679,6 +679,30 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
     end
   end
 
+  describe "module completions" do
+    test "modules should emit a completion", %{project: project} do
+      assert {:ok, completion} =
+               project
+               |> complete("Enu|")
+               |> fetch_completion(kind: :module)
+
+      assert completion.kind == :module
+      assert completion.label == "Enum"
+      assert completion.detail
+    end
+
+    test "behaviours should emit a completion", %{project: project} do
+      assert {:ok, completion} =
+               project
+               |> complete("GenS|")
+               |> fetch_completion(kind: :module)
+
+      assert completion.kind == :module
+      assert completion.label == "GenServer"
+      assert completion.detail =~ "A behaviour module"
+    end
+  end
+
   describe "structs" do
     test "should complete after %", %{project: project} do
       assert {:ok, [_, _] = account_and_user} =


### PR DESCRIPTION
I was wondering why behaviours weren't showing up, and it's because they weren't emitted. Thus, we got no suggestions for `GenServer`, which is kind of an important thing.

Added behaviour suggestions that do the same thing as normal modules