### PR TITLE
Fix crash due to formatter return iodata not binary

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/code_mod/format.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_mod/format.ex
@@ -79,7 +79,11 @@ defmodule Lexical.RemoteControl.CodeMod.Format do
             result
 
           _ ->
-            formatter = &Code.format_string!/1
+            formatter = fn source ->
+              formatted_source = Code.format_string!(source)
+              IO.iodata_to_binary([formatted_source, ?\n])
+            end
+
             {formatter, nil}
         end
       else


### PR DESCRIPTION
`Code.format_string!/1` returns iodata but
`Lexical.RemoteControl.CodeMod.Diff.diff/2` expected both `unformatted` and `formatted` to be a binary. This changes fix `formatted` to ensure that it's a binary.