### PR TITLE
Pulled out the name of arguments in pattern match args

### DIFF
--- a/apps/remote_control/test/fixtures/project/lib/default_args.ex
+++ b/apps/remote_control/test/fixtures/project/lib/default_args.ex
@@ -18,4 +18,12 @@ defmodule Project.DefaultArgs do
   def struct_arg(a, b \\ %Project.Structs.User{}) do
     Map.put(b, :username, a)
   end
+
+  def pattern_match_arg(%Project.Structs.User{} = user) do
+    user
+  end
+
+  def reverse_pattern_match_arg(user = %Project.Structs.User{}) do
+    user
+  end
 end

--- a/apps/remote_control/test/lexical/remote_control/completion/result/argument_names_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/completion/result/argument_names_test.exs
@@ -46,6 +46,24 @@ defmodule Lexical.RemoteControl.Completion.Result.ArgumentNamesTest do
       assert ~w(first second third) = from_elixir_sense(args, 3)
     end
 
+    test "handles match arguments with structs" do
+      assert ~w(project) = from_elixir_sense(["%Project{} = project"], 1)
+      assert ~w(project) = from_elixir_sense(["project = %Project{}"], 1)
+      assert ~w(arg_1) = from_elixir_sense(["%Project{}"], 1)
+    end
+
+    test "handles match arguments with lists" do
+      assert ~w(items) = from_elixir_sense(["[a, b, c] = items"], 1)
+      assert(~w(items) = from_elixir_sense(["items = [a, b, c]"], 1))
+      assert ~w(arg_1) = from_elixir_sense(["[a, b, c]"], 1)
+    end
+
+    test "handles match arguments with tuples" do
+      assert ~w(items) = from_elixir_sense(["{a, b, c = items"], 1)
+      assert(~w(items) = from_elixir_sense(["items = {a, b, c}"], 1))
+      assert ~w(arg_1) = from_elixir_sense(["{a, b, c}"], 1)
+    end
+
     test "handles incorrect arity" do
       args = ~w(first second third)
       assert :error == from_elixir_sense(args, 1)

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/function_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/function_test.exs
@@ -189,6 +189,24 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.FunctionTest d
       assert arity_1.insert_text == "struct_arg(${1:a})"
       assert arity_2.insert_text == "struct_arg(${1:a}, ${2:b})"
     end
+
+    test "works with pattern match args", %{project: project} do
+      {:ok, completion} =
+        project
+        |> complete("Project.DefaultArgs.pattern_match|")
+        |> fetch_completion(kind: :function)
+
+      assert completion.insert_text == "pattern_match_arg(${1:user})"
+    end
+
+    test "works with reverse pattern match args", %{project: project} do
+      {:ok, completion} =
+        project
+        |> complete("Project.DefaultArgs.reverse|")
+        |> fetch_completion(kind: :function)
+
+      assert completion.insert_text == "reverse_pattern_match_arg(${1:user})"
+    end
   end
 
   describe "sort_text" do


### PR DESCRIPTION
I was still getting pattern matches when completing arguments (like `%Project{} = project`). This attempts to parse out the argument name, which is assumed to be a variable on either side of the match, and falls back to `arg_#{index}`.