### PR TITLE
Fix issue-44

### DIFF
--- a/apps/common/lib/lexical/source_file.ex
+++ b/apps/common/lib/lexical/source_file.ex
@@ -135,6 +135,18 @@ defmodule Lexical.SourceFile do
     |> IO.iodata_to_binary()
   end
 
+  @doc """
+  Casts itself when received through RPC due to different module names
+  """
+  @spec cast_from_rpc(t) :: t
+  def cast_from_rpc(source) do
+    source_map = Map.from_struct(source)
+    document_map = Map.from_struct(source_map.document)
+    document = struct(Document, document_map)
+    source_map = Map.put(source_map, :document, document)
+    source_file = struct(__MODULE__, source_map)
+  end
+
   # private
 
   defp line_count(%__MODULE__{} = source) do

--- a/apps/common_protocol/lib/generated/lexical/protocol/types/text_edit.ex
+++ b/apps/common_protocol/lib/generated/lexical/protocol/types/text_edit.ex
@@ -4,4 +4,21 @@ defmodule Lexical.Protocol.Types.TextEdit do
   alias Lexical.Protocol.Types
   use Proto
   deftype new_text: string(), range: Types.Range
+
+  # How to add this function to this module without editing this file?
+  # it is important for RemoteControl.namespace_struct()
+  def cast_from_rpc(struct) do
+    map = Map.from_struct(struct)
+    range_map = Map.from_struct(map.range)
+    position_end_map = Map.from_struct(range_map.end)
+    position_start_map = Map.from_struct(range_map.start)
+    position_end = struct(Types.Position, position_end_map)
+    position_start = struct(Types.Position, position_start_map)
+    range_map = Map.put(range_map, :end, position_end)
+    range_map = Map.put(range_map, :start, position_start)
+    range = struct(Types.Range, range_map)
+    map = Map.put(map, :range, range)
+    text_edit = struct(__MODULE__, map)
+    text_edit
+  end
 end

--- a/apps/remote_control/lib/lexical/remote_control/bootstrap.ex
+++ b/apps/remote_control/lib/lexical/remote_control/bootstrap.ex
@@ -8,9 +8,9 @@ defmodule Lexical.RemoteControl.Bootstrap do
   """
   alias Lexical.RemoteControl
   alias Lexical.Project
-  require Logger
 
-  def init(%Project{} = project, listener_pid) do
+  def init(project, listener_pid) do
+    project = %Project{} = RemoteControl.namespace_struct(project)
     true = Code.append_path(hex_path())
     RemoteControl.set_project(project)
     RemoteControl.set_project_listener_pid(listener_pid)

--- a/apps/remote_control/lib/lexical/remote_control/code_mod/format.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_mod/format.ex
@@ -6,11 +6,14 @@ defmodule Lexical.RemoteControl.CodeMod.Format do
   alias Lexical.RemoteControl
   alias Lexical.SourceFile
 
-  require Logger
   @type formatter_function :: (String.t() -> any) | nil
 
   @spec text_edits(Project.t(), SourceFile.t()) :: {:ok, [TextEdit.t()]} | {:error, any}
-  def text_edits(%Project{} = project, %SourceFile{} = document) do
+  def text_edits(project, document) do
+    # Structs received from RPC, cast them
+    project = %Project{} = RemoteControl.namespace_struct(project)
+    document = %SourceFile{} = RemoteControl.namespace_struct(document)
+
     with :ok <- Build.compile_source_file(project, document),
          {:ok, unformatted, formatted} <- do_format(project, document) do
       edits = Diff.diff(unformatted, formatted)

--- a/apps/remote_control/lib/lexical/remote_control/code_mod/replace_with_underscore.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_mod/replace_with_underscore.ex
@@ -1,12 +1,15 @@
 defmodule Lexical.RemoteControl.CodeMod.ReplaceWithUnderscore do
   alias Lexical.SourceFile
   alias Lexical.Protocol.Types.TextEdit
+  alias Lexical.RemoteControl
   alias Lexical.RemoteControl.CodeMod.Ast
   alias Lexical.RemoteControl.CodeMod.Diff
 
   @spec text_edits(SourceFile.t(), non_neg_integer(), String.t() | atom) ::
           {:ok, [TextEdit.t()]} | :error
-  def text_edits(%SourceFile{} = source_file, line_number, variable_name) do
+  def text_edits(source_file, line_number, variable_name) do
+    # Struct received from RPC, cast it
+    source_file = %SourceFile{} = RemoteControl.namespace_struct(source_file)
     variable_name = ensure_atom(variable_name)
 
     with {:ok, line_text} <- SourceFile.fetch_text_at(source_file, line_number),

--- a/apps/remote_control/lib/lexical/remote_control/completion.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion.ex
@@ -1,11 +1,13 @@
 defmodule Lexical.RemoteControl.Completion do
+  alias Lexical.RemoteControl
   alias Lexical.RemoteControl.Completion.Result
   alias Lexical.SourceFile.Position
 
-  def elixir_sense_expand(source, %Position{} = position) do
+  def elixir_sense_expand(source, position) do
     # Add one to both the line and character, because elixir sense
     # has one-based lines, and the character needs to be after the context,
     # rather than in between.
+    position = %Position{} = RemoteControl.namespace_struct(position)
     line = position.line + 1
     character = position.character + 1
     hint = ElixirSense.Core.Source.prefix(source, line, character)

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,65 @@
 import Config
+
+umbrella_root = File.cwd!()
+config :remote_control, umbrella_root: umbrella_root
+
+defmodule Mix.Tasks.Compile.Namespace do
+  def namespace_modules(ast) do
+    Macro.prewalk(ast, fn
+      {:__aliases__, meta, [:Lexical | rest]} ->
+        {:__aliases__, meta, [:LexicalNamespace | rest]}
+
+      any ->
+        any
+    end)
+  end
+
+  def write_namespaced_file(path, string) do
+    # Example:
+    #   original path:
+    #       apps/remote_control/mix.exs
+    #   out_path:
+    #       _build/dev/namespaced/apps/remote_control/mix.exs
+    out_path = Path.join([Mix.Project.build_path(), "namespaced", path])
+    :ok = File.mkdir_p(Path.dirname(out_path))
+    :ok = File.write(out_path, string)
+    out_path
+  end
+
+  def run(_args) do
+    # First, clear previous build.
+    File.rm_rf(Path.join([Mix.Project.build_path(), "namespaced"]))
+    # Get all paths for common, common_protocol and remote_control.
+    # Get /lib only. If we get /test we end up with fixtures for
+    # code that has errors and it fails on Code.string_to_quoted()
+    apps = "apps/{remote_control,common,common_protocol,proto}"
+
+    paths =
+      Path.wildcard(apps <> "/lib/**/*.{ex,exs}") ++
+        Path.wildcard(apps <> "/mix.exs") ++
+        Path.wildcard("mix.exs")
+
+    _files =
+      Enum.map(paths, fn p ->
+        with {:ok, string} <- File.read(p),
+             {:ok, quoted} <- Code.string_to_quoted(string) do
+          new_quoted = namespace_modules(quoted)
+          new_string = Macro.to_string(new_quoted)
+          write_namespaced_file(p, new_string)
+        else
+          err ->
+            raise CompileError.exception(
+                    description: inspect(err),
+                    file: p
+                  )
+        end
+      end)
+
+    # Process the modified source files.
+    # Treat them as their own umbrella app to be as consistent as possible.
+    cd_path = Path.join([Mix.Project.build_path(), "namespaced"])
+    File.cd(cd_path)
+    Mix.Task.run("deps.get")
+    Mix.Task.run("compile")
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/scohen/lexical/issues/44
In a way, also fixes https://github.com/scohen/lexical/issues/45

# Summary:

Compiles another version of `RemoteControl` app, it shares the same code as the `manager node` but every reference to `Lexical.SomeModule` is replaced with `LexicalNamespace.SomeModule`.

To compile the `LexicalNamespace` version of `RemoteControl` app, an additional command must be invoked:

`mix compile.namespace`

So if you want to refresh the manager node and the project node with new code you would run a command like:

`mix release lexical --overwrite && mix compile.namespace`

These changes are made so that they are only relevant when `Mix.env() == :dev`, that way `prod` release is unaffected.

## Pros:

Get identical behavior between using `Lexical` as project and using another code base as project. This seems of utter importance to me if the quality of `Lexical` is going to depend on dogfooding.

For example, https://github.com/scohen/lexical/issues/67 is not easily visible when using `Lexical` as the project.

## Cons:

There are two types of functions where code must change slightly. 

If you want to look at examples, I added comments in the code.

#### 1. Function calls to RPC methods, usually inside `RemoteControl.Api`.

The `namespace_module()` function must be added to the RPC arguments if it is a Lexical module.

#### 2. Return values of RPC methods, usually inside `RemoteControl.Api`.

The `namespace_struct()` function must be added to the return values of the RPC methods if they return structs. This is necessary because the structs belong to `LexicalNamespace` and those aren't recognized inside `Lexical`.

#### 3. Functions that are called through RPC

The `namespace_struct()` function must be added the arguments of these functions if they are structs. This is necessary because the structs belong to `Lexical` and those aren't recognized inside `LexicalNamespace`. 

Additionally, these functions should not pattern match on their function heads. Pattern matching can still be used after `namespace_struct()` though.

#### 4. Structs that have nested structs require a special function to cast their attributes too

This is usually a simple process of turning the structs into maps, and then turning them into structs. This way any foreign structs get the right module.

## Pros of the cons?:

The additional code makes it more explicit when a function is getting called through RPC, this informs the reader of the node context in which the function is meant to be executed.
 