### PR TITLE
Fixed code actions / improved code mod api

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -85,7 +85,9 @@ jobs:
         run: mix credo
 
       - name: Compile
-        run: mix compile --warnings-as-errors
+        run: |
+          mix clean
+          mix compile --warnings-as-errors
 
       - name: Maybe create plt files
         if: steps.cache-plt.outputs.cache-hit != 'true'

--- a/apps/remote_control/lib/lexical/remote_control.ex
+++ b/apps/remote_control/lib/lexical/remote_control.ex
@@ -9,7 +9,7 @@ defmodule Lexical.RemoteControl do
   alias Lexical.RemoteControl.ProjectNode
   require Logger
 
-  @allowed_apps ~w(common path_glob remote_control elixir_sense)a
+  @allowed_apps ~w(common path_glob remote_control elixir_sense sourceror)a
 
   @app_globs Enum.map(@allowed_apps, fn app_name -> "/**/#{app_name}*/ebin" end)
 

--- a/apps/remote_control/lib/lexical/remote_control/code_mod/ast.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_mod/ast.ex
@@ -1,5 +1,9 @@
 defmodule Lexical.RemoteControl.CodeMod.Ast do
   alias Lexical.Document
+  alias Lexical.Document.Edit
+  alias Sourceror.Zipper
+
+  require Sourceror
 
   @type t :: any()
 
@@ -14,6 +18,171 @@ defmodule Lexical.RemoteControl.CodeMod.Ast do
   end
 
   defp parse(s) when is_binary(s) do
-    ElixirSense.string_to_quoted(s, 1, 6, token_metadata: true)
+    case Sourceror.string_to_quoted(s, token_metadata: true, columns: true) do
+      {:ok, code, _comments} ->
+        {:ok, code}
+
+      error ->
+        error
+    end
+  end
+
+  def zipper_at(%Document{} = document, %Document.Position{} = position) do
+    with {:ok, ast} <- from(document) do
+      zipper =
+        ast
+        |> Zipper.zip()
+        |> Zipper.find(fn node ->
+          within_range?(node, position)
+        end)
+
+      {:ok, zipper}
+    end
+  end
+
+  def traverse_line(%Document{} = document, line_number, fun) when is_integer(line_number) do
+    range = one_line_range(line_number)
+    traverse_in(document, range, fun)
+  end
+
+  def traverse_line(%Document{} = document, line_number, acc, fun) when is_integer(line_number) do
+    range = one_line_range(line_number)
+    traverse_in(document, range, acc, fun)
+  end
+
+  def patches_to_edits(patches) do
+    maybe_edits =
+      Enum.reduce_while(patches, [], fn patch, edits ->
+        case patch_to_edit(patch) do
+          {:ok, edit} -> {:cont, [edit | edits]}
+          error -> {:halt, error}
+        end
+      end)
+
+    case maybe_edits do
+      edits when is_list(edits) -> {:ok, Enum.reverse(edits)}
+      error -> error
+    end
+  end
+
+  def patch_to_edit(%{change: change, range: %{start: start_pos, end: end_pos}}) do
+    with {:ok, range} <- patch_to_range(start_pos, end_pos) do
+      {:ok, Edit.new(change, range)}
+    end
+  end
+
+  defp patch_to_range(start_pos, end_pos) do
+    with {:ok, start_pos} <- patch_to_position(start_pos),
+         {:ok, end_pos} <- patch_to_position(end_pos) do
+      {:ok, Document.Range.new(start_pos, end_pos)}
+    end
+  end
+
+  defp patch_to_position(patch_keyword) do
+    with {:ok, line} <- Keyword.fetch(patch_keyword, :line),
+         {:ok, column} <- Keyword.fetch(patch_keyword, :column) do
+      {:ok, Document.Position.new(line, column)}
+    end
+  end
+
+  # in the future, I'd like to expose functions that only traverse a section of the document,
+  # but presently, traverse only follows a subtree, so it won't work for our purposes
+  defp traverse_in(%Document{} = document, %Document.Range{} = range, fun) do
+    ignore_acc = fn node, acc ->
+      {fun.(node), acc}
+    end
+
+    case traverse_in(document, range, [], ignore_acc) do
+      {:ok, zipper, _} ->
+        {:ok, zipper}
+
+      error ->
+        error
+    end
+  end
+
+  defp traverse_in(%Document{} = document, %Document.Range{} = range, acc, fun) do
+    with {:ok, zipper} <- zipper_at(document, range.start) do
+      {zipper, {_position, acc}} =
+        Zipper.traverse_while(zipper, {{0, 0}, acc}, fn
+          {node, _} = zipper, {last_position, acc} ->
+            current_position = node_position(node, last_position)
+
+            if within_range?(current_position, range) do
+              {zipper, new_acc} = fun.(zipper, acc)
+
+              {:cont, zipper, {current_position, new_acc}}
+            else
+              {:skip, zipper, {current_position, acc}}
+            end
+        end)
+
+      {:ok, zipper, acc}
+    end
+  end
+
+  defp within_range?({current_line, current_column}, %Document.Range{} = range) do
+    start_pos = %Document.Position{} = range.start
+    end_pos = %Document.Position{} = range.end
+
+    cond do
+      current_line == start_pos.line ->
+        current_column >= start_pos.character
+
+      current_line == end_pos.line ->
+        current_column <= end_pos.character
+
+      true ->
+        current_line >= start_pos.line and current_line <= end_pos.line
+    end
+  end
+
+  defp within_range?(node, %Document.Position{} = position) do
+    line = get_line(node, 0)
+    column = get_column(node, 0)
+
+    line >= position.line and column >= position.character
+  end
+
+  defp one_line_range(line_number) do
+    start_pos = Document.Position.new(line_number, 1)
+    end_pos = Document.Position.new(line_number + 1, 0)
+    Document.Range.new(start_pos, end_pos)
+  end
+
+  defp node_position(node, {line, column}) do
+    {get_line(node, line), get_column(node, column)}
+  end
+
+  defp get_line([{:do, node}], default) do
+    get_line(node, default)
+  end
+
+  defp get_line({:do, node}, default) do
+    get_line(node, default)
+  end
+
+  defp get_line(node, default) when is_tuple(node) and tuple_size(node) == 3 do
+    Sourceror.get_line(node, default)
+  end
+
+  defp get_line(_, default) do
+    default
+  end
+
+  defp get_column([do: node], default) do
+    get_column(node, default)
+  end
+
+  defp get_column({:do, node}, default) do
+    get_column(node, default)
+  end
+
+  defp get_column(node, default) when is_tuple(node) and tuple_size(node) == 3 do
+    Sourceror.get_column(node, default)
+  end
+
+  defp get_column(_, default) do
+    default
   end
 end

--- a/apps/remote_control/mix.exs
+++ b/apps/remote_control/mix.exs
@@ -42,9 +42,10 @@ defmodule Lexical.RemoteControl.MixProject do
   defp deps do
     [
       {:common, in_umbrella: true},
-      {:path_glob, "~> 0.2", optional: true},
       {:elixir_sense, git: "https://github.com/elixir-lsp/elixir_sense.git"},
-      {:patch, "~> 0.12", only: [:dev, :test], optional: true, runtime: false}
+      {:patch, "~> 0.12", only: [:dev, :test], optional: true, runtime: false},
+      {:path_glob, "~> 0.2", optional: true},
+      {:sourceror, "~> 0.12"}
     ]
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/code_mod/ast_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_mod/ast_test.exs
@@ -1,0 +1,79 @@
+defmodule Lexical.RemoteControl.CodeMod.AstTest do
+  alias Lexical.Document
+  alias Lexical.RemoteControl.CodeMod.Ast
+  alias Sourceror.Zipper
+
+  use Lexical.Test.CodeMod.Case
+
+  setup do
+    text = ~q[
+      line = 1
+      line = 2
+      line = 3
+      line = 4
+      ""
+    ]t
+
+    document = doc(text)
+    {:ok, document: document}
+  end
+
+  def apply_code_mod({:ok, zipper}, _ast, _opts) do
+    {ast, _} = Zipper.top(zipper)
+    Sourceror.to_string(ast)
+  end
+
+  def apply_code_mod({:ok, zipper, acc}, ast, opts) do
+    converted = apply_code_mod({:ok, zipper}, ast, opts)
+    {converted, acc}
+  end
+
+  def doc(string) do
+    Document.new("file:///file.ex", string, 1)
+  end
+
+  def range(start_line, start_column, end_line, end_column) do
+    Document.Range.new(
+      Document.Position.new(start_line, start_column),
+      Document.Position.new(end_line, end_column)
+    )
+  end
+
+  defp underscore_variable({{var_name, meta, nil}, mod}) do
+    {{:"_#{var_name}", meta, nil}, mod}
+  end
+
+  defp underscore_variable(zipper), do: zipper
+
+  defp underscore_variable({{var_name, meta, nil}, mod}, acc) do
+    {{{:"_#{var_name}", meta, nil}, mod}, acc + 1}
+  end
+
+  defp underscore_variable(zipper, acc), do: {zipper, acc}
+
+  describe "traverse_line" do
+    test "/3 should only affect the specified line", %{document: doc} do
+      converted =
+        doc
+        |> Ast.traverse_line(2, &underscore_variable/1)
+        |> modify(convert_to_ast: false)
+
+      assert converted =~ "_line = 2"
+      assert converted =~ "line = 1"
+      assert converted =~ "line = 3"
+      assert converted =~ "line = 4"
+    end
+
+    test "/4 should only affect the specified line, and keeps an accumulator", %{document: doc} do
+      {converted, acc} =
+        doc
+        |> Ast.traverse_line(2, 0, &underscore_variable/2)
+        |> modify(convert_to_ast: false)
+
+      assert acc == 1
+      assert converted =~ "_line = 2"
+      refute converted =~ "_line = 1"
+      refute converted =~ "_line = 3"
+    end
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/code_mod/ast_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_mod/ast_test.exs
@@ -3,7 +3,7 @@ defmodule Lexical.RemoteControl.CodeMod.AstTest do
   alias Lexical.RemoteControl.CodeMod.Ast
   alias Sourceror.Zipper
 
-  use Lexical.Test.CodeMod.Case
+  use Lexical.Test.CodeMod.Case, enable_ast_conversion: false
 
   setup do
     text = ~q[
@@ -56,7 +56,7 @@ defmodule Lexical.RemoteControl.CodeMod.AstTest do
       converted =
         doc
         |> Ast.traverse_line(2, &underscore_variable/1)
-        |> modify(convert_to_ast: false)
+        |> modify()
 
       assert converted =~ "_line = 2"
       assert converted =~ "line = 1"
@@ -68,7 +68,7 @@ defmodule Lexical.RemoteControl.CodeMod.AstTest do
       {converted, acc} =
         doc
         |> Ast.traverse_line(2, 0, &underscore_variable/2)
-        |> modify(convert_to_ast: false)
+        |> modify()
 
       assert acc == 1
       assert converted =~ "_line = 2"

--- a/apps/remote_control/test/lexical/remote_control/code_mod/format_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_mod/format_test.exs
@@ -7,7 +7,7 @@ defmodule Lexical.RemoteControl.CodeMod.FormatTest do
   alias Lexical.RemoteControl.Build
   alias Lexical.RemoteControl.CodeMod.Format
 
-  use Lexical.Test.CodeMod.Case
+  use Lexical.Test.CodeMod.Case, enable_ast_conversion: false
   use Patch
   import Messages
 
@@ -90,20 +90,20 @@ defmodule Lexical.RemoteControl.CodeMod.FormatTest do
       def foo(a, ) do
         true
       end
-      ] |> modify(project: project, convert_to_ast: false)
+      ] |> modify(project: project)
     end
 
     test "it should provide an error for a missing token", %{project: project} do
       assert {:error, %TokenMissingError{}} = ~q[
       defmodule TokenMissing do
        :bad
-      ] |> modify(project: project, convert_to_ast: false)
+      ] |> modify(project: project)
     end
 
     test "it correctly handles unicode", %{project: project} do
       assert {:ok, result} = ~q[
         {"🎸",    "o"}
-      ] |> modify(project: project, convert_to_ast: false)
+      ] |> modify(project: project)
 
       assert ~q[
         {"🎸", "o"}
@@ -119,7 +119,7 @@ defmodule Lexical.RemoteControl.CodeMod.FormatTest do
 
           end
       end
-      ] |> modify(project: project, convert_to_ast: false)
+      ] |> modify(project: project)
 
       assert result == formatted()
     end
@@ -132,7 +132,7 @@ defmodule Lexical.RemoteControl.CodeMod.FormatTest do
       assert {:error, _} = ~q[
         def foo(a, ) do
       end
-      ] |> modify(project: project, convert_to_ast: false)
+      ] |> modify(project: project)
 
       assert_receive file_diagnostics(diagnostics: [diagnostic]), 250
       assert diagnostic.message =~ "syntax error"

--- a/apps/remote_control/test/lexical/remote_control/code_mod/format_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_mod/format_test.exs
@@ -90,20 +90,20 @@ defmodule Lexical.RemoteControl.CodeMod.FormatTest do
       def foo(a, ) do
         true
       end
-      ] |> modify(project: project)
+      ] |> modify(project: project, convert_to_ast: false)
     end
 
     test "it should provide an error for a missing token", %{project: project} do
       assert {:error, %TokenMissingError{}} = ~q[
       defmodule TokenMissing do
        :bad
-      ] |> modify(project: project)
+      ] |> modify(project: project, convert_to_ast: false)
     end
 
     test "it correctly handles unicode", %{project: project} do
       assert {:ok, result} = ~q[
         {"🎸",    "o"}
-      ] |> modify(project: project)
+      ] |> modify(project: project, convert_to_ast: false)
 
       assert ~q[
         {"🎸", "o"}
@@ -119,7 +119,7 @@ defmodule Lexical.RemoteControl.CodeMod.FormatTest do
 
           end
       end
-      ] |> modify(project: project)
+      ] |> modify(project: project, convert_to_ast: false)
 
       assert result == formatted()
     end
@@ -132,9 +132,9 @@ defmodule Lexical.RemoteControl.CodeMod.FormatTest do
       assert {:error, _} = ~q[
         def foo(a, ) do
       end
-      ] |> modify(project: project)
+      ] |> modify(project: project, convert_to_ast: false)
 
-      assert_receive file_diagnostics(diagnostics: [diagnostic]), 500
+      assert_receive file_diagnostics(diagnostics: [diagnostic]), 250
       assert diagnostic.message =~ "syntax error"
     end
   end

--- a/apps/remote_control/test/support/lexical/test/code_mod_case.ex
+++ b/apps/remote_control/test/support/lexical/test/code_mod_case.ex
@@ -4,7 +4,9 @@ defmodule Lexical.Test.CodeMod.Case do
 
   use ExUnit.CaseTemplate
 
-  using do
+  using opts do
+    convert_to_ast? = Keyword.get(opts, :enable_ast_conversion, true)
+
     quote do
       import Lexical.Test.Fixtures
       import unquote(CodeSigil), only: [sigil_q: 2]
@@ -25,7 +27,7 @@ defmodule Lexical.Test.CodeMod.Case do
       defp maybe_convert_to_ast(code, options) do
         alias Lexical.RemoteControl.CodeMod.Ast
 
-        if Keyword.get(options, :convert_to_ast, true) do
+        if Keyword.get(options, :convert_to_ast, unquote(convert_to_ast?)) do
           Ast.from(code)
         else
           {:ok, nil}

--- a/apps/server/mix.exs
+++ b/apps/server/mix.exs
@@ -52,11 +52,10 @@ defmodule Lexical.Server.MixProject do
       {:elixir_sense, github: "elixir-lsp/elixir_sense"},
       {:jason, "~> 1.4"},
       {:logger_file_backend, "~> 0.0.13", only: [:dev, :prod]},
+      {:patch, "~> 0.12", runtime: false, only: [:dev, :test]},
       {:path_glob, "~> 0.2"},
       {:protocol, in_umbrella: true},
-      {:remote_control, in_umbrella: true, runtime: false},
-      {:sourceror, "~> 0.11"},
-      {:patch, "~> 0.12", runtime: false, only: [:dev, :test]}
+      {:remote_control, in_umbrella: true, runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "credo": {:hex, :credo, "1.7.0", "6119bee47272e85995598ee04f2ebbed3e947678dee048d10b5feca139435f75", [:mix], [{:bunt, "~> 0.2.1", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "6839fcf63d1f0d1c0f450abc8564a57c43d644077ab96f2934563e68b8a769d7"},
   "dialyxir": {:hex, :dialyxir, "1.2.0", "58344b3e87c2e7095304c81a9ae65cb68b613e28340690dfe1a5597fd08dec37", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "61072136427a851674cab81762be4dbeae7679f85b1272b6d25c3a839aff8463"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.31", "a93921cdc6b9b869f519213d5bc79d9e218ba768d7270d46fdcf1c01bacff9e2", [:mix], [], "hexpm", "317d367ee0335ef037a87e46c91a2269fef6306413f731e8ec11fc45a7efd059"},
-"elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "64c4afe4f59cf22fd44302373fa88a606df941c8", []},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "64c4afe4f59cf22fd44302373fa88a606df941c8", []},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "ex_doc": {:hex, :ex_doc, "0.29.2", "dfa97532ba66910b2a3016a4bbd796f41a86fc71dd5227e96f4c8581fdf0fdf0", [:mix], [{:earmark_parser, "~> 1.4.19", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "6b5d7139eda18a753e3250e27e4a929f8d2c880dd0d460cb9986305dea3e03af"},
   "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
@@ -15,6 +15,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "patch": {:hex, :patch, "0.12.0", "2da8967d382bade20344a3e89d618bfba563b12d4ac93955468e830777f816b0", [:mix], [], "hexpm", "ffd0e9a7f2ad5054f37af84067ee88b1ad337308a1cb227e181e3967127b0235"},
   "path_glob": {:hex, :path_glob, "0.2.0", "b9e34b5045cac5ecb76ef1aa55281a52bf603bf7009002085de40958064ca312", [:mix], [{:nimble_parsec, "~> 1.2.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "be2594cb4553169a1a189f95193d910115f64f15f0d689454bb4e8cfae2e7ebc"},
-  "sourceror": {:hex, :sourceror, "0.12.1", "239a98ae2ed191528d64e079eaa355f6f1f69318dbb51796e08497dd3b24d10e", [:mix], [], "hexpm", "b5e310385813d0c791e8a481516654a4e10b7a0fdb55b4fc4ef915fbc0899b8f"},
+  "sourceror": {:hex, :sourceror, "0.12.3", "a2ad3a1a4554b486d8a113ae7adad5646f938cad99bf8bfcef26dc0c88e8fade", [:mix], [], "hexpm", "4d4e78010ca046524e8194ffc4683422f34a96f6b82901abbb45acc79ace0316"},
   "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
 }


### PR DESCRIPTION
Code actions were kind of broken, they were unable to process all elements of an elixir document. They would fail if one of the clauses in a case statement had an unused variable, for example. This was due to the old code processing one line at a time.

The new method uses Sourceror Zippers, which can focus on a line of code and process it. Even better, we can use Sourceror patches to generate a list of patches, which can then be turned directly into edits with no string processing at all. This new way of dealing with code is a lot easier than it was previously, and i'm much happier with the API.