### PR TITLE
Simplify params -- Second attempt.

### DIFF
--- a/apps/proto/.formatter.exs
+++ b/apps/proto/.formatter.exs
@@ -4,6 +4,7 @@ proto_dsl = [
   defenum: 1,
   defnotification: 1,
   defnotification: 2,
+  defrequest: 1,
   defrequest: 2,
   defresponse: 1,
   deftype: 1

--- a/apps/proto/lib/lexical/proto.ex
+++ b/apps/proto/lib/lexical/proto.ex
@@ -10,7 +10,7 @@ defmodule Lexical.Proto do
       import Proto.Alias, only: [defalias: 1]
       import Proto.Enum, only: [defenum: 1]
       import Proto.Notification, only: [defnotification: 1, defnotification: 2]
-      import Proto.Request, only: [defrequest: 2]
+      import Proto.Request, only: [defrequest: 1, defrequest: 2]
       import Proto.Response, only: [defresponse: 1]
       import Proto.Type, only: [deftype: 1]
     end

--- a/apps/proto/lib/lexical/proto/alias.ex
+++ b/apps/proto/lib/lexical/proto/alias.ex
@@ -1,11 +1,16 @@
 defmodule Lexical.Proto.Alias do
   alias Lexical.Proto.CompileMetadata
+  alias Lexical.Proto.Field
 
   defmacro defalias(alias_definition) do
     caller_module = __CALLER__.module
     CompileMetadata.add_type_alias_module(caller_module)
 
     quote location: :keep do
+      def parse(lsp_map) do
+        Field.extract(unquote(alias_definition), :alias, lsp_map)
+      end
+
       def definition do
         unquote(alias_definition)
       end
@@ -16,6 +21,14 @@ defmodule Lexical.Proto.Alias do
 
       def __meta__(:param_names) do
         []
+      end
+
+      def __meta__(:definition) do
+        unquote(alias_definition)
+      end
+
+      def __meta__(:raw_definition) do
+        unquote(Macro.escape(alias_definition))
       end
     end
   end

--- a/apps/proto/lib/lexical/proto/macros/meta.ex
+++ b/apps/proto/lib/lexical/proto/macros/meta.ex
@@ -11,6 +11,10 @@ defmodule Lexical.Proto.Macros.Meta do
       def __meta__(:types) do
         %{unquote_splicing(opts)}
       end
+
+      def __meta__(:raw_types) do
+        unquote(Macro.escape(opts))
+      end
     end
   end
 

--- a/apps/proto/lib/lexical/proto/notification.ex
+++ b/apps/proto/lib/lexical/proto/notification.ex
@@ -2,8 +2,22 @@ defmodule Lexical.Proto.Notification do
   alias Lexical.Proto.CompileMetadata
   alias Lexical.Proto.Macros.Message
 
-  defmacro defnotification(method, types \\ []) do
-    CompileMetadata.add_notification_module(__CALLER__.module)
+  defmacro defnotification(method) do
+    do_defnotification(method, [], __CALLER__)
+  end
+
+  defmacro defnotification(method, params_module_ast) do
+    params_module =
+      params_module_ast
+      |> Macro.expand(__CALLER__)
+      |> Code.ensure_compiled!()
+
+    types = params_module.__meta__(:raw_types)
+    do_defnotification(method, types, __CALLER__)
+  end
+
+  defp do_defnotification(method, types, caller) do
+    CompileMetadata.add_notification_module(caller.module)
 
     jsonrpc_types = [
       jsonrpc: quote(do: literal("2.0")),
@@ -12,8 +26,8 @@ defmodule Lexical.Proto.Notification do
 
     param_names = Keyword.keys(types)
     lsp_types = Keyword.merge(jsonrpc_types, types)
-    elixir_types = Message.generate_elixir_types(__CALLER__.module, lsp_types)
-    lsp_module_name = Module.concat(__CALLER__.module, LSP)
+    elixir_types = Message.generate_elixir_types(caller.module, lsp_types)
+    lsp_module_name = Module.concat(caller.module, LSP)
 
     quote location: :keep do
       defmodule LSP do
@@ -42,7 +56,7 @@ defmodule Lexical.Proto.Notification do
         struct(__MODULE__, lsp: LSP.new(opts), method: unquote(method), jsonrpc: "2.0")
       end
 
-      defimpl Jason.Encoder, for: unquote(__CALLER__.module) do
+      defimpl Jason.Encoder, for: unquote(caller.module) do
         def encode(notification, opts) do
           Jason.Encoder.encode(notification.lsp, opts)
         end

--- a/apps/proto/lib/mix/tasks/lsp/data_model.ex
+++ b/apps/proto/lib/mix/tasks/lsp/data_model.ex
@@ -122,4 +122,10 @@ defmodule Mix.Tasks.Lsp.DataModel do
       Jason.decode(file_contents)
     end
   end
+
+  defimpl Inspect, for: __MODULE__ do
+    def inspect(_data_model, _opts) do
+      "#DataModel<>"
+    end
+  end
 end

--- a/apps/proto/lib/mix/tasks/lsp/data_model/enumeration.ex
+++ b/apps/proto/lib/mix/tasks/lsp/data_model/enumeration.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Lsp.DataModel.Enumeration do
     }
   end
 
-  def to_protocol(%__MODULE__{} = enumeration, _, _) do
+  def to_protocol(%__MODULE__{} = enumeration, _, _, _) do
     module_name = Module.concat([enumeration.name])
     quote(do: unquote(module_name))
   end
@@ -34,7 +34,8 @@ defmodule Mix.Tasks.Lsp.DataModel.Enumeration do
   def build_definition(
         %__MODULE__{} = enumeration,
         %Mappings{} = mappings,
-        %DataModel{}
+        %DataModel{},
+        _container_module
       ) do
     proto_module = Mappings.proto_module(mappings)
 

--- a/apps/proto/lib/mix/tasks/lsp/data_model/property.ex
+++ b/apps/proto/lib/mix/tasks/lsp/data_model/property.ex
@@ -16,9 +16,14 @@ defmodule Mix.Tasks.Lsp.DataModel.Property do
     %__MODULE__{property | type: Type.resolve(property.type, data_model)}
   end
 
-  def to_protocol(%__MODULE__{} = property, %DataModel{} = data_model, %Mappings{} = mappings) do
+  def to_protocol(
+        %__MODULE__{} = property,
+        %DataModel{} = data_model,
+        %Mappings{} = mappings,
+        container_module
+      ) do
     underscored = property.name |> Macro.underscore() |> String.to_atom()
-    type_call = Type.to_protocol(property.type, data_model, mappings)
+    type_call = Type.to_protocol(property.type, data_model, mappings, container_module)
 
     if property.required? do
       quote(do: {unquote(underscored), unquote(type_call)})

--- a/apps/proto/lib/mix/tasks/lsp/mappings.ex
+++ b/apps/proto/lib/mix/tasks/lsp/mappings.ex
@@ -139,4 +139,10 @@ defmodule Mix.Tasks.Lsp.Mappings do
     current_dir = Path.dirname(__ENV__.file)
     Path.join([current_dir, @import_filename])
   end
+
+  defimpl Inspect, for: __MODULE__ do
+    def inspect(_, _) do
+      "#Mappings<>"
+    end
+  end
 end

--- a/apps/proto/lib/mix/tasks/lsp/mappings/generate.ex
+++ b/apps/proto/lib/mix/tasks/lsp/mappings/generate.ex
@@ -114,7 +114,8 @@ defmodule Mix.Tasks.Lsp.Mappings.Generate do
   defp do_mapping(%struct_module{} = structure, %Mappings{} = mappings, %DataModel{} = data_model) do
     with {:ok, %Mapping{}} <- Mappings.fetch(mappings, structure.name),
          {:ok, destination_module} <- Mappings.fetch_destination_module(mappings, structure.name),
-         {:ok, definition_ast} <- struct_module.build_definition(structure, mappings, data_model) do
+         {:ok, definition_ast} <-
+           struct_module.build_definition(structure, mappings, data_model, destination_module) do
       {:ok, file_for(destination_module), definition_ast}
     end
   end

--- a/apps/protocol/lib/generated/lexical/protocol/types/cancel/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/cancel/params.ex
@@ -1,0 +1,6 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.Cancel.Params do
+  alias Lexical.Proto
+  use Proto
+  deftype id: one_of([integer(), string()])
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/code_action.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/code_action.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.CodeAction do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule Disabled do
     use Proto
@@ -14,7 +13,7 @@ defmodule Lexical.Protocol.Types.CodeAction do
   deftype command: optional(Types.Command),
           data: optional(any()),
           diagnostics: optional(list_of(Types.Diagnostic)),
-          disabled: optional(Parent.Disabled),
+          disabled: optional(Lexical.Protocol.Types.CodeAction.Disabled),
           edit: optional(Types.Workspace.Edit),
           is_preferred: optional(boolean()),
           kind: optional(Types.CodeAction.Kind),

--- a/apps/protocol/lib/generated/lexical/protocol/types/code_action/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/code_action/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.CodeAction.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule CodeActionKind do
     use Proto
@@ -11,7 +10,7 @@ defmodule Lexical.Protocol.Types.CodeAction.ClientCapabilities do
 
   defmodule CodeActionLiteralSupport do
     use Proto
-    deftype code_action_kind: Parent.CodeActionKind
+    deftype code_action_kind: Lexical.Protocol.Types.CodeAction.ClientCapabilities.CodeActionKind
   end
 
   defmodule ResolveSupport do
@@ -21,11 +20,15 @@ defmodule Lexical.Protocol.Types.CodeAction.ClientCapabilities do
 
   use Proto
 
-  deftype code_action_literal_support: optional(Parent.CodeActionLiteralSupport),
+  deftype code_action_literal_support:
+            optional(
+              Lexical.Protocol.Types.CodeAction.ClientCapabilities.CodeActionLiteralSupport
+            ),
           data_support: optional(boolean()),
           disabled_support: optional(boolean()),
           dynamic_registration: optional(boolean()),
           honors_change_annotations: optional(boolean()),
           is_preferred_support: optional(boolean()),
-          resolve_support: optional(Parent.ResolveSupport)
+          resolve_support:
+            optional(Lexical.Protocol.Types.CodeAction.ClientCapabilities.ResolveSupport)
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/completion/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/completion/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.Completion.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule CompletionItem do
     use Proto
@@ -11,12 +10,14 @@ defmodule Lexical.Protocol.Types.Completion.ClientCapabilities do
             deprecated_support: optional(boolean()),
             documentation_format: optional(list_of(Types.Markup.Kind)),
             insert_replace_support: optional(boolean()),
-            insert_text_mode_support: optional(Parent.InsertTextModeSupport),
+            insert_text_mode_support:
+              optional(Lexical.Protocol.Types.Completion.ClientCapabilities.InsertTextModeSupport),
             label_details_support: optional(boolean()),
             preselect_support: optional(boolean()),
-            resolve_support: optional(Parent.ResolveSupport),
+            resolve_support:
+              optional(Lexical.Protocol.Types.Completion.ClientCapabilities.ResolveSupport),
             snippet_support: optional(boolean()),
-            tag_support: optional(Parent.TagSupport)
+            tag_support: optional(Lexical.Protocol.Types.Completion.ClientCapabilities.TagSupport)
   end
 
   defmodule CompletionItemKind do
@@ -46,9 +47,12 @@ defmodule Lexical.Protocol.Types.Completion.ClientCapabilities do
 
   use Proto
 
-  deftype completion_item: optional(Parent.CompletionItem),
-          completion_item_kind: optional(Parent.CompletionItemKind),
-          completion_list: optional(Parent.CompletionList),
+  deftype completion_item:
+            optional(Lexical.Protocol.Types.Completion.ClientCapabilities.CompletionItem),
+          completion_item_kind:
+            optional(Lexical.Protocol.Types.Completion.ClientCapabilities.CompletionItemKind),
+          completion_list:
+            optional(Lexical.Protocol.Types.Completion.ClientCapabilities.CompletionList),
           context_support: optional(boolean()),
           dynamic_registration: optional(boolean()),
           insert_text_mode: optional(Types.InsertTextMode)

--- a/apps/protocol/lib/generated/lexical/protocol/types/completion/list.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/completion/list.ex
@@ -13,7 +13,8 @@ defmodule Lexical.Protocol.Types.Completion.List do
 
     deftype commit_characters: optional(list_of(string())),
             data: optional(any()),
-            edit_range: optional(one_of([Types.Range, EditRange])),
+            edit_range:
+              optional(one_of([Types.Range, Lexical.Protocol.Types.Completion.List.EditRange])),
             insert_text_format: optional(Types.InsertTextFormat),
             insert_text_mode: optional(Types.InsertTextMode)
   end
@@ -21,6 +22,6 @@ defmodule Lexical.Protocol.Types.Completion.List do
   use Proto
 
   deftype is_incomplete: boolean(),
-          item_defaults: optional(ItemDefaults),
+          item_defaults: optional(Lexical.Protocol.Types.Completion.List.ItemDefaults),
           items: list_of(Types.Completion.Item)
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/completion/options.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/completion/options.ex
@@ -1,7 +1,6 @@
 # This file's contents are auto-generated. Do not edit.
 defmodule Lexical.Protocol.Types.Completion.Options do
   alias Lexical.Proto
-  alias __MODULE__, as: Parent
 
   defmodule CompletionItem do
     use Proto
@@ -11,7 +10,7 @@ defmodule Lexical.Protocol.Types.Completion.Options do
   use Proto
 
   deftype all_commit_characters: optional(list_of(string())),
-          completion_item: optional(Parent.CompletionItem),
+          completion_item: optional(Lexical.Protocol.Types.Completion.Options.CompletionItem),
           resolve_provider: optional(boolean()),
           trigger_characters: optional(list_of(string())),
           work_done_progress: optional(boolean())

--- a/apps/protocol/lib/generated/lexical/protocol/types/completion/trigger/kind.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/completion/trigger/kind.ex
@@ -2,5 +2,5 @@
 defmodule Lexical.Protocol.Types.Completion.Trigger.Kind do
   alias Lexical.Proto
   use Proto
-  defenum(invoked: 1, trigger_character: 2, trigger_for_incomplete_completions: 3)
+  defenum invoked: 1, trigger_character: 2, trigger_for_incomplete_completions: 3
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/definition/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/definition/params.ex
@@ -1,0 +1,11 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.Definition.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+
+  deftype partial_result_token: optional(Types.Progress.Token),
+          position: Types.Position,
+          text_document: Types.TextDocument.Identifier,
+          work_done_token: optional(Types.Progress.Token)
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/diagnostic/severity.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/diagnostic/severity.ex
@@ -2,5 +2,5 @@
 defmodule Lexical.Protocol.Types.Diagnostic.Severity do
   alias Lexical.Proto
   use Proto
-  defenum(error: 1, warning: 2, information: 3, hint: 4)
+  defenum error: 1, warning: 2, information: 3, hint: 4
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/diagnostic/tag.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/diagnostic/tag.ex
@@ -2,5 +2,5 @@
 defmodule Lexical.Protocol.Types.Diagnostic.Tag do
   alias Lexical.Proto
   use Proto
-  defenum(unnecessary: 1, deprecated: 2)
+  defenum unnecessary: 1, deprecated: 2
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/did_change_configuration/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/did_change_configuration/params.ex
@@ -1,0 +1,6 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.DidChangeConfiguration.Params do
+  alias Lexical.Proto
+  use Proto
+  deftype settings: any()
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/did_change_watched_files/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/did_change_watched_files/params.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.DidChangeWatchedFiles.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype changes: list_of(Types.FileEvent)
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/did_close_text_document/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/did_close_text_document/params.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.DidCloseTextDocument.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype text_document: Types.TextDocument.Identifier
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/did_open_text_document/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/did_open_text_document/params.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.DidOpenTextDocument.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype text_document: Types.TextDocument.Item
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/did_save_text_document/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/did_save_text_document/params.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.DidSaveTextDocument.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype text: optional(string()), text_document: Types.TextDocument.Identifier
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/document/selector.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/document/selector.ex
@@ -3,5 +3,5 @@ defmodule Lexical.Protocol.Types.Document.Selector do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
   use Proto
-  defalias list_of(one_of([Types.TextDocument.Filter, Types.Notebook.Cell.TextDocument.Filter]))
+  defalias list_of(Types.Document.Filter)
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/document/symbol/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/document/symbol/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.Document.Symbol.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule SymbolKind do
     use Proto
@@ -19,6 +18,8 @@ defmodule Lexical.Protocol.Types.Document.Symbol.ClientCapabilities do
   deftype dynamic_registration: optional(boolean()),
           hierarchical_document_symbol_support: optional(boolean()),
           label_support: optional(boolean()),
-          symbol_kind: optional(Parent.SymbolKind),
-          tag_support: optional(Parent.TagSupport)
+          symbol_kind:
+            optional(Lexical.Protocol.Types.Document.Symbol.ClientCapabilities.SymbolKind),
+          tag_support:
+            optional(Lexical.Protocol.Types.Document.Symbol.ClientCapabilities.TagSupport)
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/file_change_type.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/file_change_type.ex
@@ -1,0 +1,6 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.FileChangeType do
+  alias Lexical.Proto
+  use Proto
+  defenum created: 1, changed: 2, deleted: 3
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/file_event.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/file_event.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.FileEvent do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype type: Types.FileChangeType, uri: string()
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/folding_range/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/folding_range/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.FoldingRange.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule FoldingRange do
     use Proto
@@ -17,8 +16,10 @@ defmodule Lexical.Protocol.Types.FoldingRange.ClientCapabilities do
   use Proto
 
   deftype dynamic_registration: optional(boolean()),
-          folding_range: optional(Parent.FoldingRange),
-          folding_range_kind: optional(Parent.FoldingRangeKind),
+          folding_range:
+            optional(Lexical.Protocol.Types.FoldingRange.ClientCapabilities.FoldingRange),
+          folding_range_kind:
+            optional(Lexical.Protocol.Types.FoldingRange.ClientCapabilities.FoldingRangeKind),
           line_folding_only: optional(boolean()),
           range_limit: optional(integer())
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/general/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/general/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.General.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule StaleRequestSupport do
     use Proto
@@ -14,5 +13,6 @@ defmodule Lexical.Protocol.Types.General.ClientCapabilities do
   deftype markdown: optional(Types.Markdown.ClientCapabilities),
           position_encodings: optional(list_of(Types.Position.Encoding.Kind)),
           regular_expressions: optional(Types.RegularExpressions.ClientCapabilities),
-          stale_request_support: optional(Parent.StaleRequestSupport)
+          stale_request_support:
+            optional(Lexical.Protocol.Types.General.ClientCapabilities.StaleRequestSupport)
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/initialize/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/initialize/params.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.Initialize.Params do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule ClientInfo1 do
     use Proto
@@ -12,7 +11,7 @@ defmodule Lexical.Protocol.Types.Initialize.Params do
   use Proto
 
   deftype capabilities: Types.ClientCapabilities,
-          client_info: optional(Parent.ClientInfo1),
+          client_info: optional(Lexical.Protocol.Types.Initialize.Params.ClientInfo1),
           initialization_options: optional(any()),
           locale: optional(string()),
           process_id: one_of([integer(), nil]),

--- a/apps/protocol/lib/generated/lexical/protocol/types/initialize/result.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/initialize/result.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.Initialize.Result do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule ServerInfo do
     use Proto
@@ -10,5 +9,7 @@ defmodule Lexical.Protocol.Types.Initialize.Result do
   end
 
   use Proto
-  deftype capabilities: Types.ServerCapabilities, server_info: optional(Parent.ServerInfo)
+
+  deftype capabilities: Types.ServerCapabilities,
+          server_info: optional(Lexical.Protocol.Types.Initialize.Result.ServerInfo)
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/inlay_hint/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/inlay_hint/client_capabilities.ex
@@ -1,7 +1,6 @@
 # This file's contents are auto-generated. Do not edit.
 defmodule Lexical.Protocol.Types.InlayHint.ClientCapabilities do
   alias Lexical.Proto
-  alias __MODULE__, as: Parent
 
   defmodule ResolveSupport do
     use Proto
@@ -11,5 +10,6 @@ defmodule Lexical.Protocol.Types.InlayHint.ClientCapabilities do
   use Proto
 
   deftype dynamic_registration: optional(boolean()),
-          resolve_support: optional(Parent.ResolveSupport)
+          resolve_support:
+            optional(Lexical.Protocol.Types.InlayHint.ClientCapabilities.ResolveSupport)
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/location.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/location.ex
@@ -3,6 +3,5 @@ defmodule Lexical.Protocol.Types.Location do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
   use Proto
-
   deftype range: Types.Range, uri: string()
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/log_message/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/log_message/params.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.LogMessage.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype message: string(), type: Types.Message.Type
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/notebook/document/filter.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/notebook/document/filter.ex
@@ -1,7 +1,6 @@
 # This file's contents are auto-generated. Do not edit.
 defmodule Lexical.Protocol.Types.Notebook.Document.Filter do
   alias Lexical.Proto
-  alias __MODULE__, as: Parent
 
   defmodule NotebookDocumentFilter do
     use Proto
@@ -21,8 +20,8 @@ defmodule Lexical.Protocol.Types.Notebook.Document.Filter do
   use Proto
 
   defalias one_of([
-             Parent.NotebookDocumentFilter,
-             Parent.NotebookDocumentFilter1,
-             Parent.NotebookDocumentFilter2
+             Lexical.Protocol.Types.Notebook.Document.Filter.NotebookDocumentFilter,
+             Lexical.Protocol.Types.Notebook.Document.Filter.NotebookDocumentFilter1,
+             Lexical.Protocol.Types.Notebook.Document.Filter.NotebookDocumentFilter2
            ])
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/notebook/document/sync/options.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/notebook/document/sync/options.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.Notebook.Document.Sync.Options do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule Cells do
     use Proto
@@ -17,19 +16,25 @@ defmodule Lexical.Protocol.Types.Notebook.Document.Sync.Options do
   defmodule NotebookSelector do
     use Proto
 
-    deftype cells: optional(list_of(Parent.Cells)),
+    deftype cells: optional(list_of(Lexical.Protocol.Types.Notebook.Document.Sync.Options.Cells)),
             notebook: one_of([string(), Types.Notebook.Document.Filter])
   end
 
   defmodule NotebookSelector1 do
     use Proto
 
-    deftype cells: list_of(Parent.Cells1),
+    deftype cells: list_of(Lexical.Protocol.Types.Notebook.Document.Sync.Options.Cells1),
             notebook: optional(one_of([string(), Types.Notebook.Document.Filter]))
   end
 
   use Proto
 
-  deftype notebook_selector: list_of(one_of([Parent.NotebookSelector, Parent.NotebookSelector1])),
+  deftype notebook_selector:
+            list_of(
+              one_of([
+                Lexical.Protocol.Types.Notebook.Document.Sync.Options.NotebookSelector,
+                Lexical.Protocol.Types.Notebook.Document.Sync.Options.NotebookSelector1
+              ])
+            ),
           save: optional(boolean())
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/notebook/document/sync/registration/options.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/notebook/document/sync/registration/options.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.Notebook.Document.Sync.Registration.Options do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule Cells2 do
     use Proto
@@ -17,14 +16,18 @@ defmodule Lexical.Protocol.Types.Notebook.Document.Sync.Registration.Options do
   defmodule NotebookSelector2 do
     use Proto
 
-    deftype cells: optional(list_of(Parent.Cells2)),
+    deftype cells:
+              optional(
+                list_of(Lexical.Protocol.Types.Notebook.Document.Sync.Registration.Options.Cells2)
+              ),
             notebook: one_of([string(), Types.Notebook.Document.Filter])
   end
 
   defmodule NotebookSelector3 do
     use Proto
 
-    deftype cells: list_of(Parent.Cells3),
+    deftype cells:
+              list_of(Lexical.Protocol.Types.Notebook.Document.Sync.Registration.Options.Cells3),
             notebook: optional(one_of([string(), Types.Notebook.Document.Filter]))
   end
 
@@ -32,6 +35,11 @@ defmodule Lexical.Protocol.Types.Notebook.Document.Sync.Registration.Options do
 
   deftype id: optional(string()),
           notebook_selector:
-            list_of(one_of([Parent.NotebookSelector2, Parent.NotebookSelector3])),
+            list_of(
+              one_of([
+                Lexical.Protocol.Types.Notebook.Document.Sync.Registration.Options.NotebookSelector2,
+                Lexical.Protocol.Types.Notebook.Document.Sync.Registration.Options.NotebookSelector3
+              ])
+            ),
           save: optional(boolean())
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/publish_diagnostics/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/publish_diagnostics/client_capabilities.ex
@@ -13,6 +13,7 @@ defmodule Lexical.Protocol.Types.PublishDiagnostics.ClientCapabilities do
   deftype code_description_support: optional(boolean()),
           data_support: optional(boolean()),
           related_information: optional(boolean()),
-          tag_support: optional(TagSupport),
+          tag_support:
+            optional(Lexical.Protocol.Types.PublishDiagnostics.ClientCapabilities.TagSupport),
           version_support: optional(boolean())
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/semantic_tokens/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/semantic_tokens/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.SemanticTokens.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule Full do
     use Proto
@@ -17,8 +16,14 @@ defmodule Lexical.Protocol.Types.SemanticTokens.ClientCapabilities do
   defmodule Requests do
     use Proto
 
-    deftype full: optional(one_of([boolean(), Parent.Full])),
-            range: optional(one_of([boolean(), Parent.Range]))
+    deftype full:
+              optional(
+                one_of([boolean(), Lexical.Protocol.Types.SemanticTokens.ClientCapabilities.Full])
+              ),
+            range:
+              optional(
+                one_of([boolean(), Lexical.Protocol.Types.SemanticTokens.ClientCapabilities.Range])
+              )
   end
 
   use Proto
@@ -28,7 +33,7 @@ defmodule Lexical.Protocol.Types.SemanticTokens.ClientCapabilities do
           formats: list_of(Types.TokenFormat),
           multiline_token_support: optional(boolean()),
           overlapping_token_support: optional(boolean()),
-          requests: Parent.Requests,
+          requests: Lexical.Protocol.Types.SemanticTokens.ClientCapabilities.Requests,
           server_cancel_support: optional(boolean()),
           token_modifiers: list_of(string()),
           token_types: list_of(string())

--- a/apps/protocol/lib/generated/lexical/protocol/types/semantic_tokens/options.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/semantic_tokens/options.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.SemanticTokens.Options do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule Full do
     use Proto
@@ -16,8 +15,9 @@ defmodule Lexical.Protocol.Types.SemanticTokens.Options do
 
   use Proto
 
-  deftype full: optional(one_of([boolean(), Parent.Full])),
+  deftype full: optional(one_of([boolean(), Lexical.Protocol.Types.SemanticTokens.Options.Full])),
           legend: Types.SemanticTokens.Legend,
-          range: optional(one_of([boolean(), Parent.Range])),
+          range:
+            optional(one_of([boolean(), Lexical.Protocol.Types.SemanticTokens.Options.Range])),
           work_done_progress: optional(boolean())
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/semantic_tokens/registration/options.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/semantic_tokens/registration/options.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.SemanticTokens.Registration.Options do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule Full1 do
     use Proto
@@ -17,9 +16,18 @@ defmodule Lexical.Protocol.Types.SemanticTokens.Registration.Options do
   use Proto
 
   deftype document_selector: one_of([Types.Document.Selector, nil]),
-          full: optional(one_of([boolean(), Parent.Full1])),
+          full:
+            optional(
+              one_of([boolean(), Lexical.Protocol.Types.SemanticTokens.Registration.Options.Full1])
+            ),
           id: optional(string()),
           legend: Types.SemanticTokens.Legend,
-          range: optional(one_of([boolean(), Parent.Range1])),
+          range:
+            optional(
+              one_of([
+                boolean(),
+                Lexical.Protocol.Types.SemanticTokens.Registration.Options.Range1
+              ])
+            ),
           work_done_progress: optional(boolean())
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/server_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/server_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.ServerCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule Workspace do
     use Proto
@@ -136,6 +135,6 @@ defmodule Lexical.Protocol.Types.ServerCapabilities do
                 Types.TypeHierarchy.Registration.Options
               ])
             ),
-          workspace: optional(Parent.Workspace),
+          workspace: optional(Lexical.Protocol.Types.ServerCapabilities.Workspace),
           workspace_symbol_provider: optional(one_of([boolean(), Types.Workspace.Symbol.Options]))
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/show_message/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/show_message/params.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.ShowMessage.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype message: string(), type: Types.Message.Type
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/show_message_request/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/show_message_request/client_capabilities.ex
@@ -1,7 +1,6 @@
 # This file's contents are auto-generated. Do not edit.
 defmodule Lexical.Protocol.Types.ShowMessageRequest.ClientCapabilities do
   alias Lexical.Proto
-  alias __MODULE__, as: Parent
 
   defmodule MessageActionItem do
     use Proto
@@ -9,5 +8,9 @@ defmodule Lexical.Protocol.Types.ShowMessageRequest.ClientCapabilities do
   end
 
   use Proto
-  deftype message_action_item: optional(Parent.MessageActionItem)
+
+  deftype message_action_item:
+            optional(
+              Lexical.Protocol.Types.ShowMessageRequest.ClientCapabilities.MessageActionItem
+            )
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/signature_help/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/signature_help/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.SignatureHelp.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule ParameterInformation do
     use Proto
@@ -14,12 +13,16 @@ defmodule Lexical.Protocol.Types.SignatureHelp.ClientCapabilities do
 
     deftype active_parameter_support: optional(boolean()),
             documentation_format: optional(list_of(Types.Markup.Kind)),
-            parameter_information: optional(Parent.ParameterInformation)
+            parameter_information:
+              optional(
+                Lexical.Protocol.Types.SignatureHelp.ClientCapabilities.ParameterInformation
+              )
   end
 
   use Proto
 
   deftype context_support: optional(boolean()),
           dynamic_registration: optional(boolean()),
-          signature_information: optional(Parent.SignatureInformation)
+          signature_information:
+            optional(Lexical.Protocol.Types.SignatureHelp.ClientCapabilities.SignatureInformation)
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/text_document/content_change_event.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/text_document/content_change_event.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.TextDocument.ContentChangeEvent do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule TextDocumentContentChangeEvent do
     use Proto
@@ -15,5 +14,9 @@ defmodule Lexical.Protocol.Types.TextDocument.ContentChangeEvent do
   end
 
   use Proto
-  defalias one_of([Parent.TextDocumentContentChangeEvent, Parent.TextDocumentContentChangeEvent1])
+
+  defalias one_of([
+             Lexical.Protocol.Types.TextDocument.ContentChangeEvent.TextDocumentContentChangeEvent,
+             Lexical.Protocol.Types.TextDocument.ContentChangeEvent.TextDocumentContentChangeEvent1
+           ])
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/text_document/filter.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/text_document/filter.ex
@@ -1,7 +1,6 @@
 # This file's contents are auto-generated. Do not edit.
 defmodule Lexical.Protocol.Types.TextDocument.Filter do
   alias Lexical.Proto
-  alias __MODULE__, as: Parent
 
   defmodule TextDocumentFilter do
     use Proto
@@ -21,8 +20,8 @@ defmodule Lexical.Protocol.Types.TextDocument.Filter do
   use Proto
 
   defalias one_of([
-             Parent.TextDocumentFilter,
-             Parent.TextDocumentFilter1,
-             Parent.TextDocumentFilter2
+             Lexical.Protocol.Types.TextDocument.Filter.TextDocumentFilter,
+             Lexical.Protocol.Types.TextDocument.Filter.TextDocumentFilter1,
+             Lexical.Protocol.Types.TextDocument.Filter.TextDocumentFilter2
            ])
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/workspace/edit/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/workspace/edit/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.Workspace.Edit.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule ChangeAnnotationSupport do
     use Proto
@@ -11,7 +10,10 @@ defmodule Lexical.Protocol.Types.Workspace.Edit.ClientCapabilities do
 
   use Proto
 
-  deftype change_annotation_support: optional(Parent.ChangeAnnotationSupport),
+  deftype change_annotation_support:
+            optional(
+              Lexical.Protocol.Types.Workspace.Edit.ClientCapabilities.ChangeAnnotationSupport
+            ),
           document_changes: optional(boolean()),
           failure_handling: optional(Types.FailureHandling.Kind),
           normalizes_line_endings: optional(boolean()),

--- a/apps/protocol/lib/generated/lexical/protocol/types/workspace/symbol/client_capabilities.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/workspace/symbol/client_capabilities.ex
@@ -2,7 +2,6 @@
 defmodule Lexical.Protocol.Types.Workspace.Symbol.ClientCapabilities do
   alias Lexical.Proto
   alias Lexical.Protocol.Types
-  alias __MODULE__, as: Parent
 
   defmodule ResolveSupport do
     use Proto
@@ -22,7 +21,10 @@ defmodule Lexical.Protocol.Types.Workspace.Symbol.ClientCapabilities do
   use Proto
 
   deftype dynamic_registration: optional(boolean()),
-          resolve_support: optional(Parent.ResolveSupport),
-          symbol_kind: optional(Parent.SymbolKind),
-          tag_support: optional(Parent.TagSupport)
+          resolve_support:
+            optional(Lexical.Protocol.Types.Workspace.Symbol.ClientCapabilities.ResolveSupport),
+          symbol_kind:
+            optional(Lexical.Protocol.Types.Workspace.Symbol.ClientCapabilities.SymbolKind),
+          tag_support:
+            optional(Lexical.Protocol.Types.Workspace.Symbol.ClientCapabilities.TagSupport)
 end

--- a/apps/protocol/lib/lexical/protocol/notifications.ex
+++ b/apps/protocol/lib/lexical/protocol/notifications.ex
@@ -16,69 +16,56 @@ defmodule Lexical.Protocol.Notifications do
   defmodule Cancel do
     use Proto
 
-    defnotification "$/cancelRequest", id: integer()
+    defnotification "$/cancelRequest", Types.Cancel.Params
   end
 
   defmodule DidOpen do
     use Proto
 
-    defnotification "textDocument/didOpen", text_document: Types.TextDocument.Item
+    defnotification "textDocument/didOpen", Types.DidOpenTextDocument.Params
   end
 
   defmodule DidClose do
     use Proto
 
-    defnotification "textDocument/didClose", text_document: Types.TextDocument.Identifier
+    defnotification "textDocument/didClose", Types.DidCloseTextDocument.Params
   end
 
   defmodule DidChange do
     use Proto
 
-    defnotification "textDocument/didChange",
-      text_document: Types.TextDocument.Versioned.Identifier,
-      content_changes:
-        list_of(
-          one_of([
-            Types.TextDocument.ContentChangeEvent.TextDocumentContentChangeEvent,
-            Types.TextDocument.ContentChangeEvent.TextDocumentContentChangeEvent1
-          ])
-        )
+    defnotification "textDocument/didChange", Types.DidChangeTextDocument.Params
   end
 
   defmodule DidChangeConfiguration do
     use Proto
 
-    defnotification "workspace/didChangeConfiguration", settings: map_of(any())
+    defnotification "workspace/didChangeConfiguration", Types.DidChangeConfiguration.Params
   end
 
   defmodule DidChangeWatchedFiles do
     use Proto
 
-    defnotification "workspace/didChangeWatchedFiles", changes: list_of(Types.FileEvent)
+    defnotification "workspace/didChangeWatchedFiles", Types.DidChangeWatchedFiles.Params
   end
 
   defmodule DidSave do
     use Proto
 
-    defnotification "textDocument/didSave", text_document: Types.TextDocument.Identifier
+    defnotification "textDocument/didSave", Types.DidSaveTextDocument.Params
   end
 
   defmodule PublishDiagnostics do
     use Proto
 
-    defnotification "textDocument/publishDiagnostics",
-      uri: string(),
-      version: optional(integer()),
-      diagnostics: list_of(Types.Diagnostic)
+    defnotification "textDocument/publishDiagnostics", Types.PublishDiagnostics.Params
   end
 
   defmodule LogMessage do
     use Proto
     require Types.Message.Type
 
-    defnotification "window/logMessage",
-      message: string(),
-      type: Types.Message.Type
+    defnotification "window/logMessage", Types.LogMessage.Params
 
     for type <- [:error, :warning, :info, :log] do
       def unquote(type)(message) do
@@ -91,9 +78,7 @@ defmodule Lexical.Protocol.Notifications do
     use Proto
     require Types.Message.Type
 
-    defnotification "window/showMessage",
-      message: string(),
-      type: Types.Message.Type
+    defnotification "window/showMessage", Types.ShowMessage.Params
 
     for type <- [:error, :warning, :info, :log] do
       def unquote(type)(message) do

--- a/apps/protocol/lib/lexical/protocol/requests.ex
+++ b/apps/protocol/lib/lexical/protocol/requests.ex
@@ -1,76 +1,54 @@
 defmodule Lexical.Protocol.Requests do
   alias Lexical.Proto
-  alias Lexical.Protocol.LspTypes
   alias Lexical.Protocol.Types
 
   # Client -> Server request
   defmodule Initialize do
     use Proto
 
-    defrequest "initialize",
-      capabilities: optional(Types.ClientCapabilities),
-      client_info: optional(LspTypes.ClientInfo),
-      initialization_options: optional(any()),
-      locale: optional(string()),
-      process_id: optional(integer()),
-      root_path: optional(string()),
-      root_uri: optional(uri()),
-      trace: optional(Types.TraceValues),
-      workspace_folders: optional(list_of(Types.Workspace.Folder))
+    defrequest "initialize", Types.Initialize.Params
   end
 
   defmodule Cancel do
     use Proto
 
-    defrequest "$/cancelRequest", id: one_of([string(), integer()])
+    defrequest "$/cancelRequest", Types.Cancel.Params
   end
 
   defmodule Shutdown do
     use Proto
 
-    defrequest "shutdown", []
+    defrequest "shutdown"
   end
 
   defmodule FindReferences do
     use Proto
 
-    defrequest "textDocument/references",
-      position: Types.Position,
-      text_document: Types.TextDocument.Identifier
+    defrequest "textDocument/references", Types.Reference.Params
   end
 
   defmodule GoToDefinition do
     use Proto
 
-    defrequest "textDocument/definition",
-      text_document: Types.TextDocument.Identifier,
-      position: Types.Position
+    defrequest "textDocument/definition", Types.Definition.Params
   end
 
   defmodule Formatting do
     use Proto
 
-    defrequest "textDocument/formatting",
-      options: Types.Formatting.Options,
-      text_document: Types.TextDocument.Identifier
+    defrequest "textDocument/formatting", Types.Document.Formatting.Params
   end
 
   defmodule CodeAction do
     use Proto
 
-    defrequest "textDocument/codeAction",
-      context: Types.CodeAction.Context,
-      range: Types.Range,
-      text_document: Types.TextDocument.Identifier
+    defrequest "textDocument/codeAction", Types.CodeAction.Params
   end
 
   defmodule Completion do
     use Proto
 
-    defrequest "textDocument/completion",
-      text_document: Types.TextDocument.Identifier,
-      position: Types.Position,
-      context: Types.Completion.Context
+    defrequest "textDocument/completion", Types.Completion.Params
   end
 
   # Server -> Client requests
@@ -78,8 +56,7 @@ defmodule Lexical.Protocol.Requests do
   defmodule RegisterCapability do
     use Proto
 
-    defrequest "client/registerCapability",
-      registrations: optional(list_of(LspTypes.Registration))
+    defrequest "client/registerCapability", Types.Registration.Params
   end
 
   use Proto, decoders: :requests

--- a/apps/protocol/mix.exs
+++ b/apps/protocol/mix.exs
@@ -30,10 +30,11 @@ defmodule Lexical.Protocol.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:jason, "~> 1.4", optional: true},
       {:common, in_umbrella: true},
-      {:proto, in_umbrella: true},
-      {:common_protocol, in_umbrella: true}
+      {:common_protocol, in_umbrella: true},
+      {:jason, "~> 1.4", optional: true},
+      {:patch, "~> 0.12", only: [:test]},
+      {:proto, in_umbrella: true}
     ]
   end
 end

--- a/apps/protocol/test/lexical/proto_test.exs
+++ b/apps/protocol/test/lexical/proto_test.exs
@@ -342,13 +342,18 @@ defmodule Lexical.ProtoTest do
   describe "notifications" do
     setup [:with_source_file_store]
 
+    defmodule Notif.Params do
+      use Proto
+
+      deftype line: integer(),
+              notice_message: string(),
+              column: integer()
+    end
+
     defmodule Notif do
       use Proto
 
-      defnotification "textDocument/somethingHappened",
-        line: integer(),
-        notice_message: string(),
-        column: integer()
+      defnotification "textDocument/somethingHappened", Notif.Params
     end
 
     test "parse fills out the notification" do
@@ -387,11 +392,16 @@ defmodule Lexical.ProtoTest do
       assert notif.notice_message == "This went wrong"
     end
 
+    defmodule Notif.WithTextDoc.Params do
+      use Proto
+
+      deftype text_document: Types.TextDocument.Identifier
+    end
+
     defmodule Notif.WithTextDoc do
       use Proto
 
-      defnotification "notif/withTextDoc",
-        text_document: Types.TextDocument.Identifier
+      defnotification "notif/withTextDoc", Notif.WithTextDoc.Params
     end
 
     test "to_native fills out the source file", ctx do
@@ -401,12 +411,17 @@ defmodule Lexical.ProtoTest do
       assert %SourceFile{} = notif.source_file
     end
 
+    defmodule Notif.WithPos.Params do
+      use Proto
+
+      deftype text_document: Types.TextDocument.Identifier,
+              position: Types.Position
+    end
+
     defmodule Notif.WithPos do
       use Proto
 
-      defnotification "notif/WithPos",
-        text_document: Types.TextDocument.Identifier,
-        position: Types.Position
+      defnotification "notif/WithPos", Notif.WithPos.Params
     end
 
     test "to_native fills out a position", ctx do
@@ -426,12 +441,17 @@ defmodule Lexical.ProtoTest do
       assert notif.position.character == 1
     end
 
+    defmodule Notif.WithRange.Params do
+      use Proto
+
+      deftype text_document: Types.TextDocument.Identifier,
+              range: Types.Range
+    end
+
     defmodule Notif.WithRange do
       use Proto
 
-      defnotification "notif/WithPos",
-        text_document: Types.TextDocument.Identifier,
-        range: Types.Range
+      defnotification "notif/WithRange", Notif.WithRange.Params
     end
 
     test "to_native fills out a range", ctx do
@@ -459,16 +479,27 @@ defmodule Lexical.ProtoTest do
   describe "requests" do
     setup [:with_source_file_store]
 
+    defmodule Req.Params do
+      use Proto
+
+      deftype line: integer(), error_message: string()
+    end
+
     defmodule Req do
       use Proto
 
-      defrequest "something", line: integer(), error_message: string()
+      defrequest "something", Req.Params
+    end
+
+    defmodule TextDocReq.Params do
+      use Proto
+      deftype text_document: Types.TextDocument.Identifier
     end
 
     defmodule TextDocReq do
       use Proto
 
-      defrequest "textDoc", text_document: Types.TextDocument.Identifier
+      defrequest "textDoc", TextDocReq.Params
     end
 
     test "parse fills out the request" do
@@ -514,12 +545,17 @@ defmodule Lexical.ProtoTest do
       assert %SourceFile{} = ex_req.source_file
     end
 
+    defmodule PositionReq.Params do
+      use Proto
+
+      deftype text_document: Types.TextDocument.Identifier,
+              position: Types.Position
+    end
+
     defmodule PositionReq do
       use Proto
 
-      defrequest "posReq",
-        text_document: Types.TextDocument.Identifier,
-        position: Types.Position
+      defrequest "posReq", PositionReq.Params
     end
 
     test "to_native fills out a position", ctx do
@@ -540,12 +576,17 @@ defmodule Lexical.ProtoTest do
       assert %SourceFile{} = ex_req.source_file
     end
 
+    defmodule RangeReq.Params do
+      use Proto
+
+      deftype text_document: Types.TextDocument.Identifier,
+              range: Types.Range
+    end
+
     defmodule RangeReq do
       use Proto
 
-      defrequest "rangeReq",
-        text_document: Types.TextDocument.Identifier,
-        range: Types.Range
+      defrequest "rangeReq", RangeReq.Params
     end
 
     test "to_native fills out a range", ctx do

--- a/apps/protocol/test/lexical/protocol/integration/initialize_test.exs
+++ b/apps/protocol/test/lexical/protocol/integration/initialize_test.exs
@@ -1,0 +1,221 @@
+defmodule Lexical.Protocol.Integrations.InitializeTest do
+  alias Lexical.Protocol.Requests
+  alias Lexical.Protocol.Types
+  alias Lexical.Protocol.Types.Completion
+  alias Lexical.Protocol.Types.TextDocument
+
+  use ExUnit.Case
+
+  test "initialize parses a request from neovim" do
+    assert {:ok, %Requests.Initialize{lsp: %Requests.Initialize.LSP{} = parsed}} =
+             Requests.Initialize.parse(neovim_initialize())
+
+    assert parsed.client_info.name == "Neovim"
+    assert parsed.client_info.version == "0.10.0"
+
+    assert %Types.ClientCapabilities{} = capabilities = parsed.capabilities
+
+    assert %TextDocument.ClientCapabilities{} = text_doc_capabilities = capabilities.text_document
+
+    validate_workspace(capabilities)
+
+    validate_call_hierarchy(text_doc_capabilities)
+    validate_code_action(text_doc_capabilities)
+    validate_declaration(text_doc_capabilities)
+    validate_definition(text_doc_capabilities)
+    validate_completion(text_doc_capabilities)
+  end
+
+  def validate_completion(%TextDocument.ClientCapabilities{} = text_doc_capabilities) do
+    assert %Completion.ClientCapabilities{} =
+             completion_capabilities = text_doc_capabilities.completion
+
+    assert %Completion.ClientCapabilities.CompletionItemKind{} =
+             completion_capabilities.completion_item_kind
+  end
+
+  def validate_call_hierarchy(%TextDocument.ClientCapabilities{} = text_doc_capabilities) do
+    assert %Types.CallHierarchy.ClientCapabilities{} = text_doc_capabilities.call_hierarchy
+  end
+
+  def validate_code_action(%TextDocument.ClientCapabilities{} = text_doc_capabilities) do
+    assert %Types.CodeAction.ClientCapabilities{} = text_doc_capabilities.code_action
+  end
+
+  def validate_declaration(%TextDocument.ClientCapabilities{} = text_doc_capabilities) do
+    assert %Types.Declaration.ClientCapabilities{} = text_doc_capabilities.declaration
+  end
+
+  def validate_definition(%TextDocument.ClientCapabilities{} = text_doc_capabilities) do
+    assert %Types.Definition.ClientCapabilities{} = text_doc_capabilities.definition
+  end
+
+  def validate_workspace(%Types.ClientCapabilities{} = capabilities) do
+    assert %Types.Workspace.ClientCapabilities{} = capabilities.workspace
+  end
+
+  def neovim_initialize do
+    ~S(
+      {
+        "id": 1,
+        "jsonrpc": "2.0",
+        "method": "initialize",
+        "params": {
+          "capabilities": {
+            "textDocument": {
+              "callHierarchy": {
+                "dynamicRegistration": false
+              },
+              "codeAction": {
+                "codeActionLiteralSupport": {
+                  "codeActionKind": {
+                    "valueSet": ["", "quickfix", "refactor", "refactor.extract", "refactor.inline", "refactor.rewrite", "source", "source.organizeImports"]
+                  }
+                },
+                "dataSupport": true,
+                "dynamicRegistration": false,
+                "isPreferredSupport": true,
+                "resolveSupport": {
+                  "properties": [ "edit" ]
+                }
+              },
+              "completion": {
+                "completionItem": {
+                  "commitCharactersSupport": false,
+                  "deprecatedSupport": false,
+                  "documentationFormat": [ "markdown", "plaintext" ],
+                  "preselectSupport": false,
+                  "snippetSupport": false
+                },
+                "completionItemKind": {
+                  "valueSet": [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 ]
+                },
+                "contextSupport": false,
+                "dynamicRegistration": false
+              },
+              "declaration": {
+                "linkSupport": true
+              },
+              "definition": {
+                "linkSupport": true
+              },
+              "documentHighlight": {
+                "dynamicRegistration": false
+              },
+              "documentSymbol": {
+                "dynamicRegistration": false,
+                "hierarchicalDocumentSymbolSupport": true,
+                "symbolKind": {
+                  "valueSet": [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 ]
+                }
+              },
+              "hover": {
+                "contentFormat": [ "markdown", "plaintext" ],
+                "dynamicRegistration": false
+              },
+              "implementation": {
+                "linkSupport": true
+              },
+              "publishDiagnostics": {
+                "relatedInformation": true,
+                "tagSupport": {
+                  "valueSet": [ 1, 2 ]
+                }
+              },
+              "references": {
+                "dynamicRegistration": false
+              },
+              "rename": {
+                "dynamicRegistration": false,
+                "prepareSupport": true
+              },
+              "semanticTokens": {
+                "augmentsSyntaxTokens": true,
+                "dynamicRegistration": false,
+                "formats": [ "relative" ],
+                "multilineTokenSupport": false,
+                "overlappingTokenSupport": true,
+                "requests": {
+                  "full": {
+                    "delta": true
+                  },
+                  "range": false
+                },
+                "serverCancelSupport": false,
+                "tokenModifiers": [ "declaration", "definition", "readonly", "static", "deprecated", "abstract", "async", "modification", "documentation", "defaultLibrary" ],
+                "tokenTypes": [ "namespace", "type", "class", "enum", "interface", "struct", "typeParameter", "parameter", "variable", "property", "enumMember", "event", "function", "method", "macro", "keyword", "modifier", "comment", "string", "number", "regexp", "operator", "decorator" ]
+              },
+              "signatureHelp": {
+                "dynamicRegistration": false,
+                "signatureInformation": {
+                  "activeParameterSupport": true,
+                  "documentationFormat": [ "markdown", "plaintext" ],
+                  "parameterInformation": {
+                    "labelOffsetSupport": true
+                  }
+                }
+              },
+              "synchronization": {
+                "didSave": true,
+                "dynamicRegistration": false,
+                "willSave": true,
+                "willSaveWaitUntil": true
+              },
+              "typeDefinition": {
+                "linkSupport": true
+              }
+            },
+            "window": {
+              "showDocument": {
+                "support": true
+              },
+              "showMessage": {
+                "messageActionItem": {
+                  "additionalPropertiesSupport": false
+                }
+              },
+              "workDoneProgress": true
+            },
+            "workspace": {
+              "applyEdit": true,
+              "configuration": true,
+              "didChangeWatchedFiles": {
+                "dynamicRegistration": false,
+                "relativePatternSupport": true
+              },
+              "semanticTokens": {
+                "refreshSupport": true
+              },
+              "symbol": {
+                "dynamicRegistration": false,
+                "hierarchicalWorkspaceSymbolSupport": true,
+                "symbolKind": {
+                  "valueSet": [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 ]
+                }
+              },
+              "workspaceEdit": {
+                "resourceOperations": ["rename", "create", "delete"]
+              },
+              "workspaceFolders": true
+            }
+          },
+          "clientInfo": {
+            "name": "Neovim",
+            "version": "0.10.0"
+          },
+          "processId": 81648,
+          "rootPath": "/Users/scottming/Code/lexical",
+          "rootUri": "file:///Users/scottming/Code/lexical",
+          "trace": "off",
+          "workspaceFolders": [
+            {
+              "name": "/Users/scottming/Code/lexical",
+              "uri": "file:///Users/scottming/Code/lexical"
+            }
+          ]
+        }
+      }
+    )
+    |> Jason.decode!()
+  end
+end


### PR DESCRIPTION
Fixed object literal module names

Object literals are defined inside the module that uses them, and then
referred to via a local module name. This causes an issue with the
decoding logic, because these module names aren't fully qualified, and
decoding fails.

The fix here puts the full module name in calls to `deftype` and
 friends so the modules can be resolved during decoding

This PR is several commits. 
1. Reverts the revert i made earlier. This isn't reviewable
2. Changes the generators to generate fully qualified names for object literals. Review this one
3. Added inspect implementation for some of the data structures in the mix tasks. 
4. Regenerate the LSP modules. Don't review this one either.