### PR TITLE
Correct arity of format_string

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/code_mod/format.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_mod/format.ex
@@ -79,7 +79,7 @@ defmodule Lexical.RemoteControl.CodeMod.Format do
             result
 
           _ ->
-            formatter = &Code.format_string!/2
+            formatter = &Code.format_string!/1
             {formatter, nil}
         end
       else


### PR DESCRIPTION
The function is called with only one argument. Using it like this leads to a crash of the server on save.