### PR TITLE
Removed string-based completion env operations

### DIFF
--- a/apps/common/lib/lexical/completion/environment.ex
+++ b/apps/common/lib/lexical/completion/environment.ex
@@ -11,7 +11,6 @@ defmodule Lexical.Completion.Environment do
   @callback in_context?(t, context_type) :: boolean
 
   @callback empty?(maybe_binary) :: boolean
-  @callback last_word(t) :: String.t()
   @callback prefix_tokens(t) :: [lexer_token]
   @callback prefix_tokens(t, token_count) :: [lexer_token]
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion.ex
@@ -103,6 +103,9 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
       :none ->
         false
 
+      {:alias, name} ->
+        length(name) > 1
+
       {:unquoted_atom, name} ->
         length(name) > 1
 

--- a/apps/server/lib/lexical/server/code_intelligence/completion/env.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/env.ex
@@ -17,7 +17,6 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Env do
     :prefix,
     :suffix,
     :position,
-    :words,
     :zero_based_character
   ]
 
@@ -27,7 +26,6 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Env do
           prefix: String.t(),
           suffix: String.t(),
           position: Lexical.Document.Position.t(),
-          words: [String.t()],
           zero_based_character: non_neg_integer()
         }
 
@@ -36,10 +34,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Env do
     case Document.fetch_text_at(document, cursor_position.line) do
       {:ok, line} ->
         zero_based_character = cursor_position.character - 1
-        graphemes = String.graphemes(line)
-        prefix = graphemes |> Enum.take(zero_based_character) |> IO.iodata_to_binary()
+        prefix = String.slice(line, 0, zero_based_character)
         suffix = String.slice(line, zero_based_character..-1)
-        words = String.split(prefix)
 
         {:ok,
          %__MODULE__{
@@ -49,7 +45,6 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Env do
            prefix: prefix,
            project: project,
            suffix: suffix,
-           words: words,
            zero_based_character: zero_based_character
          }}
 
@@ -206,11 +201,6 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Env do
 
   def empty?(string) when is_binary(string) do
     String.trim(string) == ""
-  end
-
-  @impl Environment
-  def last_word(%__MODULE__{} = env) do
-    List.last(env.words)
   end
 
   @behaviour Builder

--- a/apps/server/lib/lexical/server/code_intelligence/completion/env.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/env.ex
@@ -31,26 +31,36 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Env do
 
   @behaviour Environment
   def new(%Project{} = project, %Document{} = document, %Position{} = cursor_position) do
-    case Document.fetch_text_at(document, cursor_position.line) do
-      {:ok, line} ->
-        zero_based_character = cursor_position.character - 1
-        prefix = String.slice(line, 0, zero_based_character)
-        suffix = String.slice(line, zero_based_character..-1)
+    zero_based_character = cursor_position.character - 1
 
-        {:ok,
-         %__MODULE__{
-           document: document,
-           line: line,
-           position: cursor_position,
-           prefix: prefix,
-           project: project,
-           suffix: suffix,
-           zero_based_character: zero_based_character
-         }}
+    env =
+      case Document.fetch_text_at(document, cursor_position.line) do
+        {:ok, line} ->
+          prefix = String.slice(line, 0, zero_based_character)
+          suffix = String.slice(line, zero_based_character..-1)
 
-      _ ->
-        {:error, :out_of_bounds}
-    end
+          %__MODULE__{
+            document: document,
+            line: line,
+            position: cursor_position,
+            prefix: prefix,
+            project: project,
+            suffix: suffix,
+            zero_based_character: zero_based_character
+          }
+
+        _ ->
+          %__MODULE__{
+            document: document,
+            line: "",
+            position: cursor_position,
+            prefix: "",
+            suffix: "",
+            zero_based_character: zero_based_character
+          }
+      end
+
+    {:ok, env}
   end
 
   @impl Environment

--- a/apps/server/lib/lexical/server/code_intelligence/completion/env.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/env.ex
@@ -33,34 +33,26 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Env do
   def new(%Project{} = project, %Document{} = document, %Position{} = cursor_position) do
     zero_based_character = cursor_position.character - 1
 
-    env =
-      case Document.fetch_text_at(document, cursor_position.line) do
-        {:ok, line} ->
-          prefix = String.slice(line, 0, zero_based_character)
-          suffix = String.slice(line, zero_based_character..-1)
+    case Document.fetch_text_at(document, cursor_position.line) do
+      {:ok, line} ->
+        prefix = String.slice(line, 0, zero_based_character)
+        suffix = String.slice(line, zero_based_character..-1)
 
-          %__MODULE__{
-            document: document,
-            line: line,
-            position: cursor_position,
-            prefix: prefix,
-            project: project,
-            suffix: suffix,
-            zero_based_character: zero_based_character
-          }
+        env = %__MODULE__{
+          document: document,
+          line: line,
+          position: cursor_position,
+          prefix: prefix,
+          project: project,
+          suffix: suffix,
+          zero_based_character: zero_based_character
+        }
 
-        _ ->
-          %__MODULE__{
-            document: document,
-            line: "",
-            position: cursor_position,
-            prefix: "",
-            suffix: "",
-            zero_based_character: zero_based_character
-          }
-      end
+        {:ok, env}
 
-    {:ok, env}
+      _ ->
+        {:error, {:out_of_bounds, cursor_position}}
+    end
   end
 
   @impl Environment

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct.ex
@@ -2,33 +2,39 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Struct do
   alias Lexical.RemoteControl.Completion.Result
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
+  alias Lexical.Server.CodeIntelligence.Completion.Translations
 
   use Translatable.Impl, for: Result.Struct
 
   def translate(%Result.Struct{} = struct, builder, %Env{} = env) do
-    struct_reference? = Env.in_context?(env, :struct_reference)
+    if Env.in_context?(env, :struct_reference) do
+      completion(env, builder, struct.name)
+    else
+      Translations.ModuleOrBehaviour.completion(
+        env,
+        builder,
+        struct.name
+      )
+    end
+  end
 
-    add_curlies? = add_curlies?(env)
+  def completion(%Env{} = env, builder, struct_name) do
+    builder_opts = [
+      kind: :struct,
+      detail: "#{struct_name} (Struct)",
+      label: "%#{struct_name}"
+    ]
+
+    range = edit_range(env)
 
     insert_text =
-      if add_percent?(env) do
-        "%" <> struct.name
+      if add_curlies?(env) do
+        struct_name <> "{$1}"
       else
-        struct.name
+        struct_name
       end
 
-    builder_opts =
-      if struct_reference? do
-        [kind: :struct, detail: "#{struct.name} (Struct)", label: "%#{struct.name}"]
-      else
-        [kind: :module, detail: "#{struct.name} (Module)", label: struct.name]
-      end
-
-    if add_curlies? do
-      builder.snippet(env, insert_text <> "{$1}", builder_opts)
-    else
-      builder.plain_text(env, insert_text, builder_opts)
-    end
+    builder.text_edit_snippet(env, insert_text, range, builder_opts)
   end
 
   def add_curlies?(%Env{} = env) do
@@ -71,38 +77,40 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Struct do
     end
   end
 
-  def struct_details(%Env{} = env) do
-    if Env.in_context?(env, :struct_reference) do
-      add_curlies? = not String.contains?(env.suffix, "{")
+  defp edit_range(%Env{} = env) do
+    prefix_end = env.position.character
 
-      # A leading percent is added only if the struct reference is to a top-level struct.
-      # If it's for a child struct (e.g. %Types.Range) then adding a percent at "Range"
-      # will be syntactically invalid and get us `%Types.%Range{}`
+    edit_begin =
+      case Code.Fragment.cursor_context(env.prefix) do
+        {:struct, {:dot, {:alias, _typed_module}, _rest}} ->
+          prefix_end
 
-      struct_module_name =
-        case Code.Fragment.cursor_context(env.prefix) do
-          {:struct, {:dot, {:alias, module_name}, []}} ->
-            '#{module_name}.'
+        {:struct, typed_module_name} ->
+          edit_begin =
+            case left_offset_of(typed_module_name, ?.) do
+              {:ok, offset} ->
+                env.position.character - offset
 
-          {:struct, module_name} ->
-            module_name
+              :error ->
+                env.position.character - length(typed_module_name)
+            end
 
-          {:dot, {:alias, module_name}, _} ->
-            module_name
+          edit_begin
+      end
 
-          _ ->
-            ''
-        end
+    {edit_begin, env.position.character}
+  end
 
-      contains_period? =
-        struct_module_name
-        |> List.to_string()
-        |> String.contains?(".")
+  defp left_offset_of(string, character) do
+    string
+    |> Enum.reverse()
+    |> Enum.with_index()
+    |> Enum.reduce_while(:error, fn
+      {^character, index}, _ ->
+        {:halt, {:ok, index}}
 
-      add_percent? = not contains_period?
-      {add_curlies?, add_percent?}
-    else
-      {false, false}
-    end
+      _, acc ->
+        {:cont, acc}
+    end)
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
@@ -7,7 +7,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
     test "do/end only has a single completion", %{project: project} do
       assert assert [completion] = complete(project, "def my_thing do|")
       assert completion.insert_text == "do\n$0\nend"
-      assert completion.label == "do/end"
+      assert completion.label == "do/end block"
     end
 
     test "def only has a single completion", %{project: project} do

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/module_or_behaviour_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/module_or_behaviour_test.exs
@@ -93,6 +93,49 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
       assert completion.detail == "User (Struct)"
     end
 
+    test "a completion with curlies in the suffix should not have them added", %{project: project} do
+      source = ~q[
+        def my_thing(%Project.Structs.A|{}) do
+      end
+      ]
+
+      assert {:ok, completion} =
+               project
+               |> complete(source)
+               |> fetch_completion(kind: :struct)
+
+      assert completion.insert_text == "Account"
+    end
+
+    test "A module without a dot should have a percent added", %{project: project} do
+      source = ~q[
+        alias Project.Structs.Account
+        def my_thing(%A|) do
+      ]
+
+      assert {:ok, completion} =
+               project
+               |> complete(source)
+               |> fetch_completion(kind: :struct)
+
+      assert completion.label == "%Account"
+      assert completion.insert_text == "%Account{$1}"
+    end
+
+    test "A module with a dot in it should not have a percent added", %{project: project} do
+      source = ~q[
+        def my_thing(%Project.Structs.A|) do
+      ]
+
+      assert {:ok, completion} =
+               project
+               |> complete(source)
+               |> fetch_completion(kind: :struct)
+
+      assert completion.label == "%Account"
+      assert completion.insert_text == "Account{$1}"
+    end
+
     test "modules that define a struct should not emit curlies if they're already present", %{
       project: project
     } do

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/module_or_behaviour_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/module_or_behaviour_test.exs
@@ -71,8 +71,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
 
       assert completion.insert_text_format == :snippet
       assert completion.label == "%MapSet"
-      assert completion.insert_text == "%MapSet{$1}"
       assert completion.detail == "MapSet (Struct)"
+      assert apply_completion(completion) == "%MapSet{$1}\n"
     end
 
     test "modules that define a struct should emit curlies if in a struct reference", %{
@@ -84,13 +84,19 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
         end
       ]
 
+      expected = ~q[
+        alias Project.Structs
+        def my_thing(%Structs.User{$1}) do
+        end
+      ]
+
       assert {:ok, completion} =
                project
                |> complete(source)
                |> fetch_completion(kind: :struct)
 
-      assert completion.insert_text == "User{$1}"
       assert completion.detail == "User (Struct)"
+      assert apply_completion(completion) == expected
     end
 
     test "a completion with curlies in the suffix should not have them added", %{project: project} do
@@ -99,12 +105,17 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
       end
       ]
 
+      expected = ~q[
+        def my_thing(%Project.Structs.Account{}) do
+      end
+      ]
+
       assert {:ok, completion} =
                project
                |> complete(source)
                |> fetch_completion(kind: :struct)
 
-      assert completion.insert_text == "Account"
+      assert apply_completion(completion) == expected
     end
 
     test "A module without a dot should have a percent added", %{project: project} do
@@ -113,18 +124,9 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
         def my_thing(%A|) do
       ]
 
-      assert {:ok, completion} =
-               project
-               |> complete(source)
-               |> fetch_completion(kind: :struct)
-
-      assert completion.label == "%Account"
-      assert completion.insert_text == "%Account{$1}"
-    end
-
-    test "A module with a dot in it should not have a percent added", %{project: project} do
-      source = ~q[
-        def my_thing(%Project.Structs.A|) do
+      expected = ~q[
+        alias Project.Structs.Account
+        def my_thing(%Account{$1}) do
       ]
 
       assert {:ok, completion} =
@@ -133,7 +135,25 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
                |> fetch_completion(kind: :struct)
 
       assert completion.label == "%Account"
-      assert completion.insert_text == "Account{$1}"
+      assert apply_completion(completion) == expected
+    end
+
+    test "A module with a dot in it should not have a percent added", %{project: project} do
+      source = ~q[
+        def my_thing(%Project.Structs.A|) do
+      ]
+
+      expected = ~q[
+        def my_thing(%Project.Structs.Account{$1}) do
+      ]
+
+      assert {:ok, completion} =
+               project
+               |> complete(source)
+               |> fetch_completion(kind: :struct)
+
+      assert completion.label == "%Account"
+      assert apply_completion(completion) == expected
     end
 
     test "modules that define a struct should not emit curlies if they're already present", %{
@@ -145,13 +165,19 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
       end
       ]
 
+      expected = ~q[
+      alias Project.Structs
+      def my_thing(%Structs.User{}) do
+      end
+      ]
+
       assert {:ok, completion} =
                project
                |> complete(source)
                |> fetch_completion(kind: :struct)
 
-      assert completion.insert_text == "User"
       assert completion.detail == "User (Struct)"
+      assert apply_completion(completion) == expected
     end
 
     test "should offer no other types of completions", %{project: project} do

--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -43,6 +43,20 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
     refute [] == complete(project, "Project.|")
   end
 
+  describe "single character completions" do
+    test "completes elixir modules", %{project: project} do
+      assert [_ | _] = completions = complete(project, "E|")
+
+      for completion <- completions do
+        assert completion.kind == :module
+      end
+    end
+
+    test "ignores erlang modules", %{project: project} do
+      assert %Completion.List{is_incomplete: true, items: []} = complete(project, ":e|")
+    end
+  end
+
   describe "ignoring things" do
     test "return empty items and mark is_incomplete when single character contexts", %{
       project: project
@@ -55,11 +69,6 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
 
     test "returns an incomplete completion list when the context is empty", %{project: project} do
       assert %Completion.List{is_incomplete: true, items: []} = complete(project, " ")
-    end
-
-    test "ignores a completion of one character", %{project: project} do
-      assert %Completion.List{is_incomplete: true, items: []} = complete(project, "E|")
-      assert %Completion.List{is_incomplete: true, items: []} = complete(project, ":e|")
     end
   end
 

--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -52,6 +52,17 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
                items: []
              }
     end
+
+    test "returns an incomplete completion list when the context is empty", %{project: project} do
+      assert %Completion.List{is_incomplete: true, items: []} = complete(project, " ")
+    end
+  end
+
+  describe "do/end" do
+    test "returns do/end when the last token is do", %{project: project} do
+      [completion] = complete(project, "for a <- something do|")
+      assert completion.label == "do/end block"
+    end
   end
 
   describe "sort_text" do

--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -56,6 +56,11 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
     test "returns an incomplete completion list when the context is empty", %{project: project} do
       assert %Completion.List{is_incomplete: true, items: []} = complete(project, " ")
     end
+
+    test "ignores a completion of one character", %{project: project} do
+      assert %Completion.List{is_incomplete: true, items: []} = complete(project, "E|")
+      assert %Completion.List{is_incomplete: true, items: []} = complete(project, ":e|")
+    end
   end
 
   describe "do/end" do

--- a/apps/server/test/support/lexical/test/completion_case.ex
+++ b/apps/server/test/support/lexical/test/completion_case.ex
@@ -3,6 +3,7 @@ defmodule Lexical.Test.Server.CompletionCase do
   alias Lexical.Project
   alias Lexical.Protocol.Types.Completion.Context, as: CompletionContext
   alias Lexical.Protocol.Types.Completion.Item, as: CompletionItem
+  alias Lexical.Protocol.Types.Completion.List, as: CompletionList
   alias Lexical.RemoteControl
   alias Lexical.Server
   alias Lexical.Server.CodeIntelligence.Completion
@@ -89,7 +90,16 @@ defmodule Lexical.Test.Server.CompletionCase do
       end)
     end
 
-    case Enum.filter(completions, matcher) do
+    completion_enumerable =
+      case completions do
+        %CompletionList{} = completion_list ->
+          completion_list.items
+
+        list when is_list(list) ->
+          list
+      end
+
+    case Enum.filter(completion_enumerable, matcher) do
       [] -> {:error, :not_found}
       [found] -> {:ok, found}
       found when is_list(found) -> {:ok, found}


### PR DESCRIPTION
I was using naive word-based heuristics to decide several things when completions were requested. This PR removes that approach in favor of a syntax-based approach that should be more robust.

FYI @doughsay