### PR TITLE
Handled Cancel Notifications

### DIFF
--- a/apps/server/lib/lexical/server.ex
+++ b/apps/server/lib/lexical/server.ex
@@ -89,7 +89,12 @@ defmodule Lexical.Server do
   end
 
   def handle_message(%Requests.Cancel{} = cancel_request, %State{} = state) do
-    Provider.Queue.cancel(to_string(cancel_request.id))
+    Provider.Queue.cancel(cancel_request)
+    {:ok, state}
+  end
+
+  def handle_message(%Notifications.Cancel{} = cancel_notification, %State{} = state) do
+    Provider.Queue.cancel(cancel_notification)
     {:ok, state}
   end
 

--- a/apps/server/lib/lexical/server/provider/queue.ex
+++ b/apps/server/lib/lexical/server/provider/queue.ex
@@ -166,6 +166,10 @@ defmodule Lexical.Server.Provider.Queue do
     GenServer.call(__MODULE__, :size)
   end
 
+  def cancel(%{lsp: %{id: id}}) do
+    cancel(id)
+  end
+
   def cancel(%{id: request_id}) do
     cancel(request_id)
   end


### PR DESCRIPTION
I switched to lsp-mode, which sends us cancel _notifications_ which are a thing, and we weren't handling them at all.

Fixes #155 