### PR TITLE
Fix record missing key's error

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build/error.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/error.ex
@@ -161,9 +161,13 @@ defmodule Lexical.RemoteControl.Build.Error do
 
   def error_to_diagnostic(%ArgumentError{} = argument_error, stack, _quoted_ast) do
     reversed_stack = Enum.reverse(stack)
-    [{_, _, _, context}, {_, maybe_pipe_or_struct, _, _} | _] = reversed_stack
 
-    if maybe_pipe_or_struct in [:|>, :__struct__] do
+    [{_, _, _, context}, {_, call, _, second_to_last_context} | _] = reversed_stack
+
+    maybe_pipe_or_struct? = call in [:|>, :__struct__]
+    expanding_macro? = second_to_last_context[:file] == 'expanding macro'
+
+    if maybe_pipe_or_struct? or expanding_macro? do
       %Diagnostic{
         message: Exception.message(argument_error),
         position: context_to_position(context),

--- a/apps/remote_control/lib/lexical/remote_control/build/error.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/error.ex
@@ -164,10 +164,10 @@ defmodule Lexical.RemoteControl.Build.Error do
 
     [{_, _, _, context}, {_, call, _, second_to_last_context} | _] = reversed_stack
 
-    maybe_pipe_or_struct? = call in [:|>, :__struct__]
+    pipe_or_struct? = call in [:|>, :__struct__]
     expanding_macro? = second_to_last_context[:file] == 'expanding macro'
 
-    if maybe_pipe_or_struct? or expanding_macro? do
+    if pipe_or_struct? or expanding_macro? do
       %Diagnostic{
         message: Exception.message(argument_error),
         position: context_to_position(context),

--- a/apps/remote_control/test/lexical/remote_control/build/error_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/error_test.exs
@@ -417,5 +417,27 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
 
       assert diagnostic.position == 9
     end
+
+    test "handles record missing key's error" do
+      {:exception, exception, stack, quoted_ast} =
+        ~s[
+        defmodule Bar do
+          import Record
+          defrecord :user, name: nil, age: nil
+
+          def bar do
+            u = user(name: "John", email: "")
+          end
+        end
+        ]
+        |> compile()
+
+      diagnostic = Error.error_to_diagnostic(exception, stack, quoted_ast)
+
+      assert diagnostic.message =~
+               "record :user does not have the key: :email"
+
+      assert diagnostic.position == 7
+    end
   end
 end


### PR DESCRIPTION
```elixir
exception #=> %ArgumentError{message: "record :user does not have the key: :email"}

[test/lexical/remote_control/build/error_test.exs:436: Lexical.RemoteControl.Build.ErrorTest."test error_to_
diagnostic/3 handles record missing keys error"/1]
stack #=> [
  {Record, :create, 4, [file: 'lib/record.ex', line: 423]},
  {Bar, :user, 1, [file: 'expanding macro']},
  {Bar, :bar, 0, [file: 'nofile', line: 7]}
]
```

### preview

<img width="602" alt="image" src="https://github.com/lexical-lsp/lexical/assets/12830256/93ac618b-2cd7-48d9-b3de-bb5e37e13453">
