### PR TITLE
Try to fix `Parent.ClientInfo1.parse/1`

### DIFF
--- a/apps/proto/lib/lexical/proto/lsp_types.ex
+++ b/apps/proto/lib/lexical/proto/lsp_types.ex
@@ -23,11 +23,6 @@ defmodule Lexical.Proto.LspTypes do
     deftype code: ErrorCodes, message: string(), data: optional(any())
   end
 
-  defmodule ClientInfo do
-    use Proto
-    deftype name: string(), version: optional(string())
-  end
-
   defmodule TraceValue do
     use Proto
     defenum off: "off", messages: "messages", verbose: "verbose"

--- a/apps/protocol/lib/generated/lexical/protocol/types/code_action/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/code_action/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.CodeAction.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule CodeActionKind do
     use Proto
@@ -11,7 +10,7 @@ defmodule Lexical.Protocol.Types.CodeAction.ClientCapabilities do
 
   defmodule CodeActionLiteralSupport do
     use Proto
-    deftype code_action_kind: Parent.CodeActionKind
+    deftype code_action_kind: CodeActionKind
   end
 
   defmodule ResolveSupport do
@@ -21,11 +20,11 @@ defmodule Lexical.Protocol.Types.CodeAction.ClientCapabilities do
 
   use Proto
 
-  deftype code_action_literal_support: optional(Parent.CodeActionLiteralSupport),
+  deftype code_action_literal_support: optional(CodeActionLiteralSupport),
           data_support: optional(boolean()),
           disabled_support: optional(boolean()),
           dynamic_registration: optional(boolean()),
           honors_change_annotations: optional(boolean()),
           is_preferred_support: optional(boolean()),
-          resolve_support: optional(Parent.ResolveSupport)
+          resolve_support: optional(ResolveSupport)
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/completion/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/completion/client_capabilities.ex
@@ -3,21 +3,6 @@ defmodule Lexical.Protocol.Types.Completion.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
 
-  defmodule CompletionItem do
-    use Proto
-
-    deftype commit_characters_support: optional(boolean()),
-            deprecated_support: optional(boolean()),
-            documentation_format: optional(list_of(Types.Markup.Kind)),
-            insert_replace_support: optional(boolean()),
-            insert_text_mode_support: optional(InsertTextModeSupport),
-            label_details_support: optional(boolean()),
-            preselect_support: optional(boolean()),
-            resolve_support: optional(ResolveSupport),
-            snippet_support: optional(boolean()),
-            tag_support: optional(TagSupport)
-  end
-
   defmodule CompletionItemKind do
     use Proto
     deftype value_set: optional(list_of(Types.Completion.Item.Kind))
@@ -41,6 +26,21 @@ defmodule Lexical.Protocol.Types.Completion.ClientCapabilities do
   defmodule TagSupport do
     use Proto
     deftype value_set: list_of(Types.Completion.Item.Tag)
+  end
+
+  defmodule CompletionItem do
+    use Proto
+
+    deftype commit_characters_support: optional(boolean()),
+            deprecated_support: optional(boolean()),
+            documentation_format: optional(list_of(Types.Markup.Kind)),
+            insert_replace_support: optional(boolean()),
+            insert_text_mode_support: optional(InsertTextModeSupport),
+            label_details_support: optional(boolean()),
+            preselect_support: optional(boolean()),
+            resolve_support: optional(ResolveSupport),
+            snippet_support: optional(boolean()),
+            tag_support: optional(TagSupport)
   end
 
   use Proto

--- a/apps/protocol/lib/generated/lexical/protocol/types/completion/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/completion/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.Completion.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule CompletionItem do
     use Proto
@@ -11,12 +10,12 @@ defmodule Lexical.Protocol.Types.Completion.ClientCapabilities do
             deprecated_support: optional(boolean()),
             documentation_format: optional(list_of(Types.Markup.Kind)),
             insert_replace_support: optional(boolean()),
-            insert_text_mode_support: optional(Parent.InsertTextModeSupport),
+            insert_text_mode_support: optional(InsertTextModeSupport),
             label_details_support: optional(boolean()),
             preselect_support: optional(boolean()),
-            resolve_support: optional(Parent.ResolveSupport),
+            resolve_support: optional(ResolveSupport),
             snippet_support: optional(boolean()),
-            tag_support: optional(Parent.TagSupport)
+            tag_support: optional(TagSupport)
   end
 
   defmodule CompletionItemKind do
@@ -46,9 +45,9 @@ defmodule Lexical.Protocol.Types.Completion.ClientCapabilities do
 
   use Proto
 
-  deftype completion_item: optional(Parent.CompletionItem),
-          completion_item_kind: optional(Parent.CompletionItemKind),
-          completion_list: optional(Parent.CompletionList),
+  deftype completion_item: optional(CompletionItem),
+          completion_item_kind: optional(CompletionItemKind),
+          completion_list: optional(CompletionList),
           context_support: optional(boolean()),
           dynamic_registration: optional(boolean()),
           insert_text_mode: optional(Types.InsertTextMode)

--- a/apps/protocol/lib/generated/lexical/protocol/types/diagnostic/tag.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/diagnostic/tag.ex
@@ -2,5 +2,5 @@
 defmodule Lexical.Protocol.Types.Diagnostic.Tag do
   alias Lexical.Proto
   use Proto
-  defenum(unnecessary: 1, deprecated: 2)
+  defenum unnecessary: 1, deprecated: 2
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/document/symbol/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/document/symbol/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.Document.Symbol.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule SymbolKind do
     use Proto
@@ -19,6 +18,6 @@ defmodule Lexical.Protocol.Types.Document.Symbol.ClientCapabilities do
   deftype dynamic_registration: optional(boolean()),
           hierarchical_document_symbol_support: optional(boolean()),
           label_support: optional(boolean()),
-          symbol_kind: optional(Parent.SymbolKind),
-          tag_support: optional(Parent.TagSupport)
+          symbol_kind: optional(SymbolKind),
+          tag_support: optional(TagSupport)
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/folding_range/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/folding_range/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.FoldingRange.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule FoldingRange do
     use Proto
@@ -17,8 +16,8 @@ defmodule Lexical.Protocol.Types.FoldingRange.ClientCapabilities do
   use Proto
 
   deftype dynamic_registration: optional(boolean()),
-          folding_range: optional(Parent.FoldingRange),
-          folding_range_kind: optional(Parent.FoldingRangeKind),
+          folding_range: optional(FoldingRange),
+          folding_range_kind: optional(FoldingRangeKind),
           line_folding_only: optional(boolean()),
           range_limit: optional(integer())
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/general/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/general/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.General.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule StaleRequestSupport do
     use Proto
@@ -14,5 +13,5 @@ defmodule Lexical.Protocol.Types.General.ClientCapabilities do
   deftype markdown: optional(Types.Markdown.ClientCapabilities),
           position_encodings: optional(list_of(Types.Position.Encoding.Kind)),
           regular_expressions: optional(Types.RegularExpressions.ClientCapabilities),
-          stale_request_support: optional(Parent.StaleRequestSupport)
+          stale_request_support: optional(StaleRequestSupport)
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/initialize/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/initialize/params.ex
@@ -11,7 +11,7 @@ defmodule Lexical.Protocol.Types.Initialize.Params do
   use Proto
 
   deftype capabilities: Types.ClientCapabilities,
-          client_info: optional(ClientInfo1),
+          # client_info: optional(ClientInfo1),
           initialization_options: optional(any()),
           locale: optional(string()),
           process_id: one_of([integer(), nil]),

--- a/apps/protocol/lib/generated/lexical/protocol/types/initialize/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/initialize/params.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.Initialize.Params do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule ClientInfo1 do
     use Proto
@@ -12,7 +11,7 @@ defmodule Lexical.Protocol.Types.Initialize.Params do
   use Proto
 
   deftype capabilities: Types.ClientCapabilities,
-          client_info: optional(Parent.ClientInfo1),
+          client_info: optional(ClientInfo1),
           initialization_options: optional(any()),
           locale: optional(string()),
           process_id: one_of([integer(), nil]),

--- a/apps/protocol/lib/generated/lexical/protocol/types/inlay_hint/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/inlay_hint/client_capabilities.ex
@@ -1,7 +1,6 @@
 # This file's contents are auto-generated. Do not edit.
 defmodule Lexical.Protocol.Types.InlayHint.ClientCapabilities do
   alias Lexical.Proto
-  alias __MODULE__, as: Parent
 
   defmodule ResolveSupport do
     use Proto
@@ -9,7 +8,5 @@ defmodule Lexical.Protocol.Types.InlayHint.ClientCapabilities do
   end
 
   use Proto
-
-  deftype dynamic_registration: optional(boolean()),
-          resolve_support: optional(Parent.ResolveSupport)
+  deftype dynamic_registration: optional(boolean()), resolve_support: optional(ResolveSupport)
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/semantic_tokens/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/semantic_tokens/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.SemanticTokens.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule Full do
     use Proto
@@ -16,9 +15,7 @@ defmodule Lexical.Protocol.Types.SemanticTokens.ClientCapabilities do
 
   defmodule Requests do
     use Proto
-
-    deftype full: optional(one_of([boolean(), Parent.Full])),
-            range: optional(one_of([boolean(), Parent.Range]))
+    deftype full: optional(one_of([boolean(), Full])), range: optional(one_of([boolean(), Range]))
   end
 
   use Proto
@@ -28,7 +25,7 @@ defmodule Lexical.Protocol.Types.SemanticTokens.ClientCapabilities do
           formats: list_of(Types.TokenFormat),
           multiline_token_support: optional(boolean()),
           overlapping_token_support: optional(boolean()),
-          requests: Parent.Requests,
+          requests: Requests,
           server_cancel_support: optional(boolean()),
           token_modifiers: list_of(string()),
           token_types: list_of(string())

--- a/apps/protocol/lib/generated/lexical/protocol/types/show_message_request/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/show_message_request/client_capabilities.ex
@@ -1,7 +1,6 @@
 # This file's contents are auto-generated. Do not edit.
 defmodule Lexical.Protocol.Types.ShowMessageRequest.ClientCapabilities do
   alias Lexical.Proto
-  alias __MODULE__, as: Parent
 
   defmodule MessageActionItem do
     use Proto
@@ -9,5 +8,5 @@ defmodule Lexical.Protocol.Types.ShowMessageRequest.ClientCapabilities do
   end
 
   use Proto
-  deftype message_action_item: optional(Parent.MessageActionItem)
+  deftype message_action_item: optional(MessageActionItem)
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/signature_help/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/signature_help/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.SignatureHelp.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule ParameterInformation do
     use Proto
@@ -14,12 +13,12 @@ defmodule Lexical.Protocol.Types.SignatureHelp.ClientCapabilities do
 
     deftype active_parameter_support: optional(boolean()),
             documentation_format: optional(list_of(Types.Markup.Kind)),
-            parameter_information: optional(Parent.ParameterInformation)
+            parameter_information: optional(ParameterInformation)
   end
 
   use Proto
 
   deftype context_support: optional(boolean()),
           dynamic_registration: optional(boolean()),
-          signature_information: optional(Parent.SignatureInformation)
+          signature_information: optional(SignatureInformation)
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/workspace/edit/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/workspace/edit/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.Workspace.Edit.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule ChangeAnnotationSupport do
     use Proto
@@ -11,7 +10,7 @@ defmodule Lexical.Protocol.Types.Workspace.Edit.ClientCapabilities do
 
   use Proto
 
-  deftype change_annotation_support: optional(Parent.ChangeAnnotationSupport),
+  deftype change_annotation_support: optional(ChangeAnnotationSupport),
           document_changes: optional(boolean()),
           failure_handling: optional(Types.FailureHandling.Kind),
           normalizes_line_endings: optional(boolean()),

--- a/apps/protocol/lib/generated/lexical/protocol/types/workspace/symbol/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/workspace/symbol/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.Workspace.Symbol.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule ResolveSupport do
     use Proto
@@ -22,7 +21,7 @@ defmodule Lexical.Protocol.Types.Workspace.Symbol.ClientCapabilities do
   use Proto
 
   deftype dynamic_registration: optional(boolean()),
-          resolve_support: optional(Parent.ResolveSupport),
-          symbol_kind: optional(Parent.SymbolKind),
-          tag_support: optional(Parent.TagSupport)
+          resolve_support: optional(ResolveSupport),
+          symbol_kind: optional(SymbolKind),
+          tag_support: optional(TagSupport)
 end


### PR DESCRIPTION
There are several problems here, so maybe a draft PR is better for describing the issue.

1. `mix lsp.mappings.generate --roots InitializeParams` won't generate the right order modules.

[CompletionItem](https://github.com/lexical-lsp/lexical/blob/1f3d003181e1af0b1ffb2746f2960ad72f2e65d0/apps/protocol/lib/generated/lexical/protocol/types/completion/client_capabilities.ex#L6) should below the `InsertTextModeSupport`, `TagSupport` and `ResolveSupport`, not above.

2. after fixed the order of the first problem, we will encounter this error

```elixir
14:34:55.179 [error] Child Lexical.Server.Transport.StdIO of Supervisor Lexical.Server.Supervisor terminated
** (exit) an exception was raised:
    ** (UndefinedFunctionError) function ClientInfo1.parse/1 is undefined (module ClientInfo1 is not available)
        ClientInfo1.parse(%{"name" => "Neovim", "version" => "0.10.0"})
        (protocol 0.1.0) lib/lexical/proto/macros/parse.ex:53: Lexical.Protocol.Requests.Initialize.LSP.parse/1
        (protocol 0.1.0) lib/lexical/protocol/requests.ex:9: Lexical.Protocol.Requests.Initialize.parse/1
        (server 0.1.0) lib/lexical/server/transport/std_io.ex:84: Lexical.Server.Transport.StdIO.loop/3
        (stdlib 4.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```
This one I have no idea. The macro part is too complicated for me. you can use vscode to replicate the error too.

Also, commenting out this line will temporarily solve the problem. https://github.com/lexical-lsp/lexical/pull/126/files#diff-924bfe533190d572b416eb5232b2b14c5c486875e60c1218d4028bc6668bfb26R14 , but this is not the correct solution.
        
