### PR TITLE
Boost callable completions that are not double underscore/default

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
@@ -71,7 +71,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
 
   defp sort_text(%_{name: name, arity: arity}) do
     normalized = String.replace(name, "__", "")
-    "#{normalized}/#{arity}"
+    fun = "#{normalized}/#{arity}"
+
+    unless String.starts_with?(name, "__") or name in ["module_info"] do
+      Env.boost(fun)
+    else
+      fun
+    end
   end
 
   defp label(%_{name: name, argument_names: argument_names}) do

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
@@ -73,10 +73,10 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
     normalized = String.replace(name, "__", "")
     fun = "#{normalized}/#{arity}"
 
-    unless String.starts_with?(name, "__") or name in ["module_info"] do
-      Env.boost(fun)
-    else
+    if String.starts_with?(name, "__") or name in ["module_info"] do
       fun
+    else
+      Env.boost(fun)
     end
   end
 

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/function_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/function_test.exs
@@ -117,7 +117,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.FunctionTest d
       [capture, args_capture] =
         project
         |> complete(source)
-        |> Enum.filter(&(&1.sort_text == "&is_map/1"))
+        |> Enum.filter(&(String.ends_with?(&1.sort_text, "is_map/1")))
 
       assert capture.detail == "(Capture)"
       assert capture.insert_text == "is_map/1"

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/function_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/function_test.exs
@@ -117,7 +117,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.FunctionTest d
       [capture, args_capture] =
         project
         |> complete(source)
-        |> Enum.filter(&(String.ends_with?(&1.sort_text, "is_map/1")))
+        |> Enum.filter(&String.ends_with?(&1.sort_text, "is_map/1"))
 
       assert capture.detail == "(Capture)"
       assert capture.insert_text == "is_map/1"

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/function_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/function_test.exs
@@ -200,5 +200,27 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.FunctionTest d
 
       assert completion.sort_text == "info/1"
     end
+
+    test "dunder functions have lower completion priority", %{project: project} do
+      completions =
+        complete(project, "GenServer.|")
+        |> Enum.sort_by(& &1.sort_text)
+
+      total_completions = length(completions)
+      info_idx = Enum.find_index(completions, &(&1.sort_text == "info/1"))
+
+      assert info_idx > total_completions * 0.80
+    end
+
+    test "default functions have lower completion priority", %{project: project} do
+      completions =
+        complete(project, "GenServer.|")
+        |> Enum.sort_by(& &1.sort_text)
+
+      total_completions = length(completions)
+      info_idx = Enum.find_index(completions, &(&1.sort_text == "module_info/0"))
+
+      assert info_idx > total_completions * 0.80
+    end
   end
 end


### PR DESCRIPTION
Lowers the priority of double underscore or default functions when completing functions and captures.

Behavior with this patch: 
![image](https://github.com/lexical-lsp/lexical/assets/59743220/8e2bdffa-ffa4-419a-af3b-1a71ce4e7213)


Closes #183