### PR TITLE
ci: Use timestamp as release names instead of commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,17 @@ jobs:
           script: return "${{ github.sha }}".slice(0, 7)
           result-encoding: string
 
+      - name: Generate timestamp
+        id: timestamp
+        uses: actions/github-script@v6
+        with:
+          script: return (new Date()).toISOString().slice(0, -5)
+          result-encoding: string
+
       - name: Archive release
         run: |
           zip -r lexical.zip _build/dev/rel/lexical
-          cp lexical.zip lexical-${{ steps.short-sha.outputs.result }}.zip
+          cp lexical.zip lexical-${{ steps.timestamp.outputs.result }}.zip
 
       - name: Create Git tag for commit
         uses: actions/github-script@v6
@@ -68,4 +75,5 @@ jobs:
         with:
           artifacts: lexical*.zip
           tag: ${{ steps.short-sha.outputs.result }}
+          name: ${{ steps.timestamp.outputs.result }}
           makeLatest: true


### PR DESCRIPTION
As discussed, use timestamps (ISO 8601 without milliseconds, in UTC) as release names instead of commit SHAs to make them more user-friendly.

Example workflow: https://github.com/Blond11516/lexical/actions/runs/4804337258/jobs/8549725577
Example release: https://github.com/Blond11516/lexical/releases/tag/36a6f00