### PR TITLE
Delete `deps.compile` from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ To install lexical fetch the source code from git, then do the following:
 
  ```
  mix deps.get
- mix deps.compile
  mix release lexical
  ```
 


### PR DESCRIPTION
More than one person has reported to me that they failed at `deps.compile`. I suspect it's caused by the relative path, and besides, our release doesn't need to compile because it will automatically compile. Therefore, I deleted this line to reduce misunderstandings.