### PR TITLE
ci: Auto-generate release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,3 +77,4 @@ jobs:
           tag: ${{ steps.short-sha.outputs.result }}
           name: ${{ steps.timestamp.outputs.result }}
           makeLatest: true
+          generateReleaseNotes: true


### PR DESCRIPTION
Automatically generate release changelogs to include links to PRs among other things.

Example release with auto-generated changelog: https://github.com/Blond11516/lexical/releases/tag/66ee53c