### PR TITLE
Fix diagnostics in namespace (but with old commit oops)

### DIFF
--- a/apps/common/lib/mix/tasks/namespace/release.ex
+++ b/apps/common/lib/mix/tasks/namespace/release.ex
@@ -4,21 +4,42 @@ defmodule Mix.Tasks.Namespace.Release do
   """
   use Mix.Task
 
-  def run([release_version_path, remote_control_ebin]) do
+  def run(_) do
+    release = Mix.Release.from_config!(:lexical, Mix.Project.config(), [])
+    release_path = release.path
+    release_version_path = release.version_path
+
+    app_names = ~w(remote_control common common_protocol server protocol)a
+    app_paths = Enum.map(app_names, fn app ->
+      vsn = Mix.Project.in_project(app, Mix.Project.apps_paths()[app],
+        fn _ -> Mix.Project.config()[:version]
+      end)
+      Path.join([release_path, "lib", "#{app}-#{vsn}", "ebin", "#{app}.app"])
+    end)
+
     release_files = ~w(start.script lexical.rel)
-    remote_app = Path.join([remote_control_ebin, "remote_control.app"])
-    paths = [remote_app | Enum.map(release_files, &Path.join([release_version_path, &1]))]
+    script_paths = Enum.map(release_files, &Path.join([release_version_path, &1]))
+
+    paths = script_paths ++ app_paths
 
     Enum.each(paths, fn p ->
       string = File.read!(p)
       # avoid replacing directory path with negative lookbehind:
       string = String.replace(string, ~r/(?<!\/)remote_control/, "lx_remote_control")
+      string = String.replace(string, ~r/(?<!\/)common(?!_)/, "lx_common")
+      string = String.replace(string, ~r/(?<!\/)common_protocol/, "lx_common_protocol")
+      string = String.replace(string, ~r/(?<!\/)server/, "lx_server")
+      string = String.replace(string, ~r/(?<![\/_])protocol/, "lx_protocol")
       File.write!(p, string)
     end)
 
-    # rename .app file because the filename is used as identifier by BEAM
-    lx_app = Path.join([remote_control_ebin, "lx_remote_control.app"])
-    :ok = File.rename(remote_app, lx_app)
+    Enum.each(app_paths, fn app_path ->
+      { app_file, dirlist } = Path.split(app_path) |> List.pop_at(-1)
+      lx_name = "lx_#{app_file}"
+      lx_app_path = Path.join(dirlist ++ [lx_name])
+      # rename .app file because the filename is used as identifier by BEAM
+      :ok = File.rename(app_path, lx_app_path)
+    end)
 
     Mix.Shell.IO.info("\nApplied namespace to release app.")
   end


### PR DESCRIPTION
worked fine when ran with

`mix clean && NAMESPACE=1 mix release lexical --overwrite`