### PR TITLE
fix: completion context can be null

### DIFF
--- a/apps/server/lib/lexical/server/provider/handlers/completion.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/completion.ex
@@ -1,6 +1,7 @@
 defmodule Lexical.Server.Provider.Handlers.Completion do
   alias Lexical.Protocol.Requests
   alias Lexical.Protocol.Responses
+  alias Lexical.Protocol.Types.Completion
   alias Lexical.Server.CodeIntelligence
   alias Lexical.Server.Provider.Env
 
@@ -12,7 +13,7 @@ defmodule Lexical.Server.Provider.Handlers.Completion do
         env.project,
         request.document,
         request.position,
-        request.context
+        request.context || Completion.Context.new(trigger_kind: :invoked)
       )
 
     response = Responses.Completion.new(request.id, completions)


### PR DESCRIPTION
Completion contexts can be nil, but we assumed they had to be present. This adds a reasonable default.

Co-Authored-By: Steve Cohen <scohen@scohen.org>
