### PR TITLE
Support Struct fields completion when in struct arguments context

### DIFF
--- a/apps/common/lib/future/macro.ex
+++ b/apps/common/lib/future/macro.ex
@@ -1,0 +1,95 @@
+# Copied some code from https://github.com/elixir-lang/elixir/blob/44c18a3/lib/elixir/lib/macro.ex#L440
+# only copied the `path/2`
+import Kernel, except: [to_string: 1]
+
+defmodule Future.Macro do
+  @doc """
+  Returns the path to the node in `ast` which `fun` returns `true`.
+
+  The path is a list, starting with the node in which `fun` returns
+  true, followed by all of its parents.
+
+  Computing the path can be an efficient operation when you want
+  to find a particular node in the AST within its context and then
+  assert something about it.
+
+  ## Examples
+
+      iex> Macro.path(quote(do: [1, 2, 3]), & &1 == 3)
+      [3, [1, 2, 3]]
+
+      iex> Macro.path(quote(do: Foo.bar(3)), & &1 == 3)
+      [3, quote(do: Foo.bar(3))]
+
+      iex> Macro.path(quote(do: %{foo: [bar: :baz]}), & &1 == :baz)
+      [
+        :baz,
+        {:bar, :baz},
+        [bar: :baz],
+        {:foo, [bar: :baz]},
+        {:%{}, [], [foo: [bar: :baz]]}
+      ]
+
+  """
+  @doc since: "1.14.0"
+  def path(ast, fun) when is_function(fun, 1) do
+    path(ast, [], fun)
+  end
+
+  defp path({form, _, args} = ast, acc, fun) when is_atom(form) do
+    acc = [ast | acc]
+
+    if fun.(ast) do
+      acc
+    else
+      path_args(args, acc, fun)
+    end
+  end
+
+  defp path({form, _meta, args} = ast, acc, fun) do
+    acc = [ast | acc]
+
+    if fun.(ast) do
+      acc
+    else
+      path(form, acc, fun) || path_args(args, acc, fun)
+    end
+  end
+
+  defp path({left, right} = ast, acc, fun) do
+    acc = [ast | acc]
+
+    if fun.(ast) do
+      acc
+    else
+      path(left, acc, fun) || path(right, acc, fun)
+    end
+  end
+
+  defp path(list, acc, fun) when is_list(list) do
+    acc = [list | acc]
+
+    if fun.(list) do
+      acc
+    else
+      path_list(list, acc, fun)
+    end
+  end
+
+  defp path(ast, acc, fun) do
+    if fun.(ast) do
+      [ast | acc]
+    end
+  end
+
+  defp path_args(atom, _acc, _fun) when is_atom(atom), do: nil
+  defp path_args(list, acc, fun) when is_list(list), do: path_list(list, acc, fun)
+
+  defp path_list([], _acc, _fun) do
+    nil
+  end
+
+  defp path_list([arg | args], acc, fun) do
+    path(arg, acc, fun) || path_list(args, acc, fun)
+  end
+end

--- a/apps/common/lib/lexical/ast.ex
+++ b/apps/common/lib/lexical/ast.ex
@@ -1,0 +1,26 @@
+defmodule Lexical.Ast do
+  alias Future.Code, as: Code
+  alias Lexical.Document
+  alias Lexical.Document.Position
+
+  @doc """
+  Returns the path to the cursor in the given document and position.
+  """
+  def cursor_path(%Document{} = doc, {line, character}) do
+    cursor_path(doc, Position.new(line, character))
+  end
+
+  def cursor_path(%Document{} = document, %Position{} = position) do
+    fragment = Document.fragment(document, position)
+
+    case Code.Fragment.container_cursor_to_quoted(fragment, columns: true) do
+      {:ok, quoted} ->
+        quoted
+        |> Future.Macro.path(&match?({:__cursor__, _, _}, &1))
+        |> List.wrap()
+
+      _ ->
+        []
+    end
+  end
+end

--- a/apps/common/test/lexical/ast_test.exs
+++ b/apps/common/test/lexical/ast_test.exs
@@ -1,0 +1,54 @@
+defmodule Lexical.AstTest do
+  alias Lexical.Ast
+  alias Lexical.Document
+  alias Lexical.Test.CodeSigil
+  alias Lexical.Test.CursorSupport
+
+  import CursorSupport
+  import CodeSigil
+
+  use ExUnit.Case, async: true
+
+  def cursor_path(text) do
+    pos = cursor_position(text)
+    text = strip_cursor(text)
+    doc = Document.new("file:///file.ex", text, 0)
+    Ast.cursor_path(doc, pos)
+  end
+
+  describe "cursor_path/2" do
+    test "contains the parent AST" do
+      text = ~q[
+      defmodule Foo do
+        def bar do
+          |
+        end
+      end
+    ]
+
+      path = cursor_path(text)
+
+      assert Enum.any?(path, &match?({:def, _, _}, &1))
+      assert Enum.any?(path, &match?({:defmodule, _, _}, &1))
+    end
+
+    test "returns cursor ast when is not in a container" do
+      text = ~q[
+      |
+      defmodule Foo do
+      end
+      ]
+
+      path = cursor_path(text)
+      assert path == [{:__cursor__, [line: 1, column: 1], []}]
+    end
+
+    test "returns [] when can't parse the AST" do
+      text = ~q[
+        foo(bar do baz, bat|
+      ]
+      path = cursor_path(text)
+      assert path == []
+    end
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -47,6 +47,13 @@ defmodule Lexical.RemoteControl.Api do
     ])
   end
 
+  def complete_struct_fields(%Project{} = project, %Document{} = document, %Position{} = position) do
+    RemoteControl.call(project, RemoteControl.Completion, :struct_fields, [
+      document,
+      position
+    ])
+  end
+
   def definition(%Project{} = project, %Document{} = document, %Position{} = position) do
     RemoteControl.call(project, CodeIntelligence.Definition, :definition, [
       document,

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/ast.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/ast.ex
@@ -1,0 +1,77 @@
+defmodule Lexical.RemoteControl.CodeIntelligence.Ast do
+  alias Lexical.Document
+  alias Lexical.Document.Position
+  alias Lexical.RemoteControl.CodeMod.Ast.Aliases
+
+  require Logger
+
+  @doc """
+  Expands the aliases in the given `document`, `postion` and `module_aliases`.
+
+  When we refer to a module, it's usually a short name,
+  so it's probably aliased or in a nested module,
+  so we need to find the real full name of the module at the cursor position.
+
+  For example, if we have:
+
+    ```elixir
+    defmodule Project do
+      defmodule Issue do
+        defstruct [:message]
+      end
+
+      def message(%Issue{|} = issue) do # cursor marked as `|`
+      end
+    end
+    ```
+
+  Then the the expanded module is `Project.Issue`.
+
+  Another example:
+
+    ```elixir
+    defmodule Project do
+      defmodule Issue do
+        defstruct [:message]
+      end
+    end
+
+    defmodule MyModule do
+      alias Project, as: MyProject
+
+      def message(%MyProject.Issue{|} = issue) do
+      end
+    end
+    ```
+
+  Then the the expanded module is still `Project.Issue`.
+
+  And sometimes we can't find the full name by the `Aliases.at/2` function,
+  then we just return the `Module.concat(module_aliases)` as it is.
+  """
+  @type short_alias :: atom()
+  @type module_aliases :: [short_alias]
+
+  @spec expand_aliases(
+          document :: Document.t(),
+          position :: Position.t(),
+          module_aliases :: module_aliases()
+        ) :: {:ok, module()} | :error
+  def expand_aliases(%Document{} = document, %Position{} = position, module_aliases)
+      when is_list(module_aliases) do
+    [first | rest] = module_aliases
+
+    with {:ok, aliases_mapping} <- Aliases.at(document, position),
+         {:ok, from} <- Map.fetch(aliases_mapping, first) do
+      {:ok, Module.concat([from | rest])}
+    else
+      _ ->
+        {:ok, Module.concat(module_aliases)}
+    end
+  end
+
+  def expand_aliases(_, _, nil) do
+    Logger.warning("Aliases are nil, can't expand them")
+    :error
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/completion.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion.ex
@@ -1,5 +1,7 @@
 defmodule Lexical.RemoteControl.Completion do
+  alias Lexical.Document
   alias Lexical.Document.Position
+  alias Lexical.RemoteControl.CodeIntelligence.Ast
   alias Lexical.RemoteControl.Completion.Candidate
 
   def elixir_sense_expand(doc_string, %Position{} = position) do
@@ -19,5 +21,35 @@ defmodule Lexical.RemoteControl.Completion do
         candidate
       end
     end
+  end
+
+  def struct_fields(%Document{} = document, %Position{} = position) do
+    container_struct_module =
+      document
+      |> Lexical.Ast.cursor_path(position)
+      |> container_struct_module()
+
+    with {:ok, struct_module} <- Ast.expand_aliases(document, position, container_struct_module),
+         true <- function_exported?(struct_module, :__struct__, 0) do
+      struct_module
+      |> struct()
+      |> Map.from_struct()
+      |> Map.keys()
+      |> Enum.map(&Candidate.StructField.new(&1, struct_module))
+    else
+      _ -> []
+    end
+  end
+
+  defp container_struct_module(cursor_path) do
+    Enum.find_value(cursor_path, fn
+      # current module struct: `%__MODULE__{|}`
+      {:%, _, [{:__MODULE__, _, _} | _]} -> [:__MODULE__]
+      # struct leading by current module: `%__MODULE__.Struct{|}`
+      {:%, _, [{:__aliases__, _, [{:__MODULE__, _, _} | tail]} | _]} -> [:__MODULE__ | tail]
+      # Struct leading by alias or just a aliased Struct: `%Struct{|}`, `%Project.Struct{|}`
+      {:%, _, [{:__aliases__, _, aliases} | _]} -> aliases
+      _ -> nil
+    end)
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
@@ -105,6 +105,10 @@ defmodule Lexical.RemoteControl.Completion.Candidate do
     def new(%{} = elixir_sense_map) do
       struct(__MODULE__, elixir_sense_map)
     end
+
+    def new(name, origin) do
+      %__MODULE__{name: name, origin: origin, call?: false}
+    end
   end
 
   defmodule MapField do

--- a/apps/remote_control/test/lexical/remote_control/completion_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/completion_test.exs
@@ -1,0 +1,111 @@
+defmodule Lexical.RemoteControl.CompletionTest do
+  alias Lexical.Document
+  alias Lexical.Document.Position
+  alias Lexical.RemoteControl.Completion
+
+  import Lexical.Test.CursorSupport
+  import Lexical.Test.CodeSigil
+
+  use ExUnit.Case, async: true
+
+  describe "struct_fields/2" do
+    test "returns the field completion for current module" do
+      source = ~q<
+        defmodule Project.Issue do
+          defstruct [:message]
+          @type t :: %__MODULE__{|}
+        end
+      >
+
+      [message] = struct_fields(source)
+      assert message.name == :message
+    end
+
+    test "returns the field completions for aliased module" do
+      source = ~q<
+        defmodule Project.Issue do
+          alias Project.Issue
+          defstruct [:message]
+          @type t :: %Issue{|}
+        end
+      >
+
+      [message] = struct_fields(source)
+      assert message.name == :message
+    end
+
+    test "returns [] when cursor is not in a struct" do
+      source = ~q<
+        defmodule Project.Issue do
+          alias Project.Issue
+          defstruct [:message]
+          @type t :: %Issue{}|
+        end
+      >
+
+      assert struct_fields(source) == []
+    end
+
+    test "returns the field completions when cursor is in the current module child's arguments" do
+      source = ~q<
+        defmodule Project do
+          defmodule Issue do
+            @type t :: %Issue{}
+            defstruct [:message]
+          end
+
+          def message(%__MODULE__.Issue{|} = issue) do
+            issue.message
+          end
+        end
+      >
+
+      [message] = struct_fields(source)
+      assert message.name == :message
+    end
+
+    test "returns the field completion when cursor is in an alias child's arguments" do
+      source = ~q<
+        defmodule Project do
+          defmodule Issue do
+            defstruct [:message]
+          end
+        end
+
+        defmodule MyModule do
+          alias Project
+
+          def message(%Project.Issue{|} = issue) do
+            issue.message
+          end
+        end
+      >
+
+      [message] = struct_fields(source)
+      assert message.name == :message
+    end
+  end
+
+  defp document(source) do
+    text = strip_cursor(source)
+    Document.new(file_uri(), text, 1)
+  end
+
+  defp file_uri do
+    "file:///elixir.ex"
+  end
+
+  defp position(source) do
+    {line, column} = cursor_position(source)
+    Position.new(line, column)
+  end
+
+  defp struct_fields(source) do
+    document = document(source)
+    position = position(source)
+    text = Document.to_string(document)
+    Code.compile_string(text)
+
+    Completion.struct_fields(document, position)
+  end
+end

--- a/apps/server/lib/lexical/server/code_intelligence/completion.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion.ex
@@ -52,7 +52,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
       prefix_tokens == [] ->
         empty_completion_list()
 
-      match?([{:operator, :do}], prefix_tokens) and Env.empty?(env.suffix) ->
+      match?([{:operator, :do, _}], prefix_tokens) and Env.empty?(env.suffix) ->
         do_end_snippet = "do\n$0\nend"
 
         env

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/bitstring_option.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/bitstring_option.ex
@@ -20,21 +20,21 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.BitstringOptio
 
   defp prefix_length(%Env{} = env) do
     case Env.prefix_tokens(env, 1) do
-      [{:operator, :"::"}] ->
+      [{:operator, :"::", _}] ->
         0
 
-      [{:operator, :in}] ->
+      [{:operator, :in, _}] ->
         # they're typing integer and got "in" out, which the lexer thinks
         # is Kernel.in/2
         2
 
-      [{_, token}] when is_binary(token) ->
+      [{_, token, _}] when is_binary(token) ->
         String.length(token)
 
-      [{_, token}] when is_list(token) ->
+      [{_, token, _}] when is_list(token) ->
         length(token)
 
-      [{_, token}] when is_atom(token) ->
+      [{_, token, _}] when is_atom(token) ->
         token |> Atom.to_string() |> String.length()
     end
   end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
@@ -3,6 +3,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
   alias Lexical.Server.CodeIntelligence.Completion.Translations.Callable
+  alias Lexical.Server.CodeIntelligence.Completion.Translations.Struct
 
   use Translatable.Impl, for: Candidate.Macro
 
@@ -512,12 +513,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
 
   def translate(%Candidate.Macro{name: "__MODULE__"} = macro, builder, env) do
     if Env.in_context?(env, :struct_reference) do
-      env
-      |> builder.snippet("%__MODULE__{$1}",
-        detail: "%__MODULE__{}",
-        label: "%__MODULE__{}",
-        kind: :struct
-      )
+      Struct.completion(env, builder, macro.name, macro.name)
     else
       env
       |> builder.plain_text("__MODULE__",

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct.ex
@@ -69,19 +69,23 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Struct do
           prefix_end
 
         {:struct, typed_module_name} ->
-          edit_begin =
-            case left_offset_of(typed_module_name, ?.) do
-              {:ok, offset} ->
-                env.position.character - offset
+          beginning_of_edit(env, typed_module_name)
 
-              :error ->
-                env.position.character - length(typed_module_name)
-            end
-
-          edit_begin
+        {:local_or_var, [?_ | _rest] = typed} ->
+          beginning_of_edit(env, typed)
       end
 
     {edit_begin, env.position.character}
+  end
+
+  defp beginning_of_edit(env, typed_module_name) do
+    case left_offset_of(typed_module_name, ?.) do
+      {:ok, offset} ->
+        env.position.character - offset
+
+      :error ->
+        env.position.character - length(typed_module_name)
+    end
   end
 
   defp left_offset_of(string, character) do

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct_field.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct_field.ex
@@ -1,4 +1,5 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructField do
+  alias Future.Code, as: Code
   alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
@@ -9,11 +10,39 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructField do
     :skip
   end
 
+  def translate(%Candidate.StructField{call?: false} = struct_field, builder, %Env{} = env) do
+    name = struct_field.name
+    value = to_string(name)
+
+    builder_opts = [
+      kind: :field,
+      label: "#{name}: #{value}"
+    ]
+
+    insert_text = "#{name}: ${1:#{value}}"
+    range = edit_range(env)
+
+    builder.text_edit_snippet(env, insert_text, range, builder_opts)
+  end
+
   def translate(%Candidate.StructField{} = struct_field, builder, %Env{} = env) do
     builder.plain_text(env, struct_field.name,
       detail: struct_field.name,
       label: struct_field.name,
       kind: :field
     )
+  end
+
+  def edit_range(env) do
+    prefix_end = env.position.character
+
+    case Code.Fragment.cursor_context(env.prefix) do
+      {:local_or_var, field_char} ->
+        edit_begin = env.position.character - length(field_char)
+        {edit_begin, prefix_end}
+
+      _ ->
+        {prefix_end, prefix_end}
+    end
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion/env_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/env_test.exs
@@ -370,8 +370,18 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
     end
 
     test "is true if a module reference starts in function arguments" do
-      env = new_env("def my_function(%__|)")
+      env = new_env("def my_function(%_|)")
       assert in_context?(env, :struct_reference)
+    end
+
+    test "is ture if a module reference start in a t type spec" do
+      env = new_env("@type t :: %_|")
+      assert in_context?(env, :struct_reference)
+    end
+
+    test "is false if module reference not starts with %" do
+      env = new_env("def something(my_thing|, %Struct{})")
+      refute in_context?(env, :struct_reference)
     end
 
     test "is true if the reference is for %__MOD in a function definition " do

--- a/apps/server/test/lexical/server/code_intelligence/completion/env_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/env_test.exs
@@ -28,7 +28,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
   describe "prefix_tokens/2" do
     test "works with bitstring specifiers" do
       env = new_env("<<foo::int|")
-      assert [{:identifier, 'int'}, {:operator, :"::"}] = prefix_tokens(env, 2)
+
+      assert [{:identifier, ~c"int", _}, {:operator, :"::", _}] = prefix_tokens(env, 2)
     end
 
     test "works with floats" do
@@ -37,7 +38,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
         |> new_env()
         |> prefix_tokens(1)
 
-      assert [{:float, 27.88}] = tokens
+      assert [{:float, 27.88, _}] = tokens
     end
 
     test "works with strings" do
@@ -46,7 +47,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
         |> new_env()
         |> prefix_tokens(1)
 
-      assert [{:string, "hello"}] = tokens
+      assert [{:string, "hello", _}] = tokens
     end
 
     test "works with interpolated strings" do
@@ -55,7 +56,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
         |> new_env()
         |> prefix_tokens(1)
 
-      assert [{:interpolated_string, ["hello" | _]}] = tokens
+      assert [{:interpolated_string, ["hello" | _], _}] = tokens
     end
 
     test "works with maps with atom keys" do
@@ -65,11 +66,11 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
         |> prefix_tokens(9)
 
       assert [
-               {:curly, :"}"},
-               {:int, 3},
-               {:kw_identifier, 'a'},
-               {:curly, :"{"},
-               {:map_new, :%{}}
+               {:curly, :"}", _},
+               {:int, 3, _},
+               {:kw_identifier, ~c"a", _},
+               {:curly, :"{", _},
+               {:map_new, :%{}, _}
              ] = tokens
     end
 
@@ -80,12 +81,12 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
         |> prefix_tokens(8)
 
       assert [
-               {:curly, :"}"},
-               {:int, 3},
-               {:assoc_op, nil},
-               {:string, "a"},
-               {:curly, :"{"},
-               {:map_new, :%{}}
+               {:curly, :"}", _},
+               {:int, 3, _},
+               {:assoc_op, nil, _},
+               {:string, "a", _},
+               {:curly, :"{", _},
+               {:map_new, :%{}, _}
              ] = tokens
     end
 
@@ -95,11 +96,11 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
         |> new_env()
         |> prefix_tokens(3)
 
-      assert tokens == [
-               {:int, 5},
-               {:operator, :+},
-               {:int, 3}
-             ]
+      assert [
+               {:int, 5, _},
+               {:operator, :+, _},
+               {:int, 3, _}
+             ] = tokens
     end
 
     test "works with remote function calls" do
@@ -109,9 +110,9 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
         |> prefix_tokens(9)
 
       assert [
-               {:identifier, 'map'},
-               {:operator, :.},
-               {:alias, 'Enum'}
+               {:identifier, ~c"map", _},
+               {:operator, :., _},
+               {:alias, ~c"Enum", _}
              ] = tokens
     end
 
@@ -122,10 +123,10 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
         |> prefix_tokens(9)
 
       assert [
-               {:paren, :"("},
-               {:paren_identifier, 'local'},
-               {:match_op, nil},
-               {:identifier, 'foo'}
+               {:paren, :"(", _},
+               {:paren_identifier, ~c"local", _},
+               {:match_op, nil, _},
+               {:identifier, ~c"foo", _}
              ] = tokens
     end
 
@@ -135,7 +136,11 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
         |> new_env()
         |> prefix_tokens(900)
 
-      assert [{:identifier, 'tri'}, {:operator, :.}, {:alias, 'String'}] = tokens
+      assert [
+               {:identifier, ~c"tri", _},
+               {:operator, :., _},
+               {:alias, ~c"String", _}
+             ] = tokens
     end
 
     test "works with macros" do
@@ -144,11 +149,11 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
         |> new_env()
         |> prefix_tokens(3)
 
-      assert tokens == [
-               {:operator, :do},
-               {:alias, 'MyModule'},
-               {:identifier, 'defmacro'}
-             ]
+      assert [
+               {:operator, :do, _},
+               {:alias, ~c"MyModule", _},
+               {:identifier, ~c"defmacro", _}
+             ] = tokens
     end
 
     test "works with lists of integers" do
@@ -157,15 +162,15 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
         |> new_env()
         |> prefix_tokens(7)
 
-      assert tokens == [
-               {:operator, :"]"},
-               {:int, 3},
-               {:comma, :","},
-               {:int, 2},
-               {:comma, :","},
-               {:int, 1},
-               {:operator, :"["}
-             ]
+      assert [
+               {:operator, :"]", _},
+               {:int, 3, _},
+               {:comma, :",", _},
+               {:int, 2, _},
+               {:comma, :",", _},
+               {:int, 1, _},
+               {:operator, :"[", _}
+             ] = tokens
     end
   end
 

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
@@ -480,18 +480,6 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.kind == :constant
     end
 
-    test "__MODULE__ is suggested in a struct reference", %{project: project} do
-      assert {:ok, completion} =
-               project
-               |> complete("%__|")
-               |> fetch_completion("%__MODULE__")
-
-      assert completion.detail
-      assert completion.label == "%__MODULE__{}"
-      assert completion.insert_text_format == :snippet
-      assert completion.insert_text == "%__MODULE__{$1}"
-    end
-
     test "__DIR__ is suggested", %{project: project} do
       assert {:ok, completion} =
                project

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
@@ -5,7 +5,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
 
   describe "Kernel* macros" do
     test "do/end only has a single completion", %{project: project} do
-      assert assert [completion] = complete(project, "def my_thing do|")
+      assert [completion] = complete(project, "def my_thing do|")
       assert completion.insert_text == "do\n$0\nend"
       assert completion.label == "do/end block"
     end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_test.exs
@@ -168,37 +168,70 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructTest do
     test "it should complete module structs", %{project: project} do
       source = ~q{
         defmodule NewStruct do
-        defstruct [:name, :value]
+          defstruct [:name, :value]
 
-        def my_function(%__|)
+          def my_function(%__|)
       }
+
+      expected = ~q<
+        defmodule NewStruct do
+          defstruct [:name, :value]
+
+          def my_function(%__MODULE__{$1})
+      >
 
       assert {:ok, completion} =
                project
                |> complete(source)
                |> fetch_completion(kind: :struct)
 
-      assert completion.label == "%__MODULE__{}"
-      assert completion.detail == "%__MODULE__{}"
-      assert completion.kind == :struct
+      assert apply_completion(completion) == expected
     end
 
     test "it should complete module structs after characters are typed", %{project: project} do
       source = ~q{
         defmodule NewStruct do
-        defstruct [:name, :value]
+          defstruct [:name, :value]
 
-        def my_function(%__MO|)
+          def my_function(%__MO|)
       }
+
+      expected = ~q<
+        defmodule NewStruct do
+          defstruct [:name, :value]
+
+          def my_function(%__MODULE__{$1})
+      >
 
       assert {:ok, completion} =
                project
                |> complete(source)
                |> fetch_completion(kind: :struct)
 
-      assert completion.label == "%__MODULE__{}"
-      assert completion.detail == "%__MODULE__{}"
-      assert completion.kind == :struct
+      assert apply_completion(completion) == expected
+    end
+
+    test "it should complete module structs when completing module type", %{project: project} do
+      source = ~q<
+        defmodule NewStruct do
+          defstruct [:name, :value]
+
+          @type t :: %_|
+      >
+
+      expected = ~q<
+        defmodule NewStruct do
+          defstruct [:name, :value]
+
+          @type t :: %__MODULE__{$1}
+      >
+
+      assert {:ok, completion} =
+               project
+               |> complete(source)
+               |> fetch_completion(kind: :struct)
+
+      assert apply_completion(completion) == expected
     end
 
     test "can be aliased", %{project: project} do


### PR DESCRIPTION
There are four commits, Please review them one by one.

### Show case

With this completion, it means that we no longer need to remember the specific names of fields, and only need to manually trigger the completion.


<img width="545" alt="image" src="https://github.com/lexical-lsp/lexical/assets/12830256/ac845235-74c6-456a-8844-cb1cc0c05d66">

<img width="654" alt="image" src="https://github.com/lexical-lsp/lexical/assets/12830256/63ff5614-08a4-44dd-a551-fe68bf2300fd">

Fixes #189
