### PR TITLE
Refactor: Make callable completions consistent

### DIFF
--- a/apps/remote_control/test/fixtures/project/lib/macros.ex
+++ b/apps/remote_control/test/fixtures/project/lib/macros.ex
@@ -1,0 +1,14 @@
+defmodule Project.Macros do
+  defmacro macro_add(a, b) do
+    quote do
+      unquote(a) + unquote(b)
+    end
+  end
+
+  defmacro l(message) do
+    quote do
+      require Logger
+      Logger.info("message is: #{unquote(inspect(message))}")
+    end
+  end
+end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
@@ -1,0 +1,86 @@
+defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
+  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.Server.CodeIntelligence.Completion.Env
+
+  @callables [Result.Function, Result.Macro]
+
+  def completion(%callable_module{} = callable, %Env{} = env)
+      when callable_module in @callables do
+    add_args? = not String.contains?(env.suffix, "(")
+
+    insert_text =
+      if add_args? do
+        callable_snippet(callable, env)
+      else
+        callable.name
+      end
+
+    tags =
+      if Map.get(callable.metadata, :deprecated) do
+        [:deprecated]
+      end
+
+    Env.snippet(env, insert_text,
+      kind: :function,
+      label: label(callable),
+      sort_text: sort_text(callable),
+      tags: tags
+    )
+  end
+
+  def capture_completions(%callable_module{} = callable, %Env{} = env)
+      when callable_module in @callables do
+    name_and_arity = name_and_arity(callable)
+
+    complete_capture =
+      Env.plain_text(env, name_and_arity,
+        detail: "(Capture)",
+        kind: :function,
+        label: name_and_arity,
+        sort_text: "&" <> sort_text(callable)
+      )
+
+    call_capture =
+      Env.snippet(env, callable_snippet(callable, env),
+        detail: "(Capture with arguments)",
+        kind: :function,
+        label: label(callable),
+        sort_text: "&" <> sort_text(callable)
+      )
+
+    [complete_capture, call_capture]
+  end
+
+  defp callable_snippet(%_{} = callable, %Env{} = env) do
+    argument_names =
+      if Env.pipe?(env) do
+        tl(callable.argument_names)
+      else
+        callable.argument_names
+      end
+
+    argument_templates =
+      argument_names
+      |> Enum.with_index()
+      |> Enum.map_join(", ", fn {name, index} ->
+        escaped_name = String.replace(name, "\\", "\\\\")
+        "${#{index + 1}:#{escaped_name}}"
+      end)
+
+    "#{callable.name}(#{argument_templates})"
+  end
+
+  defp sort_text(%_{name: name, arity: arity}) do
+    normalized = String.replace(name, "__", "")
+    "#{normalized}/#{arity}"
+  end
+
+  defp label(%_{name: name, argument_names: argument_names}) do
+    arg_detail = Enum.join(argument_names, ", ")
+    "#{name}(#{arg_detail})"
+  end
+
+  defp name_and_arity(%_{name: name, arity: arity}) do
+    "#{name}/#{arity}"
+  end
+end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/function.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/function.ex
@@ -2,92 +2,15 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Function do
   alias Lexical.RemoteControl.Completion.Result
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
+  alias Lexical.Server.CodeIntelligence.Completion.Translations.Callable
 
   use Translatable.Impl, for: Result.Function
 
   def translate(%Result.Function{} = function, _builder, %Env{} = env) do
     if Env.function_capture?(env) do
-      function_capture_completions(function, env)
+      Callable.capture_completions(function, env)
     else
-      function_call_completion(function, env)
+      Callable.completion(function, env)
     end
-  end
-
-  defp function_capture_completions(%Result.Function{} = function, %Env{} = env) do
-    name_and_arity = name_and_arity(function)
-
-    complete_capture =
-      Env.plain_text(env, name_and_arity,
-        detail: "(Capture)",
-        kind: :function,
-        label: name_and_arity,
-        sort_text: "&" <> sort_text(function)
-      )
-
-    call_capture =
-      Env.snippet(env, function_snippet(function, env),
-        detail: "(Capture with arguments)",
-        kind: :function,
-        label: function_label(function),
-        sort_text: "&" <> sort_text(function)
-      )
-
-    [complete_capture, call_capture]
-  end
-
-  defp function_call_completion(%Result.Function{} = function, %Env{} = env) do
-    add_args? = not String.contains?(env.suffix, "(")
-
-    insert_text =
-      if add_args? do
-        function_snippet(function, env)
-      else
-        function.name
-      end
-
-    tags =
-      if Map.get(function.metadata, :deprecated) do
-        [:deprecated]
-      end
-
-    Env.snippet(env, insert_text,
-      kind: :function,
-      label: function_label(function),
-      sort_text: sort_text(function),
-      tags: tags
-    )
-  end
-
-  defp function_snippet(%Result.Function{} = function, %Env{} = env) do
-    argument_names =
-      if Env.pipe?(env) do
-        tl(function.argument_names)
-      else
-        function.argument_names
-      end
-
-    argument_templates =
-      argument_names
-      |> Enum.with_index()
-      |> Enum.map_join(", ", fn {name, index} ->
-        escaped_name = String.replace(name, "\\", "\\\\")
-        "${#{index + 1}:#{escaped_name}}"
-      end)
-
-    "#{function.name}(#{argument_templates})"
-  end
-
-  defp sort_text(%Result.Function{} = function) do
-    normalized = String.replace(function.name, "__", "")
-    "#{normalized}/#{function.arity}"
-  end
-
-  defp function_label(%Result.Function{} = function) do
-    arg_detail = Enum.join(function.argument_names, ", ")
-    "#{function.name}(#{arg_detail})"
-  end
-
-  defp name_and_arity(%Result.Function{} = function) do
-    "#{function.name}/#{function.arity}"
   end
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
@@ -2,6 +2,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
   alias Lexical.RemoteControl.Completion.Result
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
+  alias Lexical.Server.CodeIntelligence.Completion.Translations.Callable
 
   use Translatable.Impl, for: Result.Macro
 
@@ -444,17 +445,9 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     :skip
   end
 
-  def translate(%Result.Macro{name: name} = macro, builder, env)
+  def translate(%Result.Macro{name: name} = macro, _builder, env)
       when name not in @snippet_macros do
-    label = "#{macro.name}/#{macro.arity}"
-    sort_text = String.replace(label, "__", "")
-
-    builder.plain_text(env, label,
-      detail: macro.spec,
-      kind: :function,
-      sort_text: sort_text,
-      label: label
-    )
+    Callable.completion(macro, env)
   end
 
   def translate(%Result.Macro{}, _builder, _env) do

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
@@ -545,6 +545,63 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
     end
   end
 
+  describe "normal macro completion" do
+    test "completes imported macros", %{project: project} do
+      source = ~q[
+        import Project.Macros
+
+        macro_a|
+      ]
+
+      assert {:ok, completion} =
+               project
+               |> complete(source)
+               |> fetch_completion(kind: :function)
+
+      assert completion.kind == :function
+      assert completion.insert_text_format == :snippet
+      assert completion.label == "macro_add(a, b)"
+      assert completion.insert_text == "macro_add(${1:a}, ${2:b})"
+    end
+
+    test "completes required macros", %{project: project} do
+      source = ~q[
+        require Project.Macros
+
+        Project.Macros.macro_a|
+      ]
+
+      assert {:ok, completion} =
+               project
+               |> complete(source)
+               |> fetch_completion(kind: :function)
+
+      assert completion.kind == :function
+      assert completion.insert_text_format == :snippet
+      assert completion.label == "macro_add(a, b)"
+      assert completion.insert_text == "macro_add(${1:a}, ${2:b})"
+    end
+
+    test "completes aliased macros", %{project: project} do
+      source = ~q[
+        alias Project.Macros
+        require Macros
+
+        Macros.macro_a|
+      ]
+
+      assert {:ok, completion} =
+               project
+               |> complete(source)
+               |> fetch_completion(kind: :function)
+
+      assert completion.kind == :function
+      assert completion.insert_text_format == :snippet
+      assert completion.label == "macro_add(a, b)"
+      assert completion.insert_text == "macro_add(${1:a}, ${2:b})"
+    end
+  end
+
   describe "sort_text" do
     test "dunder macros have the dunder removed in their sort_text", %{project: project} do
       assert {:ok, completion} =


### PR DESCRIPTION
We spent a bunch of time working on function completions in a variety of cases, but macro completions still were quite primitive, only completing with the name and arity, which is almost never what you want.

This refactors the logic for building these completions into a `Callable` module so both macros and functions can share their behavior.

Fixes #136