### PR TITLE
Made run_in_project handle exceptions

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control.ex
+++ b/apps/remote_control/lib/lexical/remote_control.ex
@@ -7,7 +7,6 @@ defmodule Lexical.RemoteControl do
 
   alias Lexical.Project
   alias Lexical.RemoteControl
-  alias Lexical.RemoteControl.Build
 
   @allowed_apps ~w(common path_glob remote_control elixir_sense)a
 
@@ -47,31 +46,6 @@ defmodule Lexical.RemoteControl do
          :ok <- ensure_apps_started(node, apps_to_start) do
       {:ok, node}
     end
-  end
-
-  def in_mix_project(fun) when is_function(fun) do
-    in_mix_project(get_project(), fun)
-  end
-
-  def in_mix_project(%Project{} = project, fun) do
-    # Locking on the build make sure we don't get a conflict on the mix.exs being
-    # already defined
-
-    old_cwd = File.cwd!()
-
-    Build.with_lock(fn ->
-      try do
-        build_path = Project.build_path(project)
-        project_root = Project.root_path(project)
-
-        project
-        |> Project.name()
-        |> String.to_atom()
-        |> Mix.Project.in_project(project_root, [build_path: build_path], fun)
-      after
-        File.cd!(old_cwd)
-      end
-    end)
   end
 
   def with_lock(lock_type, func) do

--- a/apps/remote_control/lib/lexical/remote_control/bootstrap.ex
+++ b/apps/remote_control/lib/lexical/remote_control/bootstrap.ex
@@ -68,8 +68,8 @@ defmodule Lexical.RemoteControl.Bootstrap do
     # I tried a bunch of stuff to get it to work, like checking if the
     # app is an umbrella (umbrealla? returns false when started in a subapp)
     # to no avail. This was the only thing that consistently worked
-    configured_root =
-      RemoteControl.in_mix_project(project, fn _ ->
+    {:ok, configured_root} =
+      RemoteControl.Mix.in_project(project, fn _ ->
         Mix.Project.config()
         |> Keyword.get(:config_path)
         |> Path.dirname()

--- a/apps/remote_control/lib/lexical/remote_control/mix.ex
+++ b/apps/remote_control/lib/lexical/remote_control/mix.ex
@@ -1,0 +1,50 @@
+defmodule Lexical.RemoteControl.Mix do
+  alias Lexical.Project
+  alias Lexical.RemoteControl
+  alias Lexical.RemoteControl.Build
+
+  def in_project(fun) do
+    if RemoteControl.project_node?() do
+      in_project(RemoteControl.get_project(), fun)
+    else
+      {:error, :not_project_node}
+    end
+  end
+
+  def in_project(%Project{} = project, fun) do
+    # Locking on the build make sure we don't get a conflict on the mix.exs being
+    # already defined
+
+    old_cwd = File.cwd!()
+
+    Build.with_lock(fn ->
+      try do
+        build_path = Project.build_path(project)
+        project_root = Project.root_path(project)
+
+        project
+        |> Project.name()
+        |> String.to_atom()
+        |> Mix.Project.in_project(project_root, [build_path: build_path], fun)
+      rescue
+        ex ->
+          blamed = Exception.blame(:error, ex, __STACKTRACE__)
+          {:error, {:exception, blamed, __STACKTRACE__}}
+      else
+        result ->
+          case result do
+            error when is_tuple(error) and elem(error, 0) == :error ->
+              error
+
+            ok when is_tuple(ok) and elem(ok, 0) == :ok ->
+              ok
+
+            other ->
+              {:ok, other}
+          end
+      after
+        File.cd!(old_cwd)
+      end
+    end)
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/build/state_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/state_test.exs
@@ -3,11 +3,8 @@ defmodule Lexical.RemoteControl.Build.StateTest do
   alias Lexical.RemoteControl
   alias Lexical.RemoteControl.Build
   alias Lexical.RemoteControl.Build.State
-  alias Lexical.RemoteControl.Api.Messages
   alias Lexical.SourceFile
-  alias Mix.Task.Compiler.Diagnostic
 
-  import Messages
   import Lexical.Test.Fixtures
 
   import Testing.EventualAssertions


### PR DESCRIPTION
A lot of the code that happens in mix can raise exceptions; it makes sense for `run_in_project` to handle these exceptions natively to prevent crashes.