### PR TITLE
Fixed: Lecxical won't reliably start under asdf

### DIFF
--- a/rel/deploy/overlays/start_lexical.sh
+++ b/rel/deploy/overlays/start_lexical.sh
@@ -1,4 +1,15 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set_up_version_manager() {
+    if [ -e $HOME/.asdf ]; then
+        VERSION_MANAGER="asdf"
+    elif [ -e $HOME/.rtx ]; then
+        VERSION_MANAGER="rtx"
+    else
+        VERSION_MANAGER="none"
+    fi
+}
+
 readlink_f () {
   cd "$(dirname "$1")" > /dev/null || exit 1
   filename="$(basename "$1")"
@@ -15,5 +26,16 @@ else
   dir=${ELS_INSTALL_PREFIX}
 fi
 
+set_up_version_manager
 
-exec "${dir}/bin/lexical" start
+case "$VERSION_MANAGER" in
+    asdf)
+        asdf env elixir "${dir}/bin/lexical" start
+        ;;
+    rtx)
+        rtx env -s bash elixir "${dir}/bin/lexical" start
+        ;;
+    *)
+        "${dir}/bin/lexical" start
+        ;;
+esac


### PR DESCRIPTION
The launcher script wasn't starting with the correct environment variables, which caused the default MIX_HOME (~/.mix) to be selected. If this didn't exist, lexical would crash on start with a badmatch error.

Fixes #116