### PR TITLE
Simplified building requests and responses

### DIFF
--- a/apps/proto/.formatter.exs
+++ b/apps/proto/.formatter.exs
@@ -4,6 +4,7 @@ proto_dsl = [
   defenum: 1,
   defnotification: 1,
   defnotification: 2,
+  defrequest: 1,
   defrequest: 2,
   defresponse: 1,
   deftype: 1

--- a/apps/proto/lib/lexical/proto.ex
+++ b/apps/proto/lib/lexical/proto.ex
@@ -10,7 +10,7 @@ defmodule Lexical.Proto do
       import Proto.Alias, only: [defalias: 1]
       import Proto.Enum, only: [defenum: 1]
       import Proto.Notification, only: [defnotification: 1, defnotification: 2]
-      import Proto.Request, only: [defrequest: 2]
+      import Proto.Request, only: [defrequest: 1, defrequest: 2]
       import Proto.Response, only: [defresponse: 1]
       import Proto.Type, only: [deftype: 1]
     end

--- a/apps/proto/lib/lexical/proto/alias.ex
+++ b/apps/proto/lib/lexical/proto/alias.ex
@@ -1,11 +1,16 @@
 defmodule Lexical.Proto.Alias do
   alias Lexical.Proto.CompileMetadata
+  alias Lexical.Proto.Field
 
   defmacro defalias(alias_definition) do
     caller_module = __CALLER__.module
     CompileMetadata.add_type_alias_module(caller_module)
 
     quote location: :keep do
+      def parse(lsp_map) do
+        Field.extract(unquote(alias_definition), :alias, lsp_map)
+      end
+
       def definition do
         unquote(alias_definition)
       end
@@ -16,6 +21,14 @@ defmodule Lexical.Proto.Alias do
 
       def __meta__(:param_names) do
         []
+      end
+
+      def __meta__(:definition) do
+        unquote(alias_definition)
+      end
+
+      def __meta__(:raw_definition) do
+        unquote(Macro.escape(alias_definition))
       end
     end
   end

--- a/apps/proto/lib/lexical/proto/macros/meta.ex
+++ b/apps/proto/lib/lexical/proto/macros/meta.ex
@@ -11,6 +11,10 @@ defmodule Lexical.Proto.Macros.Meta do
       def __meta__(:types) do
         %{unquote_splicing(opts)}
       end
+
+      def __meta__(:raw_types) do
+        unquote(Macro.escape(opts))
+      end
     end
   end
 

--- a/apps/proto/lib/lexical/proto/notification.ex
+++ b/apps/proto/lib/lexical/proto/notification.ex
@@ -2,8 +2,22 @@ defmodule Lexical.Proto.Notification do
   alias Lexical.Proto.CompileMetadata
   alias Lexical.Proto.Macros.Message
 
-  defmacro defnotification(method, types \\ []) do
-    CompileMetadata.add_notification_module(__CALLER__.module)
+  defmacro defnotification(method) do
+    do_defnotification(method, [], __CALLER__)
+  end
+
+  defmacro defnotification(method, params_module_ast) do
+    params_module =
+      params_module_ast
+      |> Macro.expand(__CALLER__)
+      |> Code.ensure_compiled!()
+
+    types = params_module.__meta__(:raw_types)
+    do_defnotification(method, types, __CALLER__)
+  end
+
+  defp do_defnotification(method, types, caller) do
+    CompileMetadata.add_notification_module(caller.module)
 
     jsonrpc_types = [
       jsonrpc: quote(do: literal("2.0")),
@@ -12,8 +26,8 @@ defmodule Lexical.Proto.Notification do
 
     param_names = Keyword.keys(types)
     lsp_types = Keyword.merge(jsonrpc_types, types)
-    elixir_types = Message.generate_elixir_types(__CALLER__.module, lsp_types)
-    lsp_module_name = Module.concat(__CALLER__.module, LSP)
+    elixir_types = Message.generate_elixir_types(caller.module, lsp_types)
+    lsp_module_name = Module.concat(caller.module, LSP)
 
     quote location: :keep do
       defmodule LSP do
@@ -42,7 +56,7 @@ defmodule Lexical.Proto.Notification do
         struct(__MODULE__, lsp: LSP.new(opts), method: unquote(method), jsonrpc: "2.0")
       end
 
-      defimpl Jason.Encoder, for: unquote(__CALLER__.module) do
+      defimpl Jason.Encoder, for: unquote(caller.module) do
         def encode(notification, opts) do
           Jason.Encoder.encode(notification.lsp, opts)
         end

--- a/apps/protocol/lib/generated/lexical/protocol/types/cancel/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/cancel/params.ex
@@ -1,0 +1,6 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.Cancel.Params do
+  alias Lexical.Proto
+  use Proto
+  deftype id: one_of([integer(), string()])
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/definition/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/definition/params.ex
@@ -1,0 +1,11 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.Definition.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+
+  deftype partial_result_token: optional(Types.Progress.Token),
+          position: Types.Position,
+          text_document: Types.TextDocument.Identifier,
+          work_done_token: optional(Types.Progress.Token)
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/did_change_configuration/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/did_change_configuration/params.ex
@@ -1,0 +1,6 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.DidChangeConfiguration.Params do
+  alias Lexical.Proto
+  use Proto
+  deftype settings: any()
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/did_change_watched_files/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/did_change_watched_files/params.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.DidChangeWatchedFiles.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype changes: list_of(Types.FileEvent)
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/did_close_text_document/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/did_close_text_document/params.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.DidCloseTextDocument.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype text_document: Types.TextDocument.Identifier
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/did_open_text_document/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/did_open_text_document/params.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.DidOpenTextDocument.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype text_document: Types.TextDocument.Item
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/did_save_text_document/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/did_save_text_document/params.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.DidSaveTextDocument.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype text: optional(string()), text_document: Types.TextDocument.Identifier
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/file_change_type.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/file_change_type.ex
@@ -1,0 +1,6 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.FileChangeType do
+  alias Lexical.Proto
+  use Proto
+  defenum created: 1, changed: 2, deleted: 3
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/file_event.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/file_event.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.FileEvent do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype type: Types.FileChangeType, uri: string()
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/log_message/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/log_message/params.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.LogMessage.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype message: string(), type: Types.Message.Type
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/show_message/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/show_message/params.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.ShowMessage.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype message: string(), type: Types.Message.Type
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/text_document/content_change_event.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/text_document/content_change_event.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.TextDocument.ContentChangeEvent do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule TextDocumentContentChangeEvent do
     use Proto
@@ -15,5 +14,5 @@ defmodule Lexical.Protocol.Types.TextDocument.ContentChangeEvent do
   end
 
   use Proto
-  defalias one_of([Parent.TextDocumentContentChangeEvent, Parent.TextDocumentContentChangeEvent1])
+  defalias one_of([TextDocumentContentChangeEvent, TextDocumentContentChangeEvent1])
 end

--- a/apps/protocol/lib/lexical/protocol/notifications.ex
+++ b/apps/protocol/lib/lexical/protocol/notifications.ex
@@ -16,69 +16,56 @@ defmodule Lexical.Protocol.Notifications do
   defmodule Cancel do
     use Proto
 
-    defnotification "$/cancelRequest", id: integer()
+    defnotification "$/cancelRequest", Types.Cancel.Params
   end
 
   defmodule DidOpen do
     use Proto
 
-    defnotification "textDocument/didOpen", text_document: Types.TextDocument.Item
+    defnotification "textDocument/didOpen", Types.DidOpenTextDocument.Params
   end
 
   defmodule DidClose do
     use Proto
 
-    defnotification "textDocument/didClose", text_document: Types.TextDocument.Identifier
+    defnotification "textDocument/didClose", Types.DidCloseTextDocument.Params
   end
 
   defmodule DidChange do
     use Proto
 
-    defnotification "textDocument/didChange",
-      text_document: Types.TextDocument.Versioned.Identifier,
-      content_changes:
-        list_of(
-          one_of([
-            Types.TextDocument.ContentChangeEvent.TextDocumentContentChangeEvent,
-            Types.TextDocument.ContentChangeEvent.TextDocumentContentChangeEvent1
-          ])
-        )
+    defnotification "textDocument/didChange", Types.DidChangeTextDocument.Params
   end
 
   defmodule DidChangeConfiguration do
     use Proto
 
-    defnotification "workspace/didChangeConfiguration", settings: map_of(any())
+    defnotification "workspace/didChangeConfiguration", Types.DidChangeConfiguration.Params
   end
 
   defmodule DidChangeWatchedFiles do
     use Proto
 
-    defnotification "workspace/didChangeWatchedFiles", changes: list_of(Types.FileEvent)
+    defnotification "workspace/didChangeWatchedFiles", Types.DidChangeWatchedFiles.Params
   end
 
   defmodule DidSave do
     use Proto
 
-    defnotification "textDocument/didSave", text_document: Types.TextDocument.Identifier
+    defnotification "textDocument/didSave", Types.DidSaveTextDocument.Params
   end
 
   defmodule PublishDiagnostics do
     use Proto
 
-    defnotification "textDocument/publishDiagnostics",
-      uri: string(),
-      version: optional(integer()),
-      diagnostics: list_of(Types.Diagnostic)
+    defnotification "textDocument/publishDiagnostics", Types.PublishDiagnostics.Params
   end
 
   defmodule LogMessage do
     use Proto
     require Types.Message.Type
 
-    defnotification "window/logMessage",
-      message: string(),
-      type: Types.Message.Type
+    defnotification "window/logMessage", Types.LogMessage.Params
 
     for type <- [:error, :warning, :info, :log] do
       def unquote(type)(message) do
@@ -91,9 +78,7 @@ defmodule Lexical.Protocol.Notifications do
     use Proto
     require Types.Message.Type
 
-    defnotification "window/showMessage",
-      message: string(),
-      type: Types.Message.Type
+    defnotification "window/showMessage", Types.ShowMessage.Params
 
     for type <- [:error, :warning, :info, :log] do
       def unquote(type)(message) do

--- a/apps/protocol/lib/lexical/protocol/requests.ex
+++ b/apps/protocol/lib/lexical/protocol/requests.ex
@@ -1,76 +1,54 @@
 defmodule Lexical.Protocol.Requests do
   alias Lexical.Proto
-  alias Lexical.Protocol.LspTypes
   alias Lexical.Protocol.Types
 
   # Client -> Server request
   defmodule Initialize do
     use Proto
 
-    defrequest "initialize",
-      capabilities: optional(Types.ClientCapabilities),
-      client_info: optional(LspTypes.ClientInfo),
-      initialization_options: optional(any()),
-      locale: optional(string()),
-      process_id: optional(integer()),
-      root_path: optional(string()),
-      root_uri: optional(uri()),
-      trace: optional(Types.TraceValues),
-      workspace_folders: optional(list_of(Types.Workspace.Folder))
+    defrequest "initialize", Types.Initialize.Params
   end
 
   defmodule Cancel do
     use Proto
 
-    defrequest "$/cancelRequest", id: one_of([string(), integer()])
+    defrequest "$/cancelRequest", Types.Cancel.Params
   end
 
   defmodule Shutdown do
     use Proto
 
-    defrequest "shutdown", []
+    defrequest "shutdown"
   end
 
   defmodule FindReferences do
     use Proto
 
-    defrequest "textDocument/references",
-      position: Types.Position,
-      text_document: Types.TextDocument.Identifier
+    defrequest "textDocument/references", Types.Reference.Params
   end
 
   defmodule GoToDefinition do
     use Proto
 
-    defrequest "textDocument/definition",
-      text_document: Types.TextDocument.Identifier,
-      position: Types.Position
+    defrequest "textDocument/definition", Types.Definition.Params
   end
 
   defmodule Formatting do
     use Proto
 
-    defrequest "textDocument/formatting",
-      options: Types.Formatting.Options,
-      text_document: Types.TextDocument.Identifier
+    defrequest "textDocument/formatting", Types.Document.Formatting.Params
   end
 
   defmodule CodeAction do
     use Proto
 
-    defrequest "textDocument/codeAction",
-      context: Types.CodeAction.Context,
-      range: Types.Range,
-      text_document: Types.TextDocument.Identifier
+    defrequest "textDocument/codeAction", Types.CodeAction.Params
   end
 
   defmodule Completion do
     use Proto
 
-    defrequest "textDocument/completion",
-      text_document: Types.TextDocument.Identifier,
-      position: Types.Position,
-      context: Types.Completion.Context
+    defrequest "textDocument/completion", Types.Completion.Params
   end
 
   # Server -> Client requests
@@ -78,8 +56,7 @@ defmodule Lexical.Protocol.Requests do
   defmodule RegisterCapability do
     use Proto
 
-    defrequest "client/registerCapability",
-      registrations: optional(list_of(LspTypes.Registration))
+    defrequest "client/registerCapability", Types.Registration.Params
   end
 
   use Proto, decoders: :requests

--- a/apps/protocol/mix.exs
+++ b/apps/protocol/mix.exs
@@ -30,10 +30,11 @@ defmodule Lexical.Protocol.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:jason, "~> 1.4", optional: true},
       {:common, in_umbrella: true},
-      {:proto, in_umbrella: true},
-      {:common_protocol, in_umbrella: true}
+      {:common_protocol, in_umbrella: true},
+      {:jason, "~> 1.4", optional: true},
+      {:patch, "~> 0.12", only: [:test]},
+      {:proto, in_umbrella: true}
     ]
   end
 end

--- a/apps/protocol/test/lexical/proto_test.exs
+++ b/apps/protocol/test/lexical/proto_test.exs
@@ -342,13 +342,18 @@ defmodule Lexical.ProtoTest do
   describe "notifications" do
     setup [:with_source_file_store]
 
+    defmodule Notif.Params do
+      use Proto
+
+      deftype line: integer(),
+              notice_message: string(),
+              column: integer()
+    end
+
     defmodule Notif do
       use Proto
 
-      defnotification "textDocument/somethingHappened",
-        line: integer(),
-        notice_message: string(),
-        column: integer()
+      defnotification "textDocument/somethingHappened", Notif.Params
     end
 
     test "parse fills out the notification" do
@@ -387,11 +392,16 @@ defmodule Lexical.ProtoTest do
       assert notif.notice_message == "This went wrong"
     end
 
+    defmodule Notif.WithTextDoc.Params do
+      use Proto
+
+      deftype text_document: Types.TextDocument.Identifier
+    end
+
     defmodule Notif.WithTextDoc do
       use Proto
 
-      defnotification "notif/withTextDoc",
-        text_document: Types.TextDocument.Identifier
+      defnotification "notif/withTextDoc", Notif.WithTextDoc.Params
     end
 
     test "to_native fills out the source file", ctx do
@@ -401,12 +411,17 @@ defmodule Lexical.ProtoTest do
       assert %SourceFile{} = notif.source_file
     end
 
+    defmodule Notif.WithPos.Params do
+      use Proto
+
+      deftype text_document: Types.TextDocument.Identifier,
+              position: Types.Position
+    end
+
     defmodule Notif.WithPos do
       use Proto
 
-      defnotification "notif/WithPos",
-        text_document: Types.TextDocument.Identifier,
-        position: Types.Position
+      defnotification "notif/WithPos", Notif.WithPos.Params
     end
 
     test "to_native fills out a position", ctx do
@@ -426,12 +441,17 @@ defmodule Lexical.ProtoTest do
       assert notif.position.character == 1
     end
 
+    defmodule Notif.WithRange.Params do
+      use Proto
+
+      deftype text_document: Types.TextDocument.Identifier,
+              range: Types.Range
+    end
+
     defmodule Notif.WithRange do
       use Proto
 
-      defnotification "notif/WithPos",
-        text_document: Types.TextDocument.Identifier,
-        range: Types.Range
+      defnotification "notif/WithRange", Notif.WithRange.Params
     end
 
     test "to_native fills out a range", ctx do
@@ -459,16 +479,27 @@ defmodule Lexical.ProtoTest do
   describe "requests" do
     setup [:with_source_file_store]
 
+    defmodule Req.Params do
+      use Proto
+
+      deftype line: integer(), error_message: string()
+    end
+
     defmodule Req do
       use Proto
 
-      defrequest "something", line: integer(), error_message: string()
+      defrequest "something", Req.Params
+    end
+
+    defmodule TextDocReq.Params do
+      use Proto
+      deftype text_document: Types.TextDocument.Identifier
     end
 
     defmodule TextDocReq do
       use Proto
 
-      defrequest "textDoc", text_document: Types.TextDocument.Identifier
+      defrequest "textDoc", TextDocReq.Params
     end
 
     test "parse fills out the request" do
@@ -514,12 +545,17 @@ defmodule Lexical.ProtoTest do
       assert %SourceFile{} = ex_req.source_file
     end
 
+    defmodule PositionReq.Params do
+      use Proto
+
+      deftype text_document: Types.TextDocument.Identifier,
+              position: Types.Position
+    end
+
     defmodule PositionReq do
       use Proto
 
-      defrequest "posReq",
-        text_document: Types.TextDocument.Identifier,
-        position: Types.Position
+      defrequest "posReq", PositionReq.Params
     end
 
     test "to_native fills out a position", ctx do
@@ -540,12 +576,17 @@ defmodule Lexical.ProtoTest do
       assert %SourceFile{} = ex_req.source_file
     end
 
+    defmodule RangeReq.Params do
+      use Proto
+
+      deftype text_document: Types.TextDocument.Identifier,
+              range: Types.Range
+    end
+
     defmodule RangeReq do
       use Proto
 
-      defrequest "rangeReq",
-        text_document: Types.TextDocument.Identifier,
-        range: Types.Range
+      defrequest "rangeReq", RangeReq.Params
     end
 
     test "to_native fills out a range", ctx do


### PR DESCRIPTION
The protocol acutally defines params types for notifications and responses, and we were recapitulating them in their definitions. This PR adds a bunch of the auto-generated types and allows notification/request definitions to reference them. Then the types are consulted to build the request or notification's parameters.

The result is much simpler definitions and less manual work when we need to create new ones.