### PR TITLE
Addressed deadlocks in Document Store

### DIFF
--- a/apps/server/lib/lexical/server.ex
+++ b/apps/server/lib/lexical/server.ex
@@ -20,7 +20,7 @@ defmodule Lexical.Server do
     Requests.Shutdown
   ]
 
-  @dialyzer {:nowarn_function, apply_to_state: 2}
+  @dialyzer {:nowarn_function, handle_cast: 2}
 
   @spec response_complete(Requests.request(), Responses.response()) :: :ok
   def response_complete(request, response) do
@@ -46,6 +46,9 @@ defmodule Lexical.Server do
   def handle_cast({:protocol_message, message}, %State{} = state) do
     new_state =
       case handle_message(message, state) do
+        :ok ->
+          state
+
         {:ok, new_state} ->
           new_state
 
@@ -100,26 +103,12 @@ defmodule Lexical.Server do
 
   def handle_message(%message_module{} = message, %State{} = state)
       when message_module in @server_specific_messages do
-    case apply_to_state(state, message) do
-      {:ok, _} = success ->
-        success
-
-      error ->
-        error("Failed to handle #{message.__struct__}, #{inspect(error)}")
-    end
+    State.apply(state, message)
   end
 
   def handle_message(request, %State{} = state) do
     Provider.Queue.add(request, state.configuration)
 
     {:ok, %State{} = state}
-  end
-
-  defp apply_to_state(%State{} = state, %{} = request_or_notification) do
-    case State.apply(state, request_or_notification) do
-      {:ok, new_state} -> {:ok, new_state}
-      :ok -> {:ok, state}
-      error -> {error, state}
-    end
   end
 end


### PR DESCRIPTION
I was getting sporadic deadlocks in the document store since I moved to lsp-mode (it sends a *lot* more didChange updates than eglot), so I'm trying moving writes out of the genserver to see if that helps (it seems to).

I also noticed some troubling messages about not being able to apply didChange events, but that was due to an incorrect log message in the server state, which is also fixed here.