### PR TITLE
Change Types.Initizlize.Result to Types.Initialize.Result

### DIFF
--- a/apps/protocol/lib/lexical/protocol/responses.ex
+++ b/apps/protocol/lib/lexical/protocol/responses.ex
@@ -5,7 +5,7 @@ defmodule Lexical.Protocol.Responses do
   defmodule InitializeResult do
     use Proto
 
-    defresponse Types.Initizlize.Result
+    defresponse Types.Initialize.Result
   end
 
   defmodule FindReferences do


### PR DESCRIPTION
Types.Initizlize.Result does not exist.