### PR TITLE
Reduces behaviour_info/1 priority in completions

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
@@ -86,11 +86,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
     "#{callable.name}(#{argument_templates})"
   end
 
+  @default_functions ["module_info", "behaviour_info"]
+
   defp sort_text(%_{name: name, arity: arity}) do
     normalized = String.replace(name, "__", "")
     fun = "#{normalized}/#{arity}"
 
-    if String.starts_with?(name, "__") or name in ["module_info"] do
+    if String.starts_with?(name, "__") or name in @default_functions do
       fun
     else
       Env.boost(fun)

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/function_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/function_test.exs
@@ -240,7 +240,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.FunctionTest d
     test "dunder and default functions have lower completion priority", %{project: project} do
       completions = complete(project, "GenServer.|")
 
-      defaults = ["module_info/0", "module_info/1"]
+      defaults = ["module_info/0", "module_info/1", "behaviour_info/1"]
 
       low_priority_completion? = fn fun ->
         String.starts_with?(fun.label, "__") or fun.sort_text in defaults


### PR DESCRIPTION
`behaviour_info/1` is also implemented by default by the compiler, so we should give it a low priority when suggesting completions.