### PR TITLE
Fix code actions line number issue

### DIFF
--- a/apps/server/lib/lexical/server/provider/code_action/replace_with_underscore.ex
+++ b/apps/server/lib/lexical/server/provider/code_action/replace_with_underscore.ex
@@ -81,7 +81,7 @@ defmodule Lexical.Server.Provider.CodeAction.ReplaceWithUnderscore do
 
   defp adjust_line_number(%TextEdit{} = text_edit, line_number) do
     text_edit
-    |> put_in([:range, :start, :line], line_number)
-    |> put_in([:range, :end, :line], line_number)
+    |> put_in([:range, :start, :line], line_number - 1)
+    |> put_in([:range, :end, :line], line_number - 1)
   end
 end


### PR DESCRIPTION
```elixir
defmodule MyModule do
  def foo(foo) do
  end
end
```

The line_number extracted [here](https://github.com/lexical-lsp/lexical/blob/main/apps/server/lib/lexical/server/provider/code_action/replace_with_underscore.ex#L21) is `2`, but the lsp is 0-based.