### PR TITLE
Fix: Tracing would fail for modules that aren't auto-loaded

### DIFF
--- a/apps/remote_control/test/lexical/remote_control/build_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build_test.exs
@@ -338,6 +338,19 @@ defmodule Lexical.BuildTest do
       assert_receive module_updated(name: NewModule, functions: []), 500
     end
 
+    test "adding a non-loaded module notifies the listener", %{project: project} do
+      source = ~S[
+      defmodule NotLoaded do
+        @compile {:autoload, false}
+        defstruct loaded: false
+      end
+      ]
+      compile_document(project, source)
+
+      assert_receive module_updated(name: NotLoaded, struct: fields), 500
+      assert [%{field: :loaded, required?: true}] = fields
+    end
+
     test "adding multiple modules notifies the listener for each module", %{project: project} do
       source = ~S[
         defmodule FirstModule do


### PR DESCRIPTION
Modules that aren't auto-loaded would break the compile tracer, as they don't have any functions yet. This change actually loads them from their bytecode, which is given to us and takes about 100us to do. I figure this can go in the compile tracer for now, since this won't happen too often.

Fixes #132