### PR TITLE
Fix ArgumentError of pipeline

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build/error.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/error.ex
@@ -98,9 +98,31 @@ defmodule Lexical.RemoteControl.Build.Error do
     }
   end
 
+  def error_to_diagnostic(%ArgumentError{} = argument_error, stack, _quoted_ast) do
+    reversed_stack = Enum.reverse(stack)
+    [{_, _, _, context}, {_, maybe_pipe, _, _} | _] = reversed_stack
+
+    if maybe_pipe == :|> do
+      %Diagnostic{
+        message: Exception.message(argument_error),
+        position: context_to_position(context),
+        file: nil,
+        severity: :error,
+        compiler_name: "Elixir"
+      }
+    else
+      %Diagnostic{
+        message: Exception.message(argument_error),
+        position: stack_to_position(stack),
+        file: nil,
+        severity: :error,
+        compiler_name: "Elixir"
+      }
+    end
+  end
+
   def error_to_diagnostic(%module{} = exception, stack, _quoted_ast)
       when module in [
-             ArgumentError,
              Protocol.UndefinedError,
              ExUnit.DuplicateTestError,
              ExUnit.DuplicateDescribeError

--- a/apps/remote_control/test/lexical/remote_control/build/error_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/error_test.exs
@@ -169,6 +169,30 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
       assert diagnostic.position == 1
     end
 
+    test "handles ArgumentError when in module" do
+      {:exception, exception, stack, quoted_ast} = ~s[
+        defmodule Foo do
+          :a |> {1, 2}
+        end
+      ] |> compile()
+      diagnostic = Error.error_to_diagnostic(exception, stack, quoted_ast)
+      assert diagnostic.message =~ ~s[cannot pipe :a into {1, 2}, can only pipe into local calls foo()]
+      assert diagnostic.position == 3
+    end
+
+    test "handles ArgumentError when in function" do
+      {:exception, exception, stack, quoted_ast} = ~s[
+        defmodule Foo do
+          def foo do
+            :a |> {1, 2}
+          end
+        end
+      ] |> compile()
+      diagnostic = Error.error_to_diagnostic(exception, stack, quoted_ast)
+      assert diagnostic.message =~ ~s[cannot pipe :a into {1, 2}, can only pipe into local calls foo()]
+      assert diagnostic.position == 4
+    end
+
     test "can't find right line when use macro" do
       {:exception, exception, stack, quoted_ast} = ~S[
           Module.create(


### PR DESCRIPTION
`:|>` pipeline is a little bit special. It will encounter an `ArgumentError` when piping to the wrong target.

This is the stack of a pipeline `ArgumentError`:

```elixir
[{Macro, :pipe, 3, [file: 'lib/macro.ex', line: 333]},
 {:lists, :foldl, 3, [file: 'lists.erl', line: 1350]},
 {Kernel, :|>, 2, [file: 'expanding macro']},
 {Lexi.Tracer.Builder, :fill_range, 2, [file: 'lib/lexi/tracer/builder.ex', line: 58]}]
```