### PR TITLE
Use multiple diagnostics instead of one

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build/error.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/error.ex
@@ -16,15 +16,65 @@ defmodule Lexical.RemoteControl.Build.Error do
   end
 
   def parse_error_to_diagnostics(context, message_info, token) do
-    diagnostic = %Diagnostic{
-      file: nil,
-      severity: :error,
-      position: context_to_position(context),
-      compiler_name: "Elixir",
-      message: message_info_to_binary(message_info, token)
-    }
+    parse_error_diagnostic_functions = [
+      &build_end_line_diagnostics/3,
+      &build_start_line_diagnostics/3,
+      &build_hint_diagnostics/3
+    ]
 
-    [diagnostic]
+    Enum.flat_map(parse_error_diagnostic_functions, & &1.(context, message_info, token))
+  end
+
+  defp build_end_line_diagnostics(context, message_info, token) do
+    [end_line_message | _] = String.split(message_info, "\n")
+
+    [
+      %Diagnostic{
+        file: nil,
+        severity: :error,
+        position: context_to_position(context),
+        compiler_name: "Elixir",
+        message: "#{end_line_message}#{token}"
+      }
+    ]
+  end
+
+  @start_line_regex ~r/(\w+) \(for (.*) starting at line (\d+)\)/
+  defp build_start_line_diagnostics(_context, message_info, _token) do
+    case Regex.run(@start_line_regex, message_info) do
+      [_, missing, token, start_line] ->
+        diagnostic = %Diagnostic{
+          file: nil,
+          severity: :error,
+          position: String.to_integer(start_line),
+          compiler_name: "Elixir",
+          message: "The #{token} here is missing a terminator: #{inspect(missing)}"
+        }
+
+        [diagnostic]
+
+      _ ->
+        []
+    end
+  end
+
+  @hint_regex ~r/HINT: .*on line (\d+).*/m
+  defp build_hint_diagnostics(_context, message_info, _token) do
+    case Regex.run(@hint_regex, message_info) do
+      [message, hint_line] ->
+        diagnostic = %Diagnostic{
+          file: nil,
+          severity: :error,
+          position: String.to_integer(hint_line),
+          compiler_name: "Elixir",
+          message: String.replace(message, ~r/on line \d+/, "here")
+        }
+
+        [diagnostic]
+
+      _ ->
+        []
+    end
   end
 
   def error_to_diagnostic(%CompileError{} = compile_error, _stack, _quoted_ast) do

--- a/apps/remote_control/lib/lexical/remote_control/build/error.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/error.ex
@@ -12,7 +12,7 @@ defmodule Lexical.RemoteControl.Build.Error do
     detail_diagnostics = detail_diagnostics(detail)
     error = message_info_to_binary(message_info, token)
     error_diagnostics = parse_error_to_diagnostics(context, error, token)
-    uniq(error_diagnostics ++ detail_diagnostics)
+    extract_line(error_diagnostics ++ detail_diagnostics)
   end
 
   def parse_error_to_diagnostics(context, message_info, token) do
@@ -25,18 +25,15 @@ defmodule Lexical.RemoteControl.Build.Error do
     Enum.flat_map(parse_error_diagnostic_functions, & &1.(context, message_info, token))
   end
 
-  defp uniq(diagnostics) do
+  defp extract_line(diagnostics) do
     # We need to uniq by position because the same position can be reported
     # and the `end_line_diagnostic` is always the precise one
     position_key = fn
-      %Diagnostic{position: position} when is_tuple(position) ->
-        elem(position, 0)
-
-      %Diagnostic{position: position} ->
-        position
+      %Diagnostic{position: {line, _column}} -> line
+      %Diagnostic{position: line} -> line
     end
 
-    Enum.uniq_by(diagnostics, &position_key.(&1))
+    Enum.uniq_by(diagnostics, position_key)
   end
 
   defp build_end_line_diagnostics(context, message_info, token) do

--- a/apps/remote_control/lib/lexical/remote_control/build/error.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/error.ex
@@ -12,7 +12,7 @@ defmodule Lexical.RemoteControl.Build.Error do
     detail_diagnostics = detail_diagnostics(detail)
     error = message_info_to_binary(message_info, token)
     error_diagnostics = parse_error_to_diagnostics(context, error, token)
-    extract_line(error_diagnostics ++ detail_diagnostics)
+    uniq(error_diagnostics ++ detail_diagnostics)
   end
 
   def parse_error_to_diagnostics(context, message_info, token) do
@@ -25,15 +25,15 @@ defmodule Lexical.RemoteControl.Build.Error do
     Enum.flat_map(parse_error_diagnostic_functions, & &1.(context, message_info, token))
   end
 
-  defp extract_line(diagnostics) do
+  defp uniq(diagnostics) do
     # We need to uniq by position because the same position can be reported
     # and the `end_line_diagnostic` is always the precise one
-    position_key = fn
+    extract_line = fn
       %Diagnostic{position: {line, _column}} -> line
       %Diagnostic{position: line} -> line
     end
 
-    Enum.uniq_by(diagnostics, position_key)
+    Enum.uniq_by(diagnostics, extract_line)
   end
 
   defp build_end_line_diagnostics(context, message_info, token) do

--- a/apps/remote_control/test/lexical/remote_control/build/error_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/error_test.exs
@@ -85,6 +85,20 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
       assert detail.position == 4
     end
 
+    test "return the more precise one when there are multiple diagnostics on the same line" do
+      errors =
+        ~S{Keywor.get([], fn x -> )}
+        |> compile()
+        |> parse_error()
+
+      assert [error] = errors
+
+      assert error.message ==
+               ~S[unexpected token: ). The "fn" at line 1 is missing terminator "end")]
+
+      assert error.position == {1, 24}
+    end
+
     test "returns two diagnostics when missing end at the real end" do
       errors =
         ~S[


### PR DESCRIPTION
Hint is not always available, but when there is a hint, its information is more precise than the context. Currently, when there is a hint, there will be three diagnostics provided. However, I prefer to have only **one diagnostic**.

for example:


```elixir
defmodule ElixirNav do
  def foo_middle() do
  end






  def foo_end() do

  def foo() do
  end
end
```

<img width="610" alt="image" src="https://user-images.githubusercontent.com/12830256/230026993-4feab6f9-38ba-4a70-82a1-c885055c2297.png">

The diagnostic of line 10 is enough.


### another change

Also, we cannot use the method of adding 1 to highlight the entire line. This can easily cause the range to exceed the total number of lines in the code and highlight the whole file. Instead, we should use:

```
      elixir_range =
        ExRange.new(
          ExPosition.new(line_number, column),
          ExPosition.new(min(line_number + 1, file_size), 1)
        )
```
This is the preview in VScode.(I verified this in vscode and neovim.)

<img width="273" alt="image" src="https://user-images.githubusercontent.com/12830256/230026401-4fe49e2e-14ee-47fd-9831-e840e9801a95.png">

And this is the preview of this previous code

```elixir
          ExPosition.new(line_number, column),
          ExPosition.new(line_number + 1, 1)
```

<img width="318" alt="image" src="https://user-images.githubusercontent.com/12830256/230029973-101e7899-e953-4be6-9414-f2d92b96f445.png">

Fixes #25 
