### PR TITLE
Fix script file diagnostics flushing

### DIFF
--- a/apps/server/lib/lexical/server/project/diagnostics.ex
+++ b/apps/server/lib/lexical/server/project/diagnostics.ex
@@ -38,7 +38,7 @@ defmodule Lexical.Server.Project.Diagnostics do
         Map.new(state.diagnostics_by_uri, fn {uri, diagnostics} ->
           with true <- SourceFile.Store.open?(uri),
                {:ok, %SourceFile{} = source_file} <- SourceFile.Store.fetch(uri),
-               true <- source_file.dirty? or test_file?(source_file) do
+               true <- source_file.dirty? or script_file?(source_file) do
             {uri, diagnostics}
           else
             _ ->
@@ -169,8 +169,10 @@ defmodule Lexical.Server.Project.Diagnostics do
       end
     end
 
-    defp test_file?(source_file) do
-      String.ends_with?(source_file.path, "_test.exs")
+    defp script_file?(source_file) do
+      # The script file refers to test files, or Ecto migration files, and so on.
+      # When running `MIX_ENV mix compile` to compile the project, they will not be compiled.
+      String.ends_with?(source_file.path, ".exs")
     end
   end
 

--- a/apps/server/lib/lexical/server/project/diagnostics.ex
+++ b/apps/server/lib/lexical/server/project/diagnostics.ex
@@ -38,7 +38,7 @@ defmodule Lexical.Server.Project.Diagnostics do
         Map.new(state.diagnostics_by_uri, fn {uri, diagnostics} ->
           with true <- SourceFile.Store.open?(uri),
                {:ok, %SourceFile{} = source_file} <- SourceFile.Store.fetch(uri),
-               true <- source_file.dirty? do
+               true <- source_file.dirty? or test_file?(source_file) do
             {uri, diagnostics}
           else
             _ ->
@@ -167,6 +167,10 @@ defmodule Lexical.Server.Project.Diagnostics do
             end: Position.new(line: line_number + 1, character: 0)
           )
       end
+    end
+
+    defp test_file?(source_file) do
+      String.ends_with?(source_file.path, "_test.exs")
     end
   end
 

--- a/apps/server/test/lexical/server/project/diagnostics/state_test.exs
+++ b/apps/server/test/lexical/server/project/diagnostics/state_test.exs
@@ -160,9 +160,9 @@ defmodule Lexical.Project.Diagnostics.StateTest do
       assert [_] = diagnostics
     end
 
-    test "it should not clear a test file even if it is clean", %{state: state} do
-      test_file_path = Path.join([Project.root_path(project()), "test", "project_test.exs"])
-      source_file = source_file("assert f() == 0", test_file_path)
+    test "it should not clear a script file even if it is clean", %{state: state} do
+      script_file_path = Path.join([Project.root_path(project()), "test", "*.exs"])
+      source_file = source_file("assert f() == 0", script_file_path)
 
       {:ok, state} =
         State.add(state, compiler_diagnostic(message: "undefined function f/0"), source_file.uri)

--- a/apps/server/test/lexical/server/project/diagnostics/state_test.exs
+++ b/apps/server/test/lexical/server/project/diagnostics/state_test.exs
@@ -154,10 +154,9 @@ defmodule Lexical.Project.Diagnostics.StateTest do
       {:ok, state} =
         State.add(state, compiler_diagnostic(message: "The code is awful"), source_file.uri)
 
+      old_diagnostics = State.get(state, source_file.uri)
       state = State.clear_all_flushed(state)
-      diagnostics = State.get(state, source_file.uri)
-
-      assert [_] = diagnostics
+      assert ^old_diagnostics = State.get(state, source_file.uri)
     end
 
     test "it should not clear a script file even if it is clean", %{state: state} do
@@ -167,10 +166,9 @@ defmodule Lexical.Project.Diagnostics.StateTest do
       {:ok, state} =
         State.add(state, compiler_diagnostic(message: "undefined function f/0"), source_file.uri)
 
+      old_diagnostics = State.get(state, source_file.uri)
       state = State.clear_all_flushed(state)
-
-      diagnostics = State.get(state, source_file.uri)
-      assert [_] = diagnostics
+      assert ^old_diagnostics = State.get(state, source_file.uri)
     end
 
     test "it should clear a file's diagnostics if it is just open", %{state: state} do

--- a/apps/server/test/lexical/server/project/diagnostics/state_test.exs
+++ b/apps/server/test/lexical/server/project/diagnostics/state_test.exs
@@ -22,7 +22,7 @@ defmodule Lexical.Project.Diagnostics.StateTest do
     Path.join([Project.root_path(project()), "lib", "project.ex"])
   end
 
-  def source_file(contents \\ "", file_path \\ existing_file_path()) do
+  def source_file(contents, file_path \\ existing_file_path()) do
     file_uri = SourceFile.Path.to_uri(file_path)
 
     with :ok <- SourceFile.Store.open(file_uri, contents, 0),


### PR DESCRIPTION
The compilation diagnostics of a test file only come from the compilation of the file. The project compilation (i.e., `MIX_ENV=test mix compile`) will not produce any diagnostics for the test file. Therefore, when you save a problematic test file, it may seem strange that after saving, the error disappears but reappears when you edit it.

This fix ensures that the diagnostics of test files will not be cleared when saved.