### PR TITLE
fix(asdf): change order of installation

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-elixir 1.14.3-otp-25
 erlang 25.2.1
+elixir 1.14.3-otp-25
 nodejs 12.16.3
 yarn 1.22.4


### PR DESCRIPTION
If a user has set up a `~/.default-mix-commands` file such as mine:

```
local.hex
local.rebar
archive.install hex phx_new
archive.install hex nerves_bootstrap
```

then running `$ asdf install` will fail if the specified erlang version is not installed:

```
Running mix local.hex --force...
No preset version installed for command erl
Please install a version by running one of the following:

asdf install erlang 25.2.1

or add one of the following versions in your config file at /home/juan/code/forks/GitHub/lexical/.tool-versions
erlang 26.0

Running mix local.rebar --force...
No preset version installed for command erl
Please install a version by running one of the following:

asdf install erlang 25.2.1

or add one of the following versions in your config file at /home/juan/code/forks/GitHub/lexical/.tool-versions
erlang 26.0

Running mix archive.install hex phx_new --force...
No preset version installed for command erl
Please install a version by running one of the following:

asdf install erlang 25.2.1

or add one of the following versions in your config file at /home/juan/code/forks/GitHub/lexical/.tool-versions
erlang 26.0

Running mix archive.install hex nerves_bootstrap --force...
No preset version installed for command erl
Please install a version by running one of the following:

asdf install erlang 25.2.1

or add one of the following versions in your config file at /home/juan/code/forks/GitHub/lexical/.tool-versions
erlang 26.0
```

Swapping the order fixes this issue.