### PR TITLE
Added a check for credo pipeline initial argument

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -12,12 +12,13 @@
       parse_timeout: 5000,
       color: true,
       checks: [
+        {Credo.Check.Design.AliasUsage, if_nested_deeper_than: 3, if_called_more_often_than: 1},
+        {Credo.Check.Readability.AliasOrder, []},
         {Credo.Check.Readability.ModuleDoc, false},
         {Credo.Check.Readability.PreferImplicitTry, false},
-        {Credo.Check.Readability.AliasOrder, []},
         {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 10},
         {Credo.Check.Refactor.Nesting, max_nesting: 3},
-        {Credo.Check.Design.AliasUsage, if_nested_deeper_than: 3, if_called_more_often_than: 1}
+        {Credo.Check.Refactor.PipeChainStart, []}
       ]
     }
   ]

--- a/apps/proto/lib/lexical/proto/macros/struct.ex
+++ b/apps/proto/lib/lexical/proto/macros/struct.ex
@@ -33,7 +33,8 @@ defmodule Lexical.Proto.Macros.Struct do
   end
 
   defp required_keys(opts) do
-    Enum.filter(opts, fn
+    opts
+    |> Enum.filter(fn
       # ignore the splat, it's always optional
       {:.., _} -> false
       # an optional signifier tuple

--- a/apps/proto/lib/mix/tasks/namespace/abstract.ex
+++ b/apps/proto/lib/mix/tasks/namespace/abstract.ex
@@ -306,7 +306,8 @@ defmodule Mix.Tasks.Namespace.Abstract do
         :LXRelease
 
       ["Elixir" | rest] ->
-        Enum.map(rest, fn
+        rest
+        |> Enum.map(fn
           "Lexical" -> "LXRelease"
           other -> other
         end)

--- a/apps/remote_control/lib/lexical/remote_control/bootstrap.ex
+++ b/apps/remote_control/lib/lexical/remote_control/bootstrap.ex
@@ -34,7 +34,8 @@ defmodule Lexical.RemoteControl.Bootstrap do
     hex_ebin = Path.join(["hex-*", "**", "ebin"])
 
     [hex_path] =
-      Mix.path_for(:archives)
+      :archives
+      |> Mix.path_for()
       |> Path.join(hex_ebin)
       |> Path.wildcard()
 

--- a/apps/remote_control/lib/lexical/remote_control/build/error.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/error.ex
@@ -376,7 +376,8 @@ defmodule Lexical.RemoteControl.Build.Error do
   end
 
   defp find_location(lines) do
-    Enum.find(lines, fn
+    lines
+    |> Enum.find(fn
       line when is_binary(line) ->
         Regex.scan(@location_re, line) != [] or Regex.scan(@file_and_line_re, line) != []
 

--- a/apps/remote_control/test/lexical/remote_control/project_node_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/project_node_test.exs
@@ -17,7 +17,9 @@ defmodule Lexical.RemoteControl.ProjectNodeTest do
   test "it should be able to stop a project node and won't restart", %{project: project} do
     {:ok, _node_name, _} = RemoteControl.start_link(project, self())
 
-    assert ProjectNode.name(project) |> Process.whereis() |> Process.alive?()
+    project_alive? = project |> ProjectNode.name() |> Process.whereis() |> Process.alive?()
+
+    assert project_alive?
     assert :ok = ProjectNode.stop(project, 500)
     assert Process.whereis(ProjectNode.name(project)) == nil
   end

--- a/apps/server/lib/lexical/server/json_rpc_backend.ex
+++ b/apps/server/lib/lexical/server/json_rpc_backend.ex
@@ -108,7 +108,11 @@ defmodule Lexical.Server.JsonRpc.Backend do
   defp init(config, state) do
     level = Keyword.get(config, :level)
     format = Logger.Formatter.compile(Keyword.get(config, :format))
-    metadata = Keyword.get(config, :metadata, []) |> configure_metadata()
+
+    metadata =
+      config
+      |> Keyword.get(:metadata, [])
+      |> configure_metadata()
 
     %{
       state

--- a/apps/server/test/document_test.exs
+++ b/apps/server/test/document_test.exs
@@ -187,7 +187,8 @@ defmodule Lexical.DocumentTest do
 
     def position_after_substring(text, sub_text) do
       index = index_of(text, sub_text)
-      position_at(text, index + (String.to_charlist(sub_text) |> length))
+
+      position_at(text, index + (sub_text |> String.to_charlist() |> length))
     end
 
     def range_for_substring(doc, sub_text) do

--- a/apps/server/test/lexical/server/project/diagnostics/state_test.exs
+++ b/apps/server/test/lexical/server/project/diagnostics/state_test.exs
@@ -75,7 +75,10 @@ defmodule Lexical.Project.Diagnostics.StateTest do
 
   describe "clear_all_flushed/1" do
     test "it should not clear a dirty open file", %{state: state} do
-      document = document("hello") |> change_with("hello2")
+      document =
+        "hello"
+        |> document()
+        |> change_with("hello2")
 
       state = State.add(state, compiler_diagnostic(message: "The code is awful"))
 

--- a/apps/server/test/lexical/server/project/node_test.exs
+++ b/apps/server/test/lexical/server/project/node_test.exs
@@ -55,6 +55,8 @@ defmodule Lexical.Server.Project.NodeTest do
   end
 
   defp node_pid(project) do
-    RemoteControl.ProjectNode.name(project) |> Process.whereis()
+    project
+    |> RemoteControl.ProjectNode.name()
+    |> Process.whereis()
   end
 end


### PR DESCRIPTION
I often tell people in PRs to "commit to the pipeline", this credo check will do it for me.

Also cleaned up instances where we don't do that in code.