### PR TITLE
Add Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,39 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-JafTtgMDATE8dZOImBhWMA9RCn9AP8FVOpN+9K/tTlg=",
+        "path": "/nix/store/v4alr5pcln6h03406f3s9hd89jkfl13y-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "Reimagined language server for Elixir";
+
+  inputs.nixpkgs.url = "flake:nixpkgs";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        erl = pkgs.beam.packages.erlang;
+      in
+      {
+        packages = rec {
+          lexical = erl.callPackage ./nix/lexical.nix {};
+
+          default = lexical;
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages =
+            [
+              erl.elixir
+            ]
+            ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.darwin.apple_sdk.frameworks.CoreFoundation
+              pkgs.darwin.apple_sdk.frameworks.CoreServices
+            ];
+        };
+      }
+    );
+}

--- a/nix/lexical.nix
+++ b/nix/lexical.nix
@@ -1,0 +1,34 @@
+{ mixRelease
+, fetchMixDeps
+, erlang
+}: mixRelease rec {
+  pname = "lexical";
+  version = "development";
+
+  src = ./..;
+
+  mixFodDeps = fetchMixDeps {
+    inherit pname;
+    inherit version;
+
+    src = ./..;
+
+    sha256 = "sha256-a715z1ti1J0kKzLcIS1UuFpPAMEx2VlFpkmZrRTSWh4=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mix release lexical --no-deps-check --path "$out"
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    for script in $out/releases/*/elixir; do
+      substituteInPlace "$script" --replace 'ERL_EXEC="erl"' 'ERL_EXEC="${erlang}/bin/erl"'
+    done
+
+    wrapProgram $out/bin/lexical --set RELEASE_COOKIE lexical
+  '';
+}


### PR DESCRIPTION
This adds Nix Flake which (almost) allows usage of the Lexical via `nix run github:lexical-lsp/lexical -- version` (~~the "almost" part is that one need to define `RELEASE_COOKIE=/dev/null` beforehand as `releases/COOKIE` file is removed by Nix for now~~ that is resolved). This allows user of Nix to use Lexical in their environment without writing their own derivation (Nix name for package).