### PR TITLE
Improved struct completion

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion.ex
@@ -61,8 +61,10 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
         Completion.List.new(items: [], is_incomplete: true)
 
       true ->
+        {document, position} = Env.strip_struct_reference(env)
+
         project
-        |> RemoteControl.Api.complete(env.document, env.position)
+        |> RemoteControl.Api.complete(document, position)
         |> to_completion_items(project, env, context)
     end
   end
@@ -142,7 +144,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
         true
 
       struct_reference? and struct_module == Result.Module ->
-        Intelligence.defines_struct?(env.project, result.full_name, to: :grandchild)
+        Intelligence.defines_struct?(env.project, result.full_name, to: :child)
 
       struct_reference? and match?(%Result.Macro{name: "__MODULE__"}, result) ->
         true

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/module_or_behaviour.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/module_or_behaviour.ex
@@ -26,7 +26,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
 
     cond do
       struct_reference? and defines_struct? ->
-        Translations.Struct.completion(env, builder, module.name)
+        Translations.Struct.completion(env, builder, module.name, module.full_name)
 
       struct_reference? and
           immediate_descentent_defines_struct?(env.project, module.full_name) ->
@@ -34,7 +34,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
         |> immediate_descendent_struct_modules(module.full_name)
         |> Enum.map(fn child_module_name ->
           local_name = local_module_name(module.full_name, child_module_name)
-          Translations.Struct.completion(env, builder, local_name)
+          Translations.Struct.completion(env, builder, local_name, child_module_name)
         end)
 
       true ->

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/module_or_behaviour_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/module_or_behaviour_test.exs
@@ -32,7 +32,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
 
       assert completion.kind == :module
       assert completion.label == "User"
-      assert completion.detail =~ "(Module)"
+      assert completion.detail =~ "Project.Structs.User"
     end
 
     test "behaviours should emit a completion", %{project: project} do
@@ -70,8 +70,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
                |> fetch_completion(kind: :struct)
 
       assert completion.insert_text_format == :snippet
-      assert completion.label == "%MapSet"
-      assert completion.detail == "MapSet (Struct)"
+      assert completion.label == "MapSet"
+      assert completion.detail == "MapSet"
       assert apply_completion(completion) == "%MapSet{$1}\n"
     end
 
@@ -95,7 +95,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
                |> complete(source)
                |> fetch_completion(kind: :struct)
 
-      assert completion.detail == "User (Struct)"
+      assert completion.detail == "Project.Structs.User"
       assert apply_completion(completion) == expected
     end
 
@@ -134,7 +134,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
                |> complete(source)
                |> fetch_completion(kind: :struct)
 
-      assert completion.label == "%Account"
+      assert completion.label == "Account"
       assert apply_completion(completion) == expected
     end
 
@@ -152,7 +152,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
                |> complete(source)
                |> fetch_completion(kind: :struct)
 
-      assert completion.label == "%Account"
+      assert completion.label == "Account"
       assert apply_completion(completion) == expected
     end
 
@@ -176,15 +176,15 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
                |> complete(source)
                |> fetch_completion(kind: :struct)
 
-      assert completion.detail == "User (Struct)"
+      assert completion.detail == "Project.Structs.User"
       assert apply_completion(completion) == expected
     end
 
     test "should offer no other types of completions", %{project: project} do
       assert [] = complete(project, "%MapSet.|")
       assert [account, user] = complete(project, "%Project.|")
-      assert account.label == "%Structs.Account"
-      assert user.label == "%Structs.User"
+      assert account.label == "Structs.Account"
+      assert user.label == "Structs.User"
     end
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_test.exs
@@ -8,10 +8,10 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructTest do
                |> complete("%Project.Structs.|")
                |> fetch_completion(kind: :struct)
 
-      assert Enum.find(account_and_user, &(&1.label == "%User"))
-      account = Enum.find(account_and_user, &(&1.label == "%Account"))
+      assert Enum.find(account_and_user, &(&1.label == "User"))
+      account = Enum.find(account_and_user, &(&1.label == "Account"))
       assert account
-      assert account.detail == "Account (Struct)"
+      assert account.detail == "Project.Structs.Account"
 
       assert apply_completion(account) == "%Project.Structs.Account{$1}"
     end
@@ -23,7 +23,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructTest do
                |> fetch_completion(kind: :struct)
 
       assert account
-      assert account.detail == "Account (Struct)"
+      assert account.detail == "Project.Structs.Account"
 
       assert apply_completion(account) == "%Project.Structs.Account{$1}"
     end
@@ -130,11 +130,11 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructTest do
 
     test "when using %, child structs are returned", %{project: project} do
       assert [account, user] = complete(project, "%Project.|", "%")
-      assert account.label == "%Structs.Account"
-      assert account.detail == "Structs.Account (Struct)"
+      assert account.label == "Structs.Account"
+      assert account.detail == "Project.Structs.Account"
 
-      assert user.label == "%Structs.User"
-      assert user.detail == "Structs.User (Struct)"
+      assert user.label == "Structs.User"
+      assert user.detail == "Project.Structs.User"
     end
 
     test "it should complete struct fields", %{project: project} do

--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -1,9 +1,23 @@
 defmodule Lexical.Server.CodeIntelligence.CompletionTest do
+  alias Lexical.Document
   alias Lexical.Protocol.Types.Completion
   alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.Server.CodeIntelligence.Completion, as: C
+  alias Lexical.Server.CodeIntelligence.Completion.Env
 
   use Lexical.Test.Server.CompletionCase
   use Patch
+
+  import Lexical.Test.CursorSupport
+
+  def new_env(project, code) do
+    {line, column} = cursor_position(code)
+    code = strip_cursor(code)
+    document = Document.new("file:///file.ex", code, 1)
+    position = Document.Position.new(line, column)
+    {:ok, env} = Env.new(project, document, position)
+    env
+  end
 
   describe "excluding modules from lexical dependencies" do
     test "lexical modules are removed", %{project: project} do


### PR DESCRIPTION
Struct completion under elixir sense was extremely inconsistent from context to context and even file to file. This was extremely frustrating, as structs might or might not complete depending, seemingly on the time of day.

On the other hand, module completion was pretty consistent, so to fix the issue, prior to sending a document for completion, if we're in a struct reference, we strip it out to get the original module reference back. This means we'll only get module completions from elixir_sense, but we already check for struct references and if we detect that we're in one, turn module completions into struct completions.

I've played around with this and it does seem to fix the problems I was having prior.