### PR TITLE
Converted range-able response types

### DIFF
--- a/apps/proto/lib/lexical/protocol/proto/macros/inspect.ex
+++ b/apps/proto/lib/lexical/protocol/proto/macros/inspect.ex
@@ -7,13 +7,12 @@ defmodule Lexical.Protocol.Proto.Macros.Inspect do
         import Inspect.Algebra
 
         def inspect(proto_type, opts) do
-          proto_map =
+          proto_key_values =
             proto_type
             |> Map.from_struct()
             |> Enum.reject(fn {k, v} -> is_nil(v) end)
-            |> Map.new()
 
-          concat(["%#{unquote(trimmed_name)}{", to_doc(proto_map, opts), "}"])
+          concat(["##{unquote(trimmed_name)}<", Inspect.List.inspect(proto_key_values, opts), ">"])
         end
       end
     end

--- a/apps/proto/lib/lexical/protocol/proto/response.ex
+++ b/apps/proto/lib/lexical/protocol/proto/response.ex
@@ -24,6 +24,34 @@ defmodule Lexical.Protocol.Proto.Response do
       unquote(Typespec.build())
       unquote(Meta.build(jsonrpc_types))
 
+      alias Lexical.Protocol.Proto.Convert
+
+      unquote(constructors())
+
+      defimpl Jason.Encoder, for: unquote(__CALLER__.module) do
+        def encode(%_{error: nil} = response, opts) do
+          %{
+            jsonrpc: "2.0",
+            id: response.id,
+            result: response.result
+          }
+          |> Jason.Encode.map(opts)
+        end
+
+        def encode(response, opts) do
+          %{
+            jsonrpc: "2.0",
+            id: response.id,
+            error: response.error
+          }
+          |> Jason.Encode.map(opts)
+        end
+      end
+    end
+  end
+
+  defp constructors do
+    quote do
       def new(id, result) do
         struct(__MODULE__, result: result, id: id)
       end
@@ -50,26 +78,6 @@ defmodule Lexical.Protocol.Proto.Response do
           id: id,
           error: LspTypes.ResponseError.new(code: error_code, message: error_message)
         }
-      end
-
-      defimpl Jason.Encoder, for: unquote(__CALLER__.module) do
-        def encode(%_{error: nil} = response, opts) do
-          %{
-            jsonrpc: "2.0",
-            id: response.id,
-            result: response.result
-          }
-          |> Jason.Encode.map(opts)
-        end
-
-        def encode(response, opts) do
-          %{
-            jsonrpc: "2.0",
-            id: response.id,
-            error: response.error
-          }
-          |> Jason.Encode.map(opts)
-        end
       end
     end
   end

--- a/apps/protocol/lib/lexical/protocol/ranged.ex
+++ b/apps/protocol/lib/lexical/protocol/ranged.ex
@@ -1,0 +1,20 @@
+alias Lexical.Protocol.Conversions
+alias Lexical.Protocol.Types
+alias Lexical.Ranged
+alias Lexical.SourceFile
+
+defimpl Ranged.Lsp, for: Types.Location do
+  def from_native(%Types.Location{} = location, _) do
+    with {:ok, source_file} <- SourceFile.Store.open_temporary(location.uri) do
+      Conversions.to_lsp(location.range, source_file)
+    end
+  end
+end
+
+defimpl Ranged.Native, for: Types.Location do
+  def from_lsp(%Types.Location{} = location, _) do
+    with {:ok, source_file} <- SourceFile.Store.open_temporary(location.uri) do
+      Conversions.to_elixir(location.range, source_file)
+    end
+  end
+end

--- a/apps/protocol/lib/lexical/protocol/response.ex
+++ b/apps/protocol/lib/lexical/protocol/response.ex
@@ -12,6 +12,10 @@ defmodule Lexical.Protocol.Response do
     end
   end
 
+  def to_lsp(other) do
+    {:ok, other}
+  end
+
   defp fetch_source_file(%{text_document: %{uri: uri}}) do
     SourceFile.Store.fetch(uri)
   end

--- a/apps/protocol/lib/lexical/protocol/response.ex
+++ b/apps/protocol/lib/lexical/protocol/response.ex
@@ -1,0 +1,83 @@
+defmodule Lexical.Protocol.Response do
+  alias Lexical.Ranged
+  alias Lexical.SourceFile
+
+  def to_lsp(%_{result: result} = response) do
+    case convert_to_lsp(result) do
+      {:ok, converted} ->
+        {:ok, Map.put(response, :result, converted)}
+
+      error ->
+        error
+    end
+  end
+
+  defp fetch_source_file(%{text_document: %{uri: uri}}) do
+    SourceFile.Store.fetch(uri)
+  end
+
+  defp fetch_source_file(%{source_file: %SourceFile{} = source_file}) do
+    {:ok, source_file}
+  end
+
+  defp fetch_source_file(_) do
+    :error
+  end
+
+  defp convert_to_lsp(%_{text_document: _} = response) do
+    with {:ok, source_file} <- fetch_source_file(response) do
+      convert_to_lsp(response, source_file)
+    end
+  end
+
+  defp convert_to_lsp(response_list) when is_list(response_list) do
+    result =
+      Enum.reduce_while(response_list, [], fn response, acc ->
+        case convert_to_lsp(response) do
+          {:ok, converted} ->
+            {:cont, [converted | acc]}
+
+          error ->
+            {:halt, error}
+        end
+      end)
+
+    case result do
+      l when is_list(l) ->
+        {:ok, Enum.reverse(l)}
+
+      error ->
+        error
+    end
+  end
+
+  defp convert_to_lsp(%_{} = response) do
+    {:ok, response}
+  end
+
+  defp convert_to_lsp(other) do
+    {:ok, other}
+  end
+
+  defp convert_to_lsp(%_struct{} = response, %SourceFile{} = source_file) do
+    case Ranged.Lsp.impl_for(response) do
+      nil ->
+        key_value_pairs =
+          response
+          |> Map.from_struct()
+          |> Enum.reduce(response, fn {key, value}, response ->
+            {:ok, value} = convert_to_lsp(value, source_file)
+            Map.put(response, key, value)
+          end)
+
+        {:ok, Map.merge(response, key_value_pairs)}
+
+      _impl ->
+        Ranged.Lsp.from_native(response, source_file)
+    end
+  end
+
+  defp convert_to_lsp(not_a_struct, %SourceFile{}) do
+    {:ok, not_a_struct}
+  end
+end

--- a/apps/protocol/test/lexical/proto_test.exs
+++ b/apps/protocol/test/lexical/proto_test.exs
@@ -9,7 +9,8 @@ defmodule Lexical.Protocol.ProtoTest do
 
   require LspTypes.ErrorCodes
 
-  use ExUnit.Case, async: true
+  use ExUnit.Case
+  use Patch
 
   defmodule Child do
     use Proto

--- a/apps/protocol/test/lexical/protocol/response_test.exs
+++ b/apps/protocol/test/lexical/protocol/response_test.exs
@@ -1,0 +1,77 @@
+defmodule Lexical.Protocol.ResponseTest do
+  alias Lexical.Protocol.Proto
+  alias Lexical.Protocol.Response
+  alias Lexical.Protocol.Types
+  alias Lexical.SourceFile
+
+  use ExUnit.Case
+
+  def with_open_document(_) do
+    source_file = """
+    defmodule MyTest do
+      def add(a, b), do: a + b
+    end
+    """
+
+    file_uri = "file:///file.ex"
+    {:ok, _} = start_supervised(SourceFile.Store)
+    SourceFile.Store.open(file_uri, source_file, 1)
+
+    {:ok, uri: file_uri}
+  end
+
+  describe "converting responses" do
+    setup [:with_open_document]
+
+    defmodule TextDocumentAndPosition do
+      alias Lexical.Protocol.Types
+      use Proto
+
+      deftype text_document: Types.TextDocument.Identifier,
+              placement: Types.Position
+    end
+
+    defmodule PositionContainer do
+      use Proto
+
+      defresponse optional(TextDocumentAndPosition)
+    end
+
+    test "positions are converted", %{uri: file_uri} do
+      identifier = Types.TextDocument.Identifier.new(uri: file_uri)
+
+      elixir_position = SourceFile.Position.new(2, 2)
+      body = TextDocumentAndPosition.new(text_document: identifier, placement: elixir_position)
+      response = PositionContainer.new(15, body)
+
+      assert {:ok, lsp_response} = Response.to_lsp(response)
+      assert lsp_response.id == 15
+      assert lsp_response.result.text_document == identifier
+      assert %Types.Position{} = _position = lsp_response.result.placement
+    end
+
+    defmodule Locations do
+      alias Lexical.Protocol.Types
+      use Proto
+
+      defresponse list_of(Types.Location)
+    end
+
+    test "locations are converted", %{uri: file_uri} do
+      location =
+        Types.Location.new(
+          uri: file_uri,
+          range:
+            SourceFile.Range.new(
+              SourceFile.Position.new(2, 3),
+              SourceFile.Position.new(2, 5)
+            )
+        )
+
+      response = Locations.new(5, [location])
+      assert {:ok, lsp_response} = Response.to_lsp(response)
+      assert lsp_response.id == 5
+      assert [%Types.Location{} = _lsp_location] = lsp_response.result
+    end
+  end
+end


### PR DESCRIPTION
I was noticing a lot of manual conversions in the code, and that kind of stinks. To help with this, I'm going to change how things work in the project, but this requires some additions to the protocol.

The overarching idea is to push conversions into the protocol, so that on the way in, we convert from LSP structures to native and on the way out we convert from native to LSP structures. Presently, there was no conversion on the way out (there is conversion on the way in), so this PR adds conversion when we write data.

The next step will be to change our native structures to be one-based (thanks, Elixir, for not making that configurable) so all we need to deal with in the language server are our data structures.