### PR TITLE
Improve namespace for .app files & its references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,10 @@ To install lexical fetch the source code from git, then do the following:
  
  Lexical will now be available in `_build/prod/rel/lexical`
  
+To use lexical as a language server while working on lexical source code,
+use the following to produce the release and avoid bugs:
+
+ ```
+ NAMESPACE=1 mix release lexical
+ ```
 

--- a/apps/proto/lib/mix/tasks/namespace/abstract.ex
+++ b/apps/proto/lib/mix/tasks/namespace/abstract.ex
@@ -295,9 +295,12 @@ defmodule Mix.Tasks.Namespace.Abstract do
       |> String.split(".")
 
     case split_module do
+      # namespace app references, e.g. in remote_control.ex
       ["remote_control"] ->
-        # namespace app references
         :lx_remote_control
+
+      ["common"] ->
+        :lx_common
 
       ["Lexical"] ->
         :LXRelease

--- a/apps/proto/lib/mix/tasks/namespace/release.ex
+++ b/apps/proto/lib/mix/tasks/namespace/release.ex
@@ -3,44 +3,54 @@ defmodule Mix.Tasks.Namespace.Release do
   `remote_control.app` must be namespaced too
   """
   use Mix.Task
-  @release_files ~w(start.script start_clean.script lexical.rel)
-  @apps_to_rewrite ~w(remote_control)
+  @release_files ~w(start.script lexical.rel)
+  @apps_to_rewrite ~w(remote_control common common_protocol server protocol proto)
 
-  def run([release_path, release_version_path]) do
-    Enum.map(@apps_to_rewrite, &update_app(release_path, release_version_path, &1))
+  def run(_) do
+    release = Mix.Release.from_config!(:lexical, Mix.Project.config(), [])
+    Enum.map(@apps_to_rewrite, &update_app(release.path, release.version_path, &1))
+    # namespace .app filenames because the filename is used as identifier by BEAM
+    Enum.map(@apps_to_rewrite, &namespace_app_file(release.path, &1))
+    Mix.Shell.IO.info("\nApplied namespace to release app.")
   end
 
-  defp update_app(release_path, release_version_path, app_name) do
-    app_file_name = "#{app_name}.app"
-
+  defp path(:ebin, release_path, app_name) do
     [ebin_path] =
       [release_path, "lib", "#{app_name}-*", "ebin"]
       |> Path.join()
       |> Path.wildcard()
 
-    app_file_path = Path.join([ebin_path, app_file_name])
+    ebin_path
+  end
+
+  defp path(:app_file, release_path, app_name) do
+    Path.join([path(:ebin, release_path, app_name), "#{app_name}.app"])
+  end
+
+  defp update_app(release_path, release_version_path, app_name) do
+    # Rename references in release scripts
     release_file_paths = Enum.map(@release_files, &Path.join([release_version_path, &1]))
-    paths = [app_file_path | release_file_paths]
+    # Rename references in the dependencies of app files
+    apps_file_paths = Enum.map(@apps_to_rewrite, &path(:app_file, release_path, &1))
+    paths = apps_file_paths ++ release_file_paths
 
-    Enum.each(paths, &update_file_contents(&1, "remote_control"))
-
-    # rename .app file because the filename is used as identifier by BEAM
-    namespace_app_file(app_file_path)
-
-    Mix.Shell.IO.info("\nApplied namespace to release app.")
+    Enum.each(paths, &update_file_contents(&1, app_name))
   end
 
   defp update_file_contents(path, app_name) do
     contents = File.read!(path)
-    # avoid replacing directory path with negative lookbehind:
-    updated_contents = String.replace(contents, ~r/(?<!\/)#{app_name}/, "lx_#{app_name}")
+    # matches if preceding characters involves either of: , " [ { [:blank:]
+    # this way it doesn't match on substrings or directory names
+    updated_contents =
+      String.replace(contents, ~r/([,"\[{[:blank:]])#{app_name}/, "\\1lx_#{app_name}")
+
     File.write!(path, updated_contents)
   end
 
-  defp namespace_app_file(app_file_path) do
-    app_file_dir = Path.dirname(app_file_path)
-    app_file_name = Path.basename(app_file_path)
-    namespaced_app_file = Path.join([app_file_dir, "lx_" <> app_file_name])
+  defp namespace_app_file(release_path, app_name) do
+    ebin_path = path(:ebin, release_path, app_name)
+    app_file_path = path(:app_file, release_path, app_name)
+    namespaced_app_file = Path.join([ebin_path, "lx_" <> "#{app_name}.app"])
     :ok = File.rename(app_file_path, namespaced_app_file)
   end
 end

--- a/apps/proto/lib/mix/tasks/namespace/release.ex
+++ b/apps/proto/lib/mix/tasks/namespace/release.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Namespace.Release do
     Mix.Shell.IO.info("\nApplied namespace to release app.")
   end
 
-  defp path(:ebin, release_path, app_name) do
+  defp ebin_path(release_path, app_name) do
     [ebin_path] =
       [release_path, "lib", "#{app_name}-*", "ebin"]
       |> Path.join()
@@ -23,15 +23,15 @@ defmodule Mix.Tasks.Namespace.Release do
     ebin_path
   end
 
-  defp path(:app_file, release_path, app_name) do
-    Path.join([path(:ebin, release_path, app_name), "#{app_name}.app"])
+  defp app_file_path(release_path, app_name) do
+    Path.join([ebin_path(release_path, app_name), "#{app_name}.app"])
   end
 
   defp update_app(release_path, release_version_path, app_name) do
     # Rename references in release scripts
     release_file_paths = Enum.map(@release_files, &Path.join([release_version_path, &1]))
     # Rename references in the dependencies of app files
-    apps_file_paths = Enum.map(@apps_to_rewrite, &path(:app_file, release_path, &1))
+    apps_file_paths = Enum.map(@apps_to_rewrite, &app_file_path(release_path, &1))
     paths = apps_file_paths ++ release_file_paths
 
     Enum.each(paths, &update_file_contents(&1, app_name))
@@ -48,8 +48,8 @@ defmodule Mix.Tasks.Namespace.Release do
   end
 
   defp namespace_app_file(release_path, app_name) do
-    ebin_path = path(:ebin, release_path, app_name)
-    app_file_path = path(:app_file, release_path, app_name)
+    ebin_path = ebin_path(release_path, app_name)
+    app_file_path = app_file_path(release_path, app_name)
     namespaced_app_file = Path.join([ebin_path, "lx_" <> "#{app_name}.app"])
     :ok = File.rename(app_file_path, namespaced_app_file)
   end

--- a/apps/proto/lib/mix/tasks/namespace/release.ex
+++ b/apps/proto/lib/mix/tasks/namespace/release.ex
@@ -8,9 +8,9 @@ defmodule Mix.Tasks.Namespace.Release do
 
   def run(_) do
     release = Mix.Release.from_config!(:lexical, Mix.Project.config(), [])
-    Enum.map(@apps_to_rewrite, &update_app(release.path, release.version_path, &1))
+    Enum.each(@apps_to_rewrite, &update_app(release.path, release.version_path, &1))
     # namespace .app filenames because the filename is used as identifier by BEAM
-    Enum.map(@apps_to_rewrite, &namespace_app_file(release.path, &1))
+    Enum.each(@apps_to_rewrite, &namespace_app_file(release.path, &1))
     Mix.Shell.IO.info("\nApplied namespace to release app.")
   end
 

--- a/apps/remote_control/lib/lexical/remote_control/build.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build.ex
@@ -16,10 +16,7 @@ defmodule Lexical.RemoteControl.Build do
   end
 
   def compile_source_file(%Project{} = project, %SourceFile{} = source_file) do
-    # Don't format mix.exs files until we come up with with a way to prevent them from causing errors
-    unless Path.absname(source_file.path) == "mix.exs" do
-      RemoteControl.call(project, GenServer, :cast, [__MODULE__, {:compile_file, source_file}])
-    end
+    RemoteControl.call(project, GenServer, :cast, [__MODULE__, {:compile_file, source_file}])
 
     :ok
   end

--- a/mix.exs
+++ b/mix.exs
@@ -94,7 +94,7 @@ defmodule Lexical.MixProject do
 
   defp maybe_namespace_release(%Mix.Release{} = release) do
     if System.get_env("NAMESPACE") do
-      Mix.Task.run("namespace.release", [release.path, release.version_path])
+      Mix.Task.run("namespace.release")
     end
 
     release


### PR DESCRIPTION
This should be it for namespacing everything that requires namespacing.

Just added some sneaky edge cases that were not covered by previous code, the general scheme of the task stays very similar.

This fixes diagnostics that look like:

```ex
 %Mix.Task.Compiler.Diagnostic{file: "/Users/steve/Projects/lexical/apps/server/lib/lexical/server/project/diagnostics.ex", severity: :warning, message: "Lexical.SourceFile.Store.open?/1 defined in application :common is used by the current application but the current application does not depend on :common. To fix this, you must do one of:\n\n  1. If :common is part of Erlang/Elixir, you must include it under :extra_applications inside \"def application\" in your mix.exs\n\n  2. If :common is a dependency, make sure it is listed under \"def deps\" in your mix.exs\n\n  3. In case you don't want to add a requirement to :common, you may optionally skip this warning by adding [xref: [exclude: [Lexical.SourceFile.Store]]] to your \"def project\" in mix.exs\n", position: 36, compiler_name: "Elixir", details: nil}
```

- Closes https://github.com/lexical-lsp/lexical/issues/44 
- Removes the `unless` special case here, doesn't seem to be a problem anymore: https://github.com/lexical-lsp/lexical/commit/6ab6efd2601a04a88b14e430a82108d770a054bd#diff-64a6279b1684f2330338b7564bdcb9506b6bfcf3aba3f42b9461a9af889da367R22-R27