### PR TITLE
Removed Access specifier

### DIFF
--- a/apps/proto/.formatter.exs
+++ b/apps/proto/.formatter.exs
@@ -2,9 +2,9 @@
 proto_dsl = [
   defalias: 1,
   defenum: 1,
+  defnotification: 1,
   defnotification: 2,
-  defnotification: 3,
-  defrequest: 3,
+  defrequest: 2,
   defresponse: 1,
   deftype: 1
 ]

--- a/apps/proto/lib/lexical/proto.ex
+++ b/apps/proto/lib/lexical/proto.ex
@@ -9,8 +9,8 @@ defmodule Lexical.Proto do
       import Lexical.Proto.TypeFunctions
       import Proto.Alias, only: [defalias: 1]
       import Proto.Enum, only: [defenum: 1]
-      import Proto.Notification, only: [defnotification: 2, defnotification: 3]
-      import Proto.Request, only: [defrequest: 3]
+      import Proto.Notification, only: [defnotification: 1, defnotification: 2]
+      import Proto.Request, only: [defrequest: 2]
       import Proto.Response, only: [defresponse: 1]
       import Proto.Type, only: [deftype: 1]
     end

--- a/apps/proto/lib/lexical/proto/decoders.ex
+++ b/apps/proto/lib/lexical/proto/decoders.ex
@@ -5,7 +5,6 @@ defmodule Lexical.Proto.Decoders do
     notification_modules = CompileMetadata.notification_modules()
     notification_matchers = Enum.map(notification_modules, &build_notification_matcher_macro/1)
     notification_decoders = Enum.map(notification_modules, &build_notifications_decoder/1)
-    access_map = build_acces_map(notification_modules)
 
     quote do
       defmacro notification(method) do
@@ -38,10 +37,6 @@ defmodule Lexical.Proto.Decoders do
       def __meta__(:notifications) do
         unquote(notification_modules)
       end
-
-      def __meta__(:access) do
-        %{unquote_splicing(access_map)}
-      end
     end
   end
 
@@ -49,15 +44,10 @@ defmodule Lexical.Proto.Decoders do
     request_modules = CompileMetadata.request_modules()
     request_matchers = Enum.map(request_modules, &build_request_matcher_macro/1)
     request_decoders = Enum.map(request_modules, &build_request_decoder/1)
-    access_map = build_acces_map(request_modules)
 
     quote do
       def __meta__(:requests) do
         unquote(request_modules)
-      end
-
-      def __meta__(:access) do
-        %{unquote_splicing(access_map)}
       end
 
       defmacro request(id, method) do
@@ -83,12 +73,6 @@ defmodule Lexical.Proto.Decoders do
         {:error, {:unknown_request, method}}
       end
     end
-  end
-
-  defp build_acces_map(modules) do
-    Enum.map(modules, fn module ->
-      quote(do: {unquote(module.method()), unquote(module.__meta__(:access))})
-    end)
   end
 
   defp build_notification_matcher_macro(notification_module) do

--- a/apps/proto/lib/lexical/proto/macros/message.ex
+++ b/apps/proto/lib/lexical/proto/macros/message.ex
@@ -9,7 +9,7 @@ defmodule Lexical.Proto.Macros.Message do
 
   alias Lexical.SourceFile
 
-  def build(meta_type, method, access, types, param_names, opts \\ []) do
+  def build(meta_type, method, types, param_names, opts \\ []) do
     parse_fn =
       if Keyword.get(opts, :include_parse?, true) do
         Parse.build(types)
@@ -36,10 +36,6 @@ defmodule Lexical.Proto.Macros.Message do
 
       def __meta__(:param_names) do
         unquote(param_names)
-      end
-
-      def __meta__(:access) do
-        unquote(access)
       end
     end
   end

--- a/apps/proto/lib/lexical/proto/notification.ex
+++ b/apps/proto/lib/lexical/proto/notification.ex
@@ -2,7 +2,7 @@ defmodule Lexical.Proto.Notification do
   alias Lexical.Proto.CompileMetadata
   alias Lexical.Proto.Macros.Message
 
-  defmacro defnotification(method, access, types \\ []) do
+  defmacro defnotification(method, types \\ []) do
     CompileMetadata.add_notification_module(__CALLER__.module)
 
     jsonrpc_types = [
@@ -17,7 +17,7 @@ defmodule Lexical.Proto.Notification do
 
     quote location: :keep do
       defmodule LSP do
-        unquote(Message.build({:notification, :lsp}, method, access, lsp_types, param_names))
+        unquote(Message.build({:notification, :lsp}, method, lsp_types, param_names))
 
         def new(opts \\ []) do
           opts
@@ -27,7 +27,7 @@ defmodule Lexical.Proto.Notification do
       end
 
       unquote(
-        Message.build({:notification, :elixir}, method, access, elixir_types, param_names,
+        Message.build({:notification, :elixir}, method, elixir_types, param_names,
           include_parse?: false
         )
       )

--- a/apps/proto/lib/lexical/proto/request.ex
+++ b/apps/proto/lib/lexical/proto/request.ex
@@ -5,7 +5,7 @@ defmodule Lexical.Proto.Request do
 
   import TypeFunctions, only: [optional: 1, literal: 1]
 
-  defmacro defrequest(method, access, types) do
+  defmacro defrequest(method, types) do
     CompileMetadata.add_request_module(__CALLER__.module)
     # id is optional so we can resuse the parse function. If it's required,
     # it will go in the pattern match for the params, which won't work.
@@ -23,7 +23,7 @@ defmodule Lexical.Proto.Request do
 
     quote location: :keep do
       defmodule LSP do
-        unquote(Message.build({:request, :lsp}, method, access, lsp_types, param_names))
+        unquote(Message.build({:request, :lsp}, method, lsp_types, param_names))
 
         def new(opts \\ []) do
           opts
@@ -36,7 +36,7 @@ defmodule Lexical.Proto.Request do
       alias Lexical.Protocol.Types
 
       unquote(
-        Message.build({:request, :elixir}, method, access, elixir_types, param_names,
+        Message.build({:request, :elixir}, method, elixir_types, param_names,
           include_parse?: false
         )
       )

--- a/apps/protocol/lib/lexical/protocol/notifications.ex
+++ b/apps/protocol/lib/lexical/protocol/notifications.ex
@@ -4,37 +4,37 @@ defmodule Lexical.Protocol.Notifications do
 
   defmodule Initialized do
     use Proto
-    defnotification "initialized", :shared
+    defnotification "initialized"
   end
 
   defmodule Exit do
     use Proto
 
-    defnotification "exit", :exclusive
+    defnotification "exit"
   end
 
   defmodule Cancel do
     use Proto
 
-    defnotification "$/cancelRequest", :shared, id: integer()
+    defnotification "$/cancelRequest", id: integer()
   end
 
   defmodule DidOpen do
     use Proto
 
-    defnotification "textDocument/didOpen", :shared, text_document: Types.TextDocument.Item
+    defnotification "textDocument/didOpen", text_document: Types.TextDocument.Item
   end
 
   defmodule DidClose do
     use Proto
 
-    defnotification "textDocument/didClose", :shared, text_document: Types.TextDocument.Identifier
+    defnotification "textDocument/didClose", text_document: Types.TextDocument.Identifier
   end
 
   defmodule DidChange do
     use Proto
 
-    defnotification "textDocument/didChange", :shared,
+    defnotification "textDocument/didChange",
       text_document: Types.TextDocument.Versioned.Identifier,
       content_changes:
         list_of(
@@ -48,25 +48,25 @@ defmodule Lexical.Protocol.Notifications do
   defmodule DidChangeConfiguration do
     use Proto
 
-    defnotification "workspace/didChangeConfiguration", :shared, settings: map_of(any())
+    defnotification "workspace/didChangeConfiguration", settings: map_of(any())
   end
 
   defmodule DidChangeWatchedFiles do
     use Proto
 
-    defnotification "workspace/didChangeWatchedFiles", :shared, changes: list_of(Types.FileEvent)
+    defnotification "workspace/didChangeWatchedFiles", changes: list_of(Types.FileEvent)
   end
 
   defmodule DidSave do
     use Proto
 
-    defnotification "textDocument/didSave", :shared, text_document: Types.TextDocument.Identifier
+    defnotification "textDocument/didSave", text_document: Types.TextDocument.Identifier
   end
 
   defmodule PublishDiagnostics do
     use Proto
 
-    defnotification "textDocument/publishDiagnostics", :shared,
+    defnotification "textDocument/publishDiagnostics",
       uri: string(),
       version: optional(integer()),
       diagnostics: list_of(Types.Diagnostic)
@@ -76,7 +76,7 @@ defmodule Lexical.Protocol.Notifications do
     use Proto
     require Types.Message.Type
 
-    defnotification "window/logMessage", :shared,
+    defnotification "window/logMessage",
       message: string(),
       type: Types.Message.Type
 
@@ -91,7 +91,7 @@ defmodule Lexical.Protocol.Notifications do
     use Proto
     require Types.Message.Type
 
-    defnotification "window/showMessage", :shared,
+    defnotification "window/showMessage",
       message: string(),
       type: Types.Message.Type
 

--- a/apps/protocol/lib/lexical/protocol/requests.ex
+++ b/apps/protocol/lib/lexical/protocol/requests.ex
@@ -7,7 +7,7 @@ defmodule Lexical.Protocol.Requests do
   defmodule Initialize do
     use Proto
 
-    defrequest "initialize", :shared,
+    defrequest "initialize",
       capabilities: optional(Types.ClientCapabilities),
       client_info: optional(LspTypes.ClientInfo),
       initialization_options: optional(any()),
@@ -22,19 +22,19 @@ defmodule Lexical.Protocol.Requests do
   defmodule Cancel do
     use Proto
 
-    defrequest "$/cancelRequest", :exclusive, id: one_of([string(), integer()])
+    defrequest "$/cancelRequest", id: one_of([string(), integer()])
   end
 
   defmodule Shutdown do
     use Proto
 
-    defrequest "shutdown", :exclusive, []
+    defrequest "shutdown", []
   end
 
   defmodule FindReferences do
     use Proto
 
-    defrequest "textDocument/references", :exclusive,
+    defrequest "textDocument/references",
       position: Types.Position,
       text_document: Types.TextDocument.Identifier
   end
@@ -42,7 +42,7 @@ defmodule Lexical.Protocol.Requests do
   defmodule GoToDefinition do
     use Proto
 
-    defrequest "textDocument/definition", :exclusive,
+    defrequest "textDocument/definition",
       text_document: Types.TextDocument.Identifier,
       position: Types.Position
   end
@@ -50,7 +50,7 @@ defmodule Lexical.Protocol.Requests do
   defmodule Formatting do
     use Proto
 
-    defrequest "textDocument/formatting", :exclusive,
+    defrequest "textDocument/formatting",
       options: Types.Formatting.Options,
       text_document: Types.TextDocument.Identifier
   end
@@ -58,7 +58,7 @@ defmodule Lexical.Protocol.Requests do
   defmodule CodeAction do
     use Proto
 
-    defrequest "textDocument/codeAction", :exclusive,
+    defrequest "textDocument/codeAction",
       context: Types.CodeAction.Context,
       range: Types.Range,
       text_document: Types.TextDocument.Identifier
@@ -67,7 +67,7 @@ defmodule Lexical.Protocol.Requests do
   defmodule Completion do
     use Proto
 
-    defrequest "textDocument/completion", :exclusive,
+    defrequest "textDocument/completion",
       text_document: Types.TextDocument.Identifier,
       position: Types.Position,
       context: Types.Completion.Context
@@ -78,7 +78,7 @@ defmodule Lexical.Protocol.Requests do
   defmodule RegisterCapability do
     use Proto
 
-    defrequest "client/registerCapability", :shared,
+    defrequest "client/registerCapability",
       registrations: optional(list_of(LspTypes.Registration))
   end
 

--- a/apps/protocol/test/lexical/proto_test.exs
+++ b/apps/protocol/test/lexical/proto_test.exs
@@ -346,10 +346,9 @@ defmodule Lexical.ProtoTest do
       use Proto
 
       defnotification "textDocument/somethingHappened",
-                      :exlusive,
-                      line: integer(),
-                      notice_message: string(),
-                      column: integer()
+        line: integer(),
+        notice_message: string(),
+        column: integer()
     end
 
     test "parse fills out the notification" do
@@ -392,8 +391,7 @@ defmodule Lexical.ProtoTest do
       use Proto
 
       defnotification "notif/withTextDoc",
-                      :exclusive,
-                      text_document: Types.TextDocument.Identifier
+        text_document: Types.TextDocument.Identifier
     end
 
     test "to_native fills out the source file", ctx do
@@ -407,9 +405,8 @@ defmodule Lexical.ProtoTest do
       use Proto
 
       defnotification "notif/WithPos",
-                      :exclusive,
-                      text_document: Types.TextDocument.Identifier,
-                      position: Types.Position
+        text_document: Types.TextDocument.Identifier,
+        position: Types.Position
     end
 
     test "to_native fills out a position", ctx do
@@ -433,9 +430,8 @@ defmodule Lexical.ProtoTest do
       use Proto
 
       defnotification "notif/WithPos",
-                      :exclusive,
-                      text_document: Types.TextDocument.Identifier,
-                      range: Types.Range
+        text_document: Types.TextDocument.Identifier,
+        range: Types.Range
     end
 
     test "to_native fills out a range", ctx do
@@ -466,13 +462,13 @@ defmodule Lexical.ProtoTest do
     defmodule Req do
       use Proto
 
-      defrequest "something", :exclusive, line: integer(), error_message: string()
+      defrequest "something", line: integer(), error_message: string()
     end
 
     defmodule TextDocReq do
       use Proto
 
-      defrequest "textDoc", :exclusive, text_document: Types.TextDocument.Identifier
+      defrequest "textDoc", text_document: Types.TextDocument.Identifier
     end
 
     test "parse fills out the request" do
@@ -521,7 +517,7 @@ defmodule Lexical.ProtoTest do
     defmodule PositionReq do
       use Proto
 
-      defrequest "posReq", :exclusive,
+      defrequest "posReq",
         text_document: Types.TextDocument.Identifier,
         position: Types.Position
     end
@@ -547,7 +543,7 @@ defmodule Lexical.ProtoTest do
     defmodule RangeReq do
       use Proto
 
-      defrequest "rangeReq", :exclusive,
+      defrequest "rangeReq",
         text_document: Types.TextDocument.Identifier,
         range: Types.Range
     end


### PR DESCRIPTION
It was unnecessary, since there is only one way to handle requests in lexical.