### PR TITLE
Fixed infinite loop in document updates

### DIFF
--- a/apps/common/lib/lexical/document/store.ex
+++ b/apps/common/lib/lexical/document/store.ex
@@ -2,8 +2,8 @@ defmodule Lexical.Document.Store do
   @moduledoc """
   A backing store for source file documents
 
-  This implementation stores documents in a public ETS table. Since documents are versioned, it's OK if we get writes
-  out of order, as they'll be rejected if the versions don't match up.
+  This implementation stores documents in ETS, and partitions read and write operations. Read operations are served
+  immediately by querying the ETS table, while writes go through a GenServer process (which is the owner of the ETS table).
   """
   defmodule State do
     alias Lexical.Document
@@ -15,13 +15,7 @@ defmodule Lexical.Document.Store do
     @table_name Document.Store
 
     def new do
-      :ets.new(@table_name, [
-        :named_table,
-        :set,
-        :public,
-        read_concurrency: true,
-        write_concurrency: true
-      ])
+      :ets.new(@table_name, [:named_table, :set, :protected, read_concurrency: true])
 
       %__MODULE__{}
     end
@@ -76,21 +70,21 @@ defmodule Lexical.Document.Store do
       end
     end
 
-    def get_and_update(uri, updater_fn) do
+    def get_and_update(%__MODULE__{} = store, uri, updater_fn) do
       with {:ok, document} <- fetch(uri),
            {:ok, updated_source} <- updater_fn.(document) do
         ets_put(uri, :sources, updated_source)
 
-        {:ok, updated_source}
+        {:ok, updated_source, store}
       else
         error ->
           normalize_error(error)
       end
     end
 
-    def update(uri, updater_fn) do
-      with {:ok, _} <- get_and_update(uri, updater_fn) do
-        :ok
+    def update(%__MODULE__{} = store, uri, updater_fn) do
+      with {:ok, _, new_store} <- get_and_update(store, uri, updater_fn) do
+        {:ok, new_store}
       end
     end
 
@@ -246,12 +240,12 @@ defmodule Lexical.Document.Store do
 
   @spec get_and_update(Lexical.uri(), updater()) :: {:ok, Document.t()} | {:error, any()}
   def get_and_update(uri, update_fn) do
-    State.get_and_update(uri, update_fn)
+    GenServer.call(__MODULE__, {:get_and_update, uri, update_fn})
   end
 
   @spec update(Lexical.uri(), updater()) :: :ok | {:error, any()}
   def update(uri, update_fn) do
-    State.update(uri, update_fn)
+    GenServer.call(__MODULE__, {:update, uri, update_fn})
   end
 
   def start_link(_) do
@@ -302,6 +296,26 @@ defmodule Lexical.Document.Store do
   def handle_call({:close, uri}, _from, %State{} = state) do
     {reply, new_state} =
       case State.close(state, uri) do
+        {:ok, _} = success -> success
+        error -> {error, state}
+      end
+
+    {:reply, reply, new_state}
+  end
+
+  def handle_call({:get_and_update, uri, update_fn}, _from, %State{} = state) do
+    {reply, new_state} =
+      case State.get_and_update(state, uri, update_fn) do
+        {:ok, updated_source, new_state} -> {{:ok, updated_source}, new_state}
+        error -> {error, state}
+      end
+
+    {:reply, reply, new_state}
+  end
+
+  def handle_call({:update, uri, updater_fn}, _, %State{} = state) do
+    {reply, new_state} =
+      case State.update(state, uri, updater_fn) do
         {:ok, _} = success -> success
         error -> {error, state}
       end

--- a/apps/protocol/lib/lexical/protocol/convertibles/lexical.protocol.types.text_document.content_change_event1.ex
+++ b/apps/protocol/lib/lexical/protocol/convertibles/lexical.protocol.types.text_document.content_change_event1.ex
@@ -1,0 +1,13 @@
+alias Lexical.Convertible
+alias Lexical.Document.Edit
+alias Lexical.Protocol.Types.TextDocument.ContentChangeEvent
+
+defimpl Convertible, for: ContentChangeEvent.TextDocumentContentChangeEvent1 do
+  def to_lsp(event, _context_document) do
+    {:ok, event}
+  end
+
+  def to_native(%ContentChangeEvent.TextDocumentContentChangeEvent1{} = event, _context_document) do
+    {:ok, Edit.new(event.text)}
+  end
+end

--- a/apps/protocol/test/lexical/protocol/convertibles/lexical.protocol.types.text_document.content_change_event1_test.exs
+++ b/apps/protocol/test/lexical/protocol/convertibles/lexical.protocol.types.text_document.content_change_event1_test.exs
@@ -1,0 +1,28 @@
+defmodule Lexical.Protocol.Convertibles.ContentChangeEvent.TextDocumentContentChangeEvent1Test do
+  alias Lexical.Protocol.Types.TextDocument.ContentChangeEvent.TextDocumentContentChangeEvent1,
+    as: TextOnlyEvent
+
+  use Lexical.Test.Protocol.ConvertibleSupport
+
+  describe "to_lsp/2)" do
+    setup [:with_an_open_file]
+
+    test "is a no-op", %{uri: uri} do
+      native_text_edit = TextOnlyEvent.new(text: "hi")
+      assert {:ok, ^native_text_edit} = to_lsp(native_text_edit, uri)
+    end
+  end
+
+  describe "to_native/2" do
+    setup [:with_an_open_file]
+
+    test "converts to a single replace edit", %{uri: uri} do
+      replacement_text = "This is the replacement text"
+      event = TextOnlyEvent.new(text: replacement_text)
+      {:ok, %Document.Edit{} = converted} = to_native(event, uri)
+
+      assert converted.text == replacement_text
+      assert converted.range == nil
+    end
+  end
+end

--- a/apps/server/lib/lexical/server.ex
+++ b/apps/server/lib/lexical/server.ex
@@ -20,7 +20,7 @@ defmodule Lexical.Server do
     Requests.Shutdown
   ]
 
-  @dialyzer {:nowarn_function, handle_cast: 2}
+  @dialyzer {:nowarn_function, apply_to_state: 2}
 
   @spec response_complete(Requests.request(), Responses.response()) :: :ok
   def response_complete(request, response) do
@@ -46,9 +46,6 @@ defmodule Lexical.Server do
   def handle_cast({:protocol_message, message}, %State{} = state) do
     new_state =
       case handle_message(message, state) do
-        :ok ->
-          state
-
         {:ok, new_state} ->
           new_state
 
@@ -103,7 +100,13 @@ defmodule Lexical.Server do
 
   def handle_message(%message_module{} = message, %State{} = state)
       when message_module in @server_specific_messages do
-    State.apply(state, message)
+    case apply_to_state(state, message) do
+      {:ok, _} = success ->
+        success
+
+      error ->
+        error("Failed to handle #{message.__struct__}, #{inspect(error)}")
+    end
   end
 
   def handle_message(nil, %State{} = state) do
@@ -116,5 +119,13 @@ defmodule Lexical.Server do
     Provider.Queue.add(request, state.configuration)
 
     {:ok, state}
+  end
+
+  defp apply_to_state(%State{} = state, %{} = request_or_notification) do
+    case State.apply(state, request_or_notification) do
+      {:ok, new_state} -> {:ok, new_state}
+      :ok -> {:ok, state}
+      error -> {error, state}
+    end
   end
 end

--- a/apps/server/lib/lexical/server/transport/std_io.ex
+++ b/apps/server/lib/lexical/server/transport/std_io.ex
@@ -48,6 +48,12 @@ defmodule Lexical.Server.Transport.StdIO do
     IO.binwrite(io_device, message)
   end
 
+  def write(_, nil) do
+  end
+
+  def write(_, []) do
+  end
+
   def log(level, message, opts \\ [])
 
   def log(level, message, opts) when level in [:error, :warning, :info, :log] do

--- a/apps/server/test/document_test.exs
+++ b/apps/server/test/document_test.exs
@@ -4,6 +4,12 @@ defmodule Lexical.DocumentTest do
   alias Lexical.Protocol.Types.Range
   alias Lexical.Protocol.Types.TextEdit
 
+  alias Lexical.Protocol.Types.TextDocument.ContentChangeEvent.TextDocumentContentChangeEvent,
+    as: RangedContentChange
+
+  alias Lexical.Protocol.Types.TextDocument.ContentChangeEvent.TextDocumentContentChangeEvent1,
+    as: TextOnlyContentChange
+
   use ExUnit.Case
   use ExUnitProperties
 
@@ -62,6 +68,24 @@ defmodule Lexical.DocumentTest do
       assert {:ok, "end"} = fetch_text_at(parsed, 7)
 
       assert :error = fetch_text_at(parsed, 8)
+    end
+  end
+
+  describe "applying protocol content change events" do
+    test "applying a text only change replaces all the test" do
+      {:ok, doc} = run_changes("hello", [TextOnlyContentChange.new(text: "goodbye")])
+      assert "goodbye" = text(doc)
+    end
+
+    test "applying a range event replaces the range" do
+      range_change =
+        RangedContentChange.new(
+          range: new_range(0, 6, 1, 0),
+          text: "people"
+        )
+
+      {:ok, doc} = run_changes("hello there", [range_change])
+      assert "hello people" == text(doc)
     end
   end
 


### PR DESCRIPTION
After I switched to lsp-mode, my editor was hanging whenever I would update a file using git, and never when I made changes to it in the editor itself. This is because, unlike eglot, when lsp-mode detects a file system change, it sends the entire document over as a replace update, and not an update with many text edits. This would cause the document to go into an infinite loop, and the request would never end, and lexical would become unresponsive.

The reason for this is that the ContentChangeEvent is a type alias with multiple types, one with just a "text" key and one with "text" and a "range" key. The version with a "text" and "range"" key were properly converted to a native Edit by the `Any` convertible implementation, but the version with just the text wasn't properly converted, but the conversion succeeded because the `Any` code thought it had converted it properly. The solution is to give a `Convertible` implementation to the specific `ContentChangeEvent` and have that just build a simple edit.

I also think that the "deadlocks" I was experiencing prior were due to this bug, and I'm going to back out those changes, as they'll yield a more correct codebase.

This is what I get for fixing a problem without actually understanding it first.