### PR TITLE
Suggest behavior callbacks

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
@@ -2,7 +2,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
   alias Lexical.RemoteControl.Completion.Result
   alias Lexical.Server.CodeIntelligence.Completion.Env
 
-  @callables [Result.Function, Result.Macro]
+  @callables [Result.Function, Result.Macro, Result.Callback]
 
   def completion(%callable_module{arity: 0} = callable, %Env{} = env)
       when callable_module in @callables do

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
@@ -1,0 +1,12 @@
+defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callback do
+  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.Server.CodeIntelligence.Completion.Env
+  alias Lexical.Server.CodeIntelligence.Completion.Translatable
+  alias Lexical.Server.CodeIntelligence.Completion.Translations.Callable
+
+  use Translatable.Impl, for: Result.Callback
+
+  def translate(%Result.Callback{} = callback, _builder, %Env{} = env) do
+    Callable.completion(callback, env)
+  end
+end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/callback_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/callback_test.exs
@@ -1,0 +1,37 @@
+defmodule Lexical.Server.CodeIntelligence.Completion.Translations.CallbackTest do
+  use Lexical.Test.Server.CompletionCase
+
+  describe "callback completions" do
+    test "suggest callbacks", %{project: project} do
+      source = ~q[
+      defmodule MyServer do
+        use GenServer
+        def handle_inf|
+      end
+      ]
+
+      {:ok, completion} =
+        project
+        |> complete(source)
+        |> fetch_completion(kind: :function)
+
+      assert completion.insert_text == "handle_info(${1:msg}, ${2:state})"
+    end
+
+    test "do not add parens if they're already present", %{project: project} do
+      source = ~q[
+        defmodule MyServer do
+          use GenServer
+          def handle_inf|(msg, state)
+        end
+        ]
+
+      {:ok, completion} =
+        project
+        |> complete(source)
+        |> fetch_completion(kind: :function)
+
+      assert completion.insert_text == "handle_info"
+    end
+  end
+end


### PR DESCRIPTION
Basic behavior callback completion.  I think this is a good start, but I think there's still more that can be done here, and more thorough tests probably.  Please let me know anything else I should add or cover.

Improvements I'd love to see (but maybe not in this PR) are:

* adding `do/end` to the end of the suggestion snippet for callbacks
* suggest available callbacks at `def|` when inside a module that `use`s a behavior

Thoughts?