### PR TITLE
Moved store to ets

### DIFF
--- a/apps/common/lib/lexical/source_file/store.ex
+++ b/apps/common/lib/lexical/source_file/store.ex
@@ -1,29 +1,40 @@
 defmodule Lexical.SourceFile.Store do
+  @moduledoc """
+  A backing store for source file documents
+
+  This implementation stores documents in ETS, and partitions read and write operations. Read operations are served
+  immediately by querying the ETS table, while writes go through a GenServer process (which is the owner of the ETS table).
+  """
   defmodule State do
     alias Lexical.SourceFile
     alias Lexical.SourceFile.Store
     require Logger
 
-    defstruct source_files: %{}, temp_files: %{}, temporary_open_refs: %{}
+    defstruct temporary_open_refs: %{}
+
+    @table_name SourceFile.Store
+
     @type t :: %__MODULE__{}
     def new do
+      :ets.new(@table_name, [:named_table, :set, :protected, write_concurrency: true])
+
       %__MODULE__{}
     end
 
-    @spec fetch(t, Store.uri()) :: {:ok, t()} | {:error, :not_open}
-    def fetch(%__MODULE__{} = store, uri) do
-      with :error <- Map.fetch(store.source_files, uri),
-           :error <- Map.fetch(store.temp_files, uri) do
-        {:error, :not_open}
+    @spec fetch(Store.uri()) :: {:ok, t()} | {:error, :not_open}
+    def fetch(uri) do
+      case ets_fetch(:any, uri) do
+        {:ok, _} = success -> success
+        :error -> {:error, :not_open}
       end
     end
 
     @spec save(t, Store.uri()) :: {:ok, t()} | {:error, :not_open}
     def save(%__MODULE__{} = store, uri) do
-      case Map.fetch(store.source_files, uri) do
+      case ets_fetch(:sources, uri) do
         {:ok, source_file} ->
           source_file = SourceFile.mark_clean(source_file)
-          store = %__MODULE__{store | source_files: Map.put(store.source_files, uri, source_file)}
+          ets_put(:sources, uri, source_file)
           {:ok, store}
 
         :error ->
@@ -33,41 +44,37 @@ defmodule Lexical.SourceFile.Store do
 
     @spec open(t, Store.uri(), String.t(), pos_integer()) :: {:ok, t} | {:error, :already_open}
     def open(%__MODULE__{} = store, uri, text, version) do
-      case Map.fetch(store.source_files, uri) do
+      case ets_fetch(:sources, uri) do
         {:ok, _} ->
           {:error, :already_open}
 
         :error ->
           source_file = SourceFile.new(uri, text, version)
-          store = %__MODULE__{store | source_files: Map.put(store.source_files, uri, source_file)}
+          ets_put(:sources, uri, source_file)
           {:ok, store}
       end
     end
 
-    def open?(%__MODULE__{} = store, uri) do
-      Map.has_key?(store.source_files, uri) or Map.has_key?(store.temp_files, uri)
+    def open?(uri) do
+      ets_has_key?(:any, uri)
     end
 
     def close(%__MODULE__{} = store, uri) do
-      case Map.pop(store.source_files, uri) do
-        {nil, _store} ->
+      case ets_pop(:sources, uri) do
+        nil ->
           {:error, :not_open}
 
-        {_, source_files} ->
-          store = %__MODULE__{store | source_files: source_files}
+        _source_file ->
           {:ok, store}
       end
     end
 
     def get_and_update(%__MODULE__{} = store, uri, updater_fn) do
-      with {:ok, source_file} <- fetch(store, uri),
+      with {:ok, source_file} <- fetch(uri),
            {:ok, updated_source} <- updater_fn.(source_file) do
-        new_store = %__MODULE__{
-          store
-          | source_files: Map.put(store.source_files, uri, updated_source)
-        }
+        ets_put(:sources, uri, updated_source)
 
-        {:ok, updated_source, new_store}
+        {:ok, updated_source, store}
       else
         error ->
           normalize_error(error)
@@ -93,9 +100,8 @@ defmodule Lexical.SourceFile.Store do
           |> maybe_cancel_old_ref(uri)
           |> Map.put(uri, ref)
 
-        temp_files = Map.put(store.temp_files, uri, source_file)
-
-        new_store = %__MODULE__{store | temp_files: temp_files, temporary_open_refs: new_refs}
+        ets_put(:temp, uri, source_file)
+        new_store = %__MODULE__{store | temporary_open_refs: new_refs}
 
         {:ok, source_file, new_store}
       end
@@ -116,13 +122,8 @@ defmodule Lexical.SourceFile.Store do
 
     def unload(%__MODULE__{} = store, uri) do
       new_refs = Map.delete(store.temporary_open_refs, uri)
-      temp_files = Map.delete(store.temp_files, uri)
-
-      %__MODULE__{
-        store
-        | temp_files: temp_files,
-          temporary_open_refs: new_refs
-      }
+      ets_delete(:temp, uri)
+      %__MODULE__{store | temporary_open_refs: new_refs}
     end
 
     defp maybe_cancel_old_ref(%__MODULE__{} = store, uri) do
@@ -145,6 +146,48 @@ defmodule Lexical.SourceFile.Store do
 
     defp normalize_error(:error), do: {:error, :not_open}
     defp normalize_error(e), do: e
+
+    @read_types [:sources, :temp, :any]
+    @write_types [:sources, :temp]
+    defp ets_fetch(type, key) when type in @read_types do
+      case :ets.match(@table_name, {key, type_selector(type), :"$1"}) do
+        [[value]] -> {:ok, value}
+        _ -> :error
+      end
+    end
+
+    defp ets_put(type, key, value) when type in @write_types do
+      :ets.insert(@table_name, {key, type, value})
+      :ok
+    end
+
+    defp ets_has_key?(type, key) when type in @read_types do
+      match_spec = {key, type_selector(type), :"$1"}
+
+      case :ets.match(@table_name, match_spec) do
+        [] -> false
+        _ -> true
+      end
+    end
+
+    defp ets_pop(type, key) when type in @write_types do
+      with {:ok, value} <- ets_fetch(type, key),
+           :ok <- ets_delete(type, key) do
+        value
+      else
+        _ ->
+          nil
+      end
+    end
+
+    defp ets_delete(type, key) when type in @write_types do
+      match_spec = {key, type_selector(type), :_}
+      :ets.match_delete(@table_name, match_spec)
+      :ok
+    end
+
+    defp type_selector(:any), do: :_
+    defp type_selector(type), do: type
   end
 
   alias Lexical.ProcessCache
@@ -159,7 +202,7 @@ defmodule Lexical.SourceFile.Store do
 
   @spec fetch(uri()) :: {:ok, SourceFile.t()} | :error
   def fetch(uri) do
-    GenServer.call(__MODULE__, {:fetch, uri})
+    State.fetch(uri)
   end
 
   @spec save(uri()) :: :ok | {:error, :not_open}
@@ -169,7 +212,7 @@ defmodule Lexical.SourceFile.Store do
 
   @spec open?(uri()) :: boolean()
   def open?(uri) do
-    GenServer.call(__MODULE__, {:open?, uri})
+    State.open?(uri)
   end
 
   @spec open(uri(), String.t(), pos_integer()) :: :ok | {:error, :already_open}
@@ -206,16 +249,6 @@ defmodule Lexical.SourceFile.Store do
     {:ok, State.new()}
   end
 
-  def handle_call({:fetch, uri}, _, %State{} = state) do
-    {reply, new_state} =
-      case State.fetch(state, uri) do
-        {:ok, _} = success -> {success, state}
-        error -> {error, state}
-      end
-
-    {:reply, reply, new_state}
-  end
-
   def handle_call({:save, uri}, _from, %State{} = state) do
     {reply, new_state} =
       case State.save(state, uri) do
@@ -238,7 +271,7 @@ defmodule Lexical.SourceFile.Store do
 
   def handle_call({:open_temporarily, uri, timeout_ms}, _, %State{} = state) do
     {reply, new_state} =
-      with {:error, :not_open} <- State.fetch(state, uri),
+      with {:error, :not_open} <- State.fetch(uri),
            {:ok, source_file, new_state} <- State.open_temporarily(state, uri, timeout_ms) do
         {{:ok, source_file}, new_state}
       else
@@ -251,10 +284,6 @@ defmodule Lexical.SourceFile.Store do
       end
 
     {:reply, reply, new_state}
-  end
-
-  def handle_call({:open?, uri}, _from, %State{} = state) do
-    {:reply, State.open?(state, uri), state}
   end
 
   def handle_call({:close, uri}, _from, %State{} = state) do

--- a/apps/common/test/lexical/source_file/store_test.exs
+++ b/apps/common/test/lexical/source_file/store_test.exs
@@ -161,6 +161,7 @@ defmodule Lexical.SourceFile.StoreTest do
       assert {:ok, _} = SourceFile.Store.open_temporary(ctx.uri, 100)
       Process.sleep(101)
       refute SourceFile.Store.open?(ctx.uri)
+      assert SourceFile.Store.fetch(ctx.uri) == {:error, :not_open}
     end
 
     test "the extension is extended on subsequent access", ctx do


### PR DESCRIPTION
While refactoring conversions to make them easier, I was getting deadlocks during get_and_update because the code neeed the context document in order to convert from lsp to native. However, it was inside the genserver process when it called `fetch`, which caused a deadlock. Moving read operations out of the genserver will fix this deadlock.

This commit moves all store read operations into an ETS table that has read concurrency, which should also speed up reads (though there is a small chance of getting stale data now).