### PR TITLE
Don't crash if env contains no words

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion.ex
@@ -66,7 +66,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
           )
         ]
 
-      String.length(Env.last_word(env)) == 1 ->
+      is_nil(Env.last_word(env)) || String.length(Env.last_word(env)) == 1 ->
         Completion.List.new(items: [], is_incomplete: true)
 
       true ->


### PR DESCRIPTION
VSCode will send  no words if you just hit `ctrl+space` on an empty line, which crashes the completions.  This fixes it.  I'm not entirely sure how to write a test for this, as when I tried `assert complete(project, "|") ...` it returned `{:error, :out_of_bounds}`...