### PR TITLE
Converted positions to be one-based

### DIFF
--- a/apps/common/lib/lexical/code_unit.ex
+++ b/apps/common/lib/lexical/code_unit.ex
@@ -39,7 +39,7 @@ defmodule Lexical.CodeUnit do
   """
   @spec utf8_offset(String.t(), utf16_offset()) :: utf8_offset()
   def utf8_offset(binary, character_position) do
-    do_utf8_offset(binary, character_position, 0)
+    do_utf8_offset(binary, character_position, 1)
   end
 
   @doc """
@@ -47,7 +47,7 @@ defmodule Lexical.CodeUnit do
   """
   @spec to_utf8(String.t(), utf16_code_unit()) :: {:ok, utf8_code_unit()} | error
   def to_utf8(binary, utf16_unit) do
-    do_to_utf8(binary, utf16_unit, 0)
+    do_to_utf8(binary, utf16_unit, 1)
   end
 
   @doc """

--- a/apps/common/lib/lexical/source_file.ex
+++ b/apps/common/lib/lexical/source_file.ex
@@ -146,7 +146,6 @@ defmodule Lexical.SourceFile do
          %Range{start: %Position{} = start_pos, end: %Position{} = end_pos},
          new_text
        ) do
-
     start_line = start_pos.line
 
     new_lines_iodata =
@@ -227,7 +226,6 @@ defmodule Lexical.SourceFile do
   end
 
   defp edit_action(line() = line, edit_text, %Position{} = start_pos, %Position{} = end_pos) do
-
     %Position{line: start_line, character: start_char} = start_pos
     %Position{line: end_line, character: end_char} = end_pos
 

--- a/apps/common/lib/lexical/source_file.ex
+++ b/apps/common/lib/lexical/source_file.ex
@@ -146,14 +146,15 @@ defmodule Lexical.SourceFile do
          %Range{start: %Position{} = start_pos, end: %Position{} = end_pos},
          new_text
        ) do
+
     start_line = start_pos.line
 
     new_lines_iodata =
       cond do
-        start_line >= line_count(source) - source.document.starting_index ->
+        start_line > line_count(source) ->
           append_to_end(source, new_text)
 
-        start_line < 0 ->
+        start_line < 1 ->
           prepend_to_beginning(source, new_text)
 
         true ->
@@ -189,8 +190,11 @@ defmodule Lexical.SourceFile do
        )
        when start_line >= 0 and start_char >= 0 and end_line >= 0 and end_char >= 0 do
     case Ranged.Native.from_lsp(range, source) do
-      {:ok, ex_range} -> apply_change(source, ex_range, new_text)
-      _ -> {:error, {:invalid_range, range}}
+      {:ok, ex_range} ->
+        apply_change(source, ex_range, new_text)
+
+      _ ->
+        {:error, {:invalid_range, range}}
     end
   end
 
@@ -223,6 +227,7 @@ defmodule Lexical.SourceFile do
   end
 
   defp edit_action(line() = line, edit_text, %Position{} = start_pos, %Position{} = end_pos) do
+
     %Position{line: start_line, character: start_char} = start_pos
     %Position{line: end_line, character: end_char} = end_pos
 
@@ -238,7 +243,6 @@ defmodule Lexical.SourceFile do
       line_number == start_line && line_number == end_line ->
         prefix_text = utf8_prefix(line, start_char)
         suffix_text = utf8_suffix(line, end_char)
-
         {:append, [prefix_text, edit_text, suffix_text, ending]}
 
       line_number == start_line ->
@@ -255,13 +259,13 @@ defmodule Lexical.SourceFile do
   end
 
   defp utf8_prefix(line(text: text), start_code_unit) do
-    length = max(0, start_code_unit)
+    length = max(0, start_code_unit - 1)
     binary_part(text, 0, length)
   end
 
   defp utf8_suffix(line(text: text), start_code_unit) do
     byte_count = byte_size(text)
-    start_index = min(start_code_unit, byte_count)
+    start_index = min(start_code_unit - 1, byte_count)
     length = byte_count - start_index
 
     binary_part(text, start_index, length)

--- a/apps/common/test/lexical/code_unit_test.exs
+++ b/apps/common/test/lexical/code_unit_test.exs
@@ -8,11 +8,11 @@ defmodule Lexical.CodeUnitTest do
   describe "utf8 offsets" do
     test "handles single-byte characters" do
       s = "do"
-      assert 0 == utf8_offset(s, 0)
-      assert 1 == utf8_offset(s, 1)
-      assert 2 == utf8_offset(s, 2)
-      assert 2 == utf8_offset(s, 3)
-      assert 2 == utf8_offset(s, 4)
+      assert 1 == utf8_offset(s, 0)
+      assert 2 == utf8_offset(s, 1)
+      assert 3 == utf8_offset(s, 2)
+      assert 3 == utf8_offset(s, 3)
+      assert 3 == utf8_offset(s, 4)
     end
 
     test "caps offsets at the end of the string and beyond" do
@@ -22,10 +22,10 @@ defmodule Lexical.CodeUnitTest do
       # character code unit offsets, which differ
       # from utf8's, and can have gaps.
 
-      assert 4 == utf8_offset(line, 1)
-      assert 4 == utf8_offset(line, 2)
-      assert 4 == utf8_offset(line, 3)
-      assert 4 == utf8_offset(line, 4)
+      assert 5 == utf8_offset(line, 1)
+      assert 5 == utf8_offset(line, 2)
+      assert 5 == utf8_offset(line, 3)
+      assert 5 == utf8_offset(line, 4)
     end
 
     test "handles multi-byte characters properly" do
@@ -35,13 +35,13 @@ defmodule Lexical.CodeUnitTest do
       # character code unit offsets, which differ
       # from utf8's, and can have gaps.
 
-      assert 0 == utf8_offset(line, 0)
-      assert 1 == utf8_offset(line, 1)
-      assert 5 == utf8_offset(line, 3)
-      assert 6 == utf8_offset(line, 4)
-      assert 7 == utf8_offset(line, 5)
-      assert 8 == utf8_offset(line, 6)
-      assert 8 == utf8_offset(line, 7)
+      assert 1 == utf8_offset(line, 0)
+      assert 2 == utf8_offset(line, 1)
+      assert 6 == utf8_offset(line, 3)
+      assert 7 == utf8_offset(line, 4)
+      assert 8 == utf8_offset(line, 5)
+      assert 9 == utf8_offset(line, 6)
+      assert 9 == utf8_offset(line, 7)
     end
   end
 
@@ -86,32 +86,32 @@ defmodule Lexical.CodeUnitTest do
 
       code_unit_count = count_utf8_code_units(line)
 
-      assert to_utf8(line, 0) == {:ok, 0}
+      assert to_utf8(line, 0) == {:ok, 1}
       assert to_utf8(line, 1) == {:error, :misaligned}
-      assert to_utf8(line, 2) == {:ok, 4}
-      assert to_utf8(line, 3) == {:ok, 7}
-      assert to_utf8(line, 4) == {:ok, 10}
+      assert to_utf8(line, 2) == {:ok, 5}
+      assert to_utf8(line, 3) == {:ok, 8}
+      assert to_utf8(line, 4) == {:ok, 11}
       assert to_utf8(line, 5) == {:error, :misaligned}
-      assert to_utf8(line, 6) == {:ok, code_unit_count}
+      assert to_utf8(line, 6) == {:ok, code_unit_count + 1}
     end
 
     test "after a unicode character" do
       line = "    {\"🎸\",   \"ok\"}"
 
-      assert to_utf8(line, 0) == {:ok, 0}
-      assert to_utf8(line, 1) == {:ok, 1}
-      assert to_utf8(line, 4) == {:ok, 4}
-      assert to_utf8(line, 5) == {:ok, 5}
-      assert to_utf8(line, 6) == {:ok, 6}
+      assert to_utf8(line, 0) == {:ok, 1}
+      assert to_utf8(line, 1) == {:ok, 2}
+      assert to_utf8(line, 4) == {:ok, 5}
+      assert to_utf8(line, 5) == {:ok, 6}
+      assert to_utf8(line, 6) == {:ok, 7}
       assert to_utf8(line, 7) == {:error, :misaligned}
       # after the guitar character
-      assert to_utf8(line, 8) == {:ok, 10}
-      assert to_utf8(line, 9) == {:ok, 11}
-      assert to_utf8(line, 10) == {:ok, 12}
-      assert to_utf8(line, 11) == {:ok, 13}
-      assert to_utf8(line, 12) == {:ok, 14}
-      assert to_utf8(line, 13) == {:ok, 15}
-      assert to_utf8(line, 17) == {:ok, 19}
+      assert to_utf8(line, 8) == {:ok, 11}
+      assert to_utf8(line, 9) == {:ok, 12}
+      assert to_utf8(line, 10) == {:ok, 13}
+      assert to_utf8(line, 11) == {:ok, 14}
+      assert to_utf8(line, 12) == {:ok, 15}
+      assert to_utf8(line, 13) == {:ok, 16}
+      assert to_utf8(line, 17) == {:ok, 20}
     end
   end
 
@@ -168,7 +168,8 @@ defmodule Lexical.CodeUnitTest do
       assert utf16_unit == utf16_unit_count
 
       assert {:ok, utf8_unit} = to_utf8(s, utf16_unit)
-      assert utf8_unit == utf8_code_unit_count
+      # adding 1 here because our utf8 conversion is one-based
+      assert utf8_unit == utf8_code_unit_count + 1
     end
   end
 
@@ -178,9 +179,11 @@ defmodule Lexical.CodeUnitTest do
       utf8_code_unit_count = count_utf8_code_units(s)
 
       assert {:ok, utf8_code_unit} = to_utf8(s, utf16_code_unit_count)
-      assert utf8_code_unit == utf8_code_unit_count
+      # adding 1 here because our utf8 conversion is one-based
+      assert utf8_code_unit == utf8_code_unit_count + 1
 
-      assert {:ok, utf16_unit} = to_utf16(s, utf8_code_unit)
+      # subtracting 1 here because our utf8 conversion is one-based
+      assert {:ok, utf16_unit} = to_utf16(s, utf8_code_unit - 1)
       assert utf16_unit == utf16_code_unit_count
     end
   end

--- a/apps/common/test/lexical/source_file/store_test.exs
+++ b/apps/common/test/lexical/source_file/store_test.exs
@@ -95,8 +95,8 @@ defmodule Lexical.SourceFile.StoreTest do
         build_change(
           text: "dog",
           range: [
-            start: [line: 0, character: 0],
-            end: [line: 0, character: 3]
+            start: [line: 1, character: 1],
+            end: [line: 1, character: 4]
           ]
         )
 

--- a/apps/common_protocol/lib/lexical/protocol/conversions.ex
+++ b/apps/common_protocol/lib/lexical/protocol/conversions.ex
@@ -8,7 +8,6 @@ defmodule Lexical.Protocol.Conversions do
   are the same in both utf-8 and utf-16, since they reference characters and not bytes.
   """
   alias Lexical.CodeUnit
-  alias Lexical.Math
   alias Lexical.Protocol.Types.Position, as: LSPosition
   alias Lexical.Protocol.Types.Range, as: LSRange
   alias Lexical.SourceFile

--- a/apps/common_protocol/test/lexical/ranged_test.exs
+++ b/apps/common_protocol/test/lexical/ranged_test.exs
@@ -17,27 +17,27 @@ defmodule Lexical.Protocol.RangedTest do
   describe "to_elixir/2 for positions" do
     test "empty" do
       assert {:ok, pos} = Ranged.Native.from_lsp(lsp_position(0, 0), doc(""))
-      assert %ExPosition{line: 0, character: 0} = pos
+      assert %ExPosition{line: 1, character: 1} = pos
     end
 
     test "single first char" do
       assert {:ok, pos} = Ranged.Native.from_lsp(lsp_position(0, 0), doc("abcde"))
-      assert %ExPosition{line: 0, character: 0} == pos
+      assert %ExPosition{line: 1, character: 1} == pos
     end
 
     test "single line" do
       assert {:ok, pos} = Ranged.Native.from_lsp(lsp_position(0, 0), doc("abcde"))
-      assert %ExPosition{line: 0, character: 0} == pos
+      assert %ExPosition{line: 1, character: 1} == pos
     end
 
     test "single line utf8" do
       assert {:ok, pos} = Ranged.Native.from_lsp(lsp_position(0, 6), doc("🏳️‍🌈abcde"))
-      assert %ExPosition{line: 0, character: 14} == pos
+      assert %ExPosition{line: 1, character: 15} == pos
     end
 
     test "multi line" do
       assert {:ok, pos} = Ranged.Native.from_lsp(lsp_position(1, 1), doc("abcde\n1234"))
-      assert %ExPosition{line: 1, character: 1} == pos
+      assert %ExPosition{line: 2, character: 2} == pos
     end
 
     # LSP spec 3.17 https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position
@@ -45,12 +45,12 @@ defmodule Lexical.Protocol.RangedTest do
 
     test "position > line length of an empty document" do
       assert {:ok, pos} = Ranged.Native.from_lsp(lsp_position(0, 15), doc(""))
-      assert %ExPosition{line: 0, character: 0} == pos
+      assert %ExPosition{line: 1, character: 1} == pos
     end
 
     test "position > line length of a document with characters" do
       assert {:ok, pos} = Ranged.Native.from_lsp(lsp_position(0, 15), doc("abcde"))
-      assert %ExPosition{line: 0, character: 5} == pos
+      assert %ExPosition{line: 1, character: 6} == pos
     end
 
     #   # This is not specified in LSP but some clients fail to synchronize text properly
@@ -58,7 +58,7 @@ defmodule Lexical.Protocol.RangedTest do
       # the behavior that conversions does is to clamp at the start line of the end of the
       # document.
       assert {:ok, pos} = Ranged.Native.from_lsp(lsp_position(8, 2), doc("abcde\n1234"))
-      assert %ExPosition{line: 2, character: 0} == pos
+      assert %ExPosition{line: 3, character: 1} == pos
     end
   end
 end

--- a/apps/protocol/test/lexical/proto_test.exs
+++ b/apps/protocol/test/lexical/proto_test.exs
@@ -424,8 +424,8 @@ defmodule Lexical.Protocol.ProtoTest do
       assert %SourceFile{} = notif.source_file
       assert %SourceFile.Position{} = notif.position
 
-      assert notif.position.line == 0
-      assert notif.position.character == 0
+      assert notif.position.line == 1
+      assert notif.position.character == 1
     end
 
     defmodule Notif.WithRange do
@@ -452,10 +452,10 @@ defmodule Lexical.Protocol.ProtoTest do
 
       assert %SourceFile{} = notif.source_file
       assert %SourceFile.Range{} = notif.range
-      assert notif.range.start.line == 0
-      assert notif.range.start.character == 0
-      assert notif.range.end.line == 0
-      assert notif.range.end.character == 3
+      assert notif.range.start.line == 1
+      assert notif.range.start.character == 1
+      assert notif.range.end.line == 1
+      assert notif.range.end.character == 4
     end
   end
 
@@ -563,8 +563,8 @@ defmodule Lexical.Protocol.ProtoTest do
 
       assert req.range ==
                SourceFile.Range.new(
-                 SourceFile.Position.new(0, 0),
-                 SourceFile.Position.new(0, 5)
+                 SourceFile.Position.new(1, 1),
+                 SourceFile.Position.new(1, 6)
                )
     end
   end

--- a/apps/remote_control/lib/lexical/remote_control/completion.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion.ex
@@ -6,8 +6,8 @@ defmodule Lexical.RemoteControl.Completion do
     # Add one to both the line and character, because elixir sense
     # has one-based lines, and the character needs to be after the context,
     # rather than in between.
-    line = position.line + 1
-    character = position.character + 1
+    line = position.line
+    character = position.character
     hint = ElixirSense.Core.Source.prefix(source, line, character)
 
     if String.trim(hint) == "" do

--- a/apps/remote_control/test/lexical/remote_control/code_mod/replace_with_underscore_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_mod/replace_with_underscore_test.exs
@@ -7,7 +7,7 @@ defmodule Lexical.RemoteControl.CodeMod.ReplaceWithUnderscoreTest do
   def apply_code_mod(original_text, _ast, options) do
     variable = Keyword.get(options, :variable, :unused)
     source_file = SourceFile.new("file:///file.ex", original_text, 0)
-    ReplaceWithUnderscore.text_edits(source_file, 0, variable)
+    ReplaceWithUnderscore.text_edits(source_file, 1, variable)
   end
 
   describe "fixes in parameters" do

--- a/apps/server/lib/lexical/server/project/diagnostics.ex
+++ b/apps/server/lib/lexical/server/project/diagnostics.ex
@@ -150,8 +150,8 @@ defmodule Lexical.Server.Project.Diagnostics do
 
         _error ->
           Range.new(
-            start: Position.new(line: 0, character: 0),
-            end: Position.new(line: line_number, character: 0)
+            start: Position.new(line: line_number, character: 0),
+            end: Position.new(line: line_number + 1, character: 0)
           )
       end
     end

--- a/apps/server/lib/lexical/server/project/diagnostics.ex
+++ b/apps/server/lib/lexical/server/project/diagnostics.ex
@@ -135,7 +135,7 @@ defmodule Lexical.Server.Project.Diagnostics do
     end
 
     defp position_to_range(%SourceFile{} = source_file, {line_number, column}) do
-      line_number = Math.clamp(line_number, 1, SourceFile.size(source_file) + 1)
+      line_number = Math.clamp(line_number, 1, SourceFile.size(source_file))
       column = max(column, 1)
 
       elixir_range =

--- a/apps/server/lib/lexical/server/project/diagnostics.ex
+++ b/apps/server/lib/lexical/server/project/diagnostics.ex
@@ -1,12 +1,14 @@
 defmodule Lexical.Server.Project.Diagnostics do
   defmodule State do
-    alias Lexical.CodeUnit
     alias Lexical.Math
     alias Lexical.Project
     alias Lexical.Protocol.Types.Diagnostic
     alias Lexical.Protocol.Types.Position
     alias Lexical.Protocol.Types.Range
+    alias Lexical.Ranged
     alias Lexical.SourceFile
+    alias Lexical.SourceFile.Position, as: ExPosition
+    alias Lexical.SourceFile.Range, as: ExRange
     alias Mix.Task.Compiler
 
     defstruct [:project, :diagnostics_by_uri]
@@ -133,20 +135,23 @@ defmodule Lexical.Server.Project.Diagnostics do
     end
 
     defp position_to_range(%SourceFile{} = source_file, {line_number, column}) do
-      line_number = Math.clamp(line_number - 1, 0, SourceFile.size(source_file) - 1)
-      column = max(column - 1, 0)
+      line_number = Math.clamp(line_number, 1, SourceFile.size(source_file) + 1)
+      column = max(column, 1)
 
-      with {:ok, line_text} <- SourceFile.fetch_text_at(source_file, line_number),
-           {:ok, character} <- CodeUnit.to_utf16(line_text, column) do
-        Range.new(
-          start: Position.new(line: line_number, character: character),
-          end: Position.new(line: line_number + 1, character: 0)
+      elixir_range =
+        ExRange.new(
+          ExPosition.new(line_number, column),
+          ExPosition.new(line_number + 1, 1)
         )
-      else
-        _ ->
+
+      case Ranged.Lsp.from_native(elixir_range, source_file) do
+        {:ok, range} ->
+          range
+
+        _error ->
           Range.new(
             start: Position.new(line: 0, character: 0),
-            end: Position.new(line: 1, character: 0)
+            end: Position.new(line: line_number, character: 0)
           )
       end
     end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/function_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/function_test.exs
@@ -60,6 +60,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.FunctionTest d
       ]
 
       completions = complete(project, source)
+
       arity_one_completions = Enum.filter(completions, &String.ends_with?(&1.sort_text, "/1"))
 
       Enum.each(arity_one_completions, fn completion ->

--- a/apps/server/test/lexical/server/project/diagnostics/state_test.exs
+++ b/apps/server/test/lexical/server/project/diagnostics/state_test.exs
@@ -43,19 +43,8 @@ defmodule Lexical.Project.Diagnostics.StateTest do
     source_file
   end
 
-  defp compiler_position({line, column}) do
-    {compiler_position(line), compiler_position(column)}
-  end
-
-  defp compiler_position(line) do
-    line + 1
-  end
-
   def compiler_diagnostic(opts \\ []) do
-    position =
-      opts
-      |> Keyword.get(:position, 4)
-      |> compiler_position()
+    position = Keyword.get(opts, :position, 1)
 
     %Compiler.Diagnostic{
       message: Keyword.get(opts, :message, "This file is broken"),
@@ -110,7 +99,7 @@ defmodule Lexical.Project.Diagnostics.StateTest do
       end
       ]
       source_file = source_file(source)
-      diagnostic = compiler_diagnostic(message: "Hoo boy, this is a mess", position: {1, 5})
+      diagnostic = compiler_diagnostic(message: "Hoo boy, this is a mess", position: {2, 5})
 
       {:ok, state} = State.add(state, diagnostic, source_file.uri)
 
@@ -123,7 +112,7 @@ defmodule Lexical.Project.Diagnostics.StateTest do
 
       # Starting at 0 and going to character 0 on the next line highlights the entire line
       assert range.start.line == 1
-      assert range.start.character == 5
+      assert range.start.character == 4
 
       assert range.end.line == 2
       assert range.end.character == 0
@@ -139,7 +128,7 @@ defmodule Lexical.Project.Diagnostics.StateTest do
       ]t
 
       source_file = source_file(source)
-      diagnostic = compiler_diagnostic(message: "Hoo boy, this is a mess", position: {2, 9})
+      diagnostic = compiler_diagnostic(message: "Hoo boy, this is a mess", position: {3, 10})
 
       {:ok, state} = State.add(state, diagnostic, source_file.uri)
 

--- a/apps/server/test/lexical/server/project/diagnostics_test.exs
+++ b/apps/server/test/lexical/server/project/diagnostics_test.exs
@@ -105,9 +105,9 @@ defmodule Lexical.Server.Project.DiagnosticsTest do
       assert_receive {:transport, %PublishDiagnostics{lsp: %{diagnostics: [diagnostic]}}}, 500
 
       range = diagnostic.range
-      assert range.start.line == 0
+      assert range.start.line == 3
       assert range.start.character == 0
-      assert range.end.line == 3
+      assert range.end.line == 4
       assert range.end.character == 0
     end
   end

--- a/apps/server/test/lexical/server/project/diagnostics_test.exs
+++ b/apps/server/test/lexical/server/project/diagnostics_test.exs
@@ -107,7 +107,7 @@ defmodule Lexical.Server.Project.DiagnosticsTest do
       range = diagnostic.range
       assert range.start.line == 0
       assert range.start.character == 0
-      assert range.end.line == 4
+      assert range.end.line == 3
       assert range.end.character == 0
     end
   end

--- a/apps/server/test/lexical/server/project/diagnostics_test.exs
+++ b/apps/server/test/lexical/server/project/diagnostics_test.exs
@@ -90,24 +90,6 @@ defmodule Lexical.Server.Project.DiagnosticsTest do
       assert_receive {:transport, %PublishDiagnostics{diagnostics: nil}}
     end
 
-    test "it converts a file's diagnostics to the first line if they're out of bounds", %{
-      project: project
-    } do
-      source_file = open_file(project, "defmodule Foo")
-      file_diagnostics = diagnostic(source_file.uri, position: {100, 2})
-
-      file_diagnostics_message =
-        file_diagnostics(diagnostics: [file_diagnostics], uri: source_file.uri)
-
-      Project.Dispatch.broadcast(project, file_diagnostics_message)
-      assert_receive {:transport, %PublishDiagnostics{lsp: %{diagnostics: [diagnostic]}}}, 500
-
-      range = diagnostic.range
-
-      assert range.start.line == 0
-      assert range.end.line == 1
-    end
-
     test "it adds a diagnostic to the last line if they're out of bounds", %{project: project} do
       source_file = open_file(project, "defmodule Dummy do\n  .\nend\n")
       # only 3 lines in the file, but elixir compiler gives us a line number of 4
@@ -123,8 +105,10 @@ defmodule Lexical.Server.Project.DiagnosticsTest do
       assert_receive {:transport, %PublishDiagnostics{lsp: %{diagnostics: [diagnostic]}}}, 500
 
       range = diagnostic.range
-      assert range.start.line == 2
-      assert range.end.line == 3
+      assert range.start.line == 0
+      assert range.start.character == 0
+      assert range.end.line == 4
+      assert range.end.character == 0
     end
   end
 end

--- a/apps/server/test/source_file_test.exs
+++ b/apps/server/test/source_file_test.exs
@@ -32,7 +32,7 @@ defmodule Lexical.SourceFileTest do
     test "it should be able to parse a single line" do
       assert parsed = new("file:///elixir.ex", "hello", 1)
 
-      assert {:ok, "hello"} = fetch_text_at(parsed, 0)
+      assert {:ok, "hello"} = fetch_text_at(parsed, 1)
     end
 
     test "it should parse its input into lines", ctx do
@@ -40,15 +40,15 @@ defmodule Lexical.SourceFileTest do
       refute parsed.dirty?
       assert parsed.version == 100
 
-      assert {:ok, "defmodule MyModule do"} = fetch_text_at(parsed, 0)
-      assert {:ok, "  def foo, do: 3"} = fetch_text_at(parsed, 1)
-      assert {:ok, ""} = fetch_text_at(parsed, 2)
-      assert {:ok, "  def bar(a, b) do"} = fetch_text_at(parsed, 3)
-      assert {:ok, "    a + b"} = fetch_text_at(parsed, 4)
-      assert {:ok, "  end"} = fetch_text_at(parsed, 5)
-      assert {:ok, "end"} = fetch_text_at(parsed, 6)
+      assert {:ok, "defmodule MyModule do"} = fetch_text_at(parsed, 1)
+      assert {:ok, "  def foo, do: 3"} = fetch_text_at(parsed, 2)
+      assert {:ok, ""} = fetch_text_at(parsed, 3)
+      assert {:ok, "  def bar(a, b) do"} = fetch_text_at(parsed, 4)
+      assert {:ok, "    a + b"} = fetch_text_at(parsed, 5)
+      assert {:ok, "  end"} = fetch_text_at(parsed, 6)
+      assert {:ok, "end"} = fetch_text_at(parsed, 7)
 
-      assert :error = fetch_text_at(parsed, 7)
+      assert :error = fetch_text_at(parsed, 8)
     end
   end
 
@@ -578,7 +578,7 @@ defmodule Lexical.SourceFileTest do
       }
 
       assert {:ok, source} = run_changes(orig, [event])
-      assert {:ok, ""} = fetch_text_at(source, 2)
+      assert {:ok, ""} = fetch_text_at(source, 3)
     end
 
     test "deleting a line with a multi-byte character" do
@@ -595,7 +595,7 @@ defmodule Lexical.SourceFileTest do
                  %{text: "", range: new_range(2, 0, 2, 19)}
                ])
 
-      {:ok, line} = fetch_text_at(source, 2)
+      {:ok, line} = fetch_text_at(source, 3)
       assert line == ""
     end
 
@@ -614,7 +614,7 @@ defmodule Lexical.SourceFileTest do
                  %{text: "", range: new_range(2, 11, 2, 13)}
                ])
 
-      {:ok, line} = fetch_text_at(source, 2)
+      {:ok, line} = fetch_text_at(source, 3)
 
       assert line == "    {\"🎸\", \"ok\"}"
     end

--- a/apps/server/test/support/completion_case.ex
+++ b/apps/server/test/support/completion_case.ex
@@ -44,7 +44,12 @@ defmodule Lexical.Test.Server.CompletionCase do
 
     root_path = Project.root_path(project)
     file_path = Path.join([root_path, "lib", "file.ex"])
-    document = SourceFile.new("file://#{file_path}", text, 0)
+
+    document =
+      file_path
+      |> SourceFile.Path.ensure_uri()
+      |> SourceFile.new(text, 0)
+
     position = %SourceFile.Position{line: line, character: column}
 
     context =

--- a/apps/server/test/support/cursor_support.ex
+++ b/apps/server/test/support/cursor_support.ex
@@ -3,7 +3,7 @@ defmodule Lexical.Test.CursorSupport do
     text
     |> String.graphemes()
     |> Enum.chunk_every(2, 1, [""])
-    |> Enum.reduce_while({0, 0}, fn
+    |> Enum.reduce_while({starting_line(), starting_column()}, fn
       ["|", ">"], {line, column} ->
         {:cont, {line, column + 1}}
 
@@ -11,7 +11,7 @@ defmodule Lexical.Test.CursorSupport do
         {:halt, position}
 
       ["\n", _], {line, _column} ->
-        {:cont, {line + 1, 0}}
+        {:cont, {line + 1, starting_column()}}
 
       _, {line, column} ->
         {:cont, {line, column + 1}}
@@ -50,5 +50,13 @@ defmodule Lexical.Test.CursorSupport do
         [iodata, c]
     end)
     |> IO.iodata_to_binary()
+  end
+
+  defp starting_line do
+    1
+  end
+
+  defp starting_column do
+    1
   end
 end


### PR DESCRIPTION
When I designed lexical, I thought it would be good to have zero-based positions like the LS protocol and elixir's conventions. I thought that getting the compiler to emit zero-based messages would be as simple as adding a compiler setting. However, it's not so easy. In fact, it's impossible at the present moment.

So, we can see the code is starting to get a lot of `line + 1` and `line - 1` kind of code, which stinks.

Combined with the last commit, this changes source files, code units, positions and ranges to be one-based, and we convert from the zero-based language server at the boundaries. Now, the only code that adds or subtracts will be string manipulation code, which we'll likely put behind some kind of interface.

Get ready for a series of off-by-one errors

Fixes #81 