### PR TITLE
ci: Add automatic release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release Lexical
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Build and release Lexical
+    permissions:
+      contents: write
+    steps:
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: "25.2.1"
+          elixir-version: "1.14.3-otp-25"
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Cache deps
+        id: cache-deps
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-elixir-deps
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ env.cache-name }}-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Compile
+        run: mix compile
+
+      - name: Build release
+        run: mix release lexical
+
+      - name: Generate short sha
+        id: short-sha
+        uses: actions/github-script@v6
+        with:
+          script: return "${{ github.sha }}".slice(0, 7)
+          result-encoding: string
+
+      - name: Archive release
+        run: |
+          zip -r lexical.zip _build/dev/rel/lexical
+          cp lexical.zip lexical-${{ steps.short-sha.outputs.result }}.zip
+
+      - name: Create Git tag for commit
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ steps.short-sha.outputs.result }}",
+              sha: context.sha
+            })
+
+      - name: Publish release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: lexical*.zip
+          tag: ${{ steps.short-sha.outputs.result }}
+          makeLatest: true


### PR DESCRIPTION
Github actions workflow for building and publishing a release of Lexical on every commit.

Publishes the same zip twice with and without the short sha in the file name. The version without the file name is to simplify automation for the likes of vscode auto-install.

Obviously this is a bit hard to test, but I've confirmed it works on my fork.
- Working workflow log: https://github.com/Blond11516/lexical/actions/runs/4775550397/jobs/8489933099
- Corresponding release: https://github.com/Blond11516/lexical/releases/tag/9c0d013