### PR TITLE
Improved completions for %__MODULE__

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion/env.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/env.ex
@@ -44,10 +44,10 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Env do
           {:struct, _} ->
             true
 
-          {:local_or_var, '__'} ->
+          {:local_or_var, [?_, ?_ | rest]} ->
             # a reference to `%__MODULE`, often in a function head, as in
             # def foo(%__)
-            String.contains?(line, "%__")
+            String.starts_with?("MODULE", List.to_string(rest)) and String.contains?(line, "%__")
 
           _ ->
             false

--- a/apps/server/test/lexical/server/code_intelligence/completion/env_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/env_test.exs
@@ -38,6 +38,16 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
       assert Completion.Env.struct_reference?(env)
     end
 
+    test "is true if the reference is for %__MOD in a function definition " do
+      env = new_env("def my_fn(%__MOD")
+      assert Completion.Env.struct_reference?(env)
+    end
+
+    test "is false if the reference is for %__MOC in a function definition" do
+      env = new_env("def my_fn(%__MOC)")
+      refute Completion.Env.struct_reference?(env)
+    end
+
     test "is false if a module reference lacks a %" do
       env = new_env("def my_function(__|)")
       refute Completion.Env.struct_reference?(env)

--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -799,6 +799,24 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
       assert completion.kind == :struct
     end
 
+    test "it should complete module structs after characters are typed", %{project: project} do
+      completion = """
+      defmodule NewStruct do
+        defstruct [:name, :value]
+
+        def my_function(%__MO|)
+      """
+
+      assert {:ok, completion} =
+               project
+               |> complete(completion)
+               |> fetch_completion(kind: :struct)
+
+      assert completion.label == "%__MODULE__{}"
+      assert completion.detail == "%__MODULE__{}"
+      assert completion.kind == :struct
+    end
+
     test "can be aliased", %{project: project} do
       assert [completion] = complete(project, "alias Project.Structs.A|")
 


### PR DESCRIPTION
I noticed that I would correctly get a completion for %__MODULE when I typed %__, but not when I typed %__M, which was annoying, as I usually can type to the M before emacs provides completions, and I'd have to backtrack.

This was caused by a bug in `Completion.Env` that failed to detect that %__M was still possibly a struct reference to %__MODULE__.