### PR TITLE
Module sorting / Refactor boost

### DIFF
--- a/apps/common/lib/lexical/completion/builder.ex
+++ b/apps/common/lib/lexical/completion/builder.ex
@@ -91,5 +91,7 @@ defmodule Lexical.Completion.Builder do
   Use the second digit to boost a certain kind of item above other kinds. For example, modules are sorted
   above functions, so they carry a default boost of 20, which will put them above functions.
   """
-  @callback boost(translated_item, 0..99) :: translated_item
+  @callback boost(translated_item, 0..9, 0..9) :: translated_item
+  @callback boost(translated_item, 0..9) :: translated_item
+  @callback boost(translated_item) :: translated_item
 end

--- a/apps/common/lib/lexical/completion/builder.ex
+++ b/apps/common/lib/lexical/completion/builder.ex
@@ -81,5 +81,15 @@ defmodule Lexical.Completion.Builder do
               translated_item()
 
   @callback fallback(any, any) :: any
-  @callback boost(String.t(), 0..10) :: String.t()
+
+  @doc """
+  Boosts a translated item.
+
+  Provides the ability to boost the relevance of an item above its peers.
+  The boost is hierarchical, a single-digit boost will elevate items above other items of the same kind.
+  use single-digit boosts to increase (or decrease) the prominence of individual functions or modules.
+  Use the second digit to boost a certain kind of item above other kinds. For example, modules are sorted
+  above functions, so they carry a default boost of 20, which will put them above functions.
+  """
+  @callback boost(translated_item, 0..99) :: translated_item
 end

--- a/apps/common/lib/lexical/completion/builder.ex
+++ b/apps/common/lib/lexical/completion/builder.ex
@@ -86,12 +86,13 @@ defmodule Lexical.Completion.Builder do
   Boosts a translated item.
 
   Provides the ability to boost the relevance of an item above its peers.
-  The boost is hierarchical, a single-digit boost will elevate items above other items of the same kind.
-  use single-digit boosts to increase (or decrease) the prominence of individual functions or modules.
-  Use the second digit to boost a certain kind of item above other kinds. For example, modules are sorted
-  above functions, so they carry a default boost of 20, which will put them above functions.
+  The boost is hierarchical, and split into a local boost and a global boost.
+  Use the local boost to increase (or decrease) the prominence of individual functions or modules relative to another
+  item of the same type. For example, you can use the local boost to increase the prominence of test functions inside of test files.
+  Use the global boost to boost a certain kind of item above other kinds. For example, modules are sorted
+  above functions, so they carry a global boost of 2, which will put them above functions, which have no global boost.
   """
-  @callback boost(translated_item, 0..9, 0..9) :: translated_item
-  @callback boost(translated_item, 0..9) :: translated_item
+  @callback boost(translated_item, local_boost :: 0..9, global_boost :: 0..9) :: translated_item
+  @callback boost(translated_item, local_bost :: 0..9) :: translated_item
   @callback boost(translated_item) :: translated_item
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/env.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/env.ex
@@ -268,20 +268,15 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Env do
   def fallback(detail, _), do: detail
 
   @impl Builder
-  def boost(item, amount \\ 5)
+  def boost(item, local_boost \\ 1, global_boost \\ 0)
 
-  def boost(%Completion.Item{} = item, amount) when amount in 0..99 do
-    boost =
-      (99 - amount)
-      |> Integer.to_string()
-      |> String.pad_leading(3, "0")
+  def boost(%Completion.Item{} = item, local_boost, global_boost)
+      when local_boost in 0..9 and global_boost in 0..9 do
+    global_boost = Integer.to_string(9 - global_boost)
+    local_boost = Integer.to_string(9 - local_boost)
 
-    sort_text = boost <> "_" <> item.label
+    sort_text = "0#{global_boost}#{local_boost}_#{item.label}"
     %Completion.Item{item | sort_text: sort_text}
-  end
-
-  def boost(%Completion.Item{} = item, _) do
-    boost(%Completion.Item{} = item, 0)
   end
 
   # end builder behaviour

--- a/apps/server/lib/lexical/server/code_intelligence/completion/env.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/env.ex
@@ -226,6 +226,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Env do
     |> Keyword.put(:insert_text, snippet_text)
     |> Keyword.put(:insert_text_format, :snippet)
     |> Completion.Item.new()
+    |> boost(0)
   end
 
   @impl Builder
@@ -233,6 +234,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Env do
     options
     |> Keyword.put(:insert_text, insert_text)
     |> Completion.Item.new()
+    |> boost(0)
   end
 
   @impl Builder
@@ -244,6 +246,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Env do
     options
     |> Keyword.put(:text_edit, edits)
     |> Completion.Item.new()
+    |> boost(0)
   end
 
   @impl Builder
@@ -256,6 +259,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Env do
     |> Keyword.put(:text_edit, edits)
     |> Keyword.put(:insert_text_format, :snippet)
     |> Completion.Item.new()
+    |> boost(0)
   end
 
   @impl Builder
@@ -264,15 +268,20 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Env do
   def fallback(detail, _), do: detail
 
   @impl Builder
-  def boost(text, amount \\ 5)
+  def boost(item, amount \\ 5)
 
-  def boost(text, amount) when amount in 0..10 do
-    boost_char = ?* - amount
-    IO.iodata_to_binary([boost_char, text])
+  def boost(%Completion.Item{} = item, amount) when amount in 0..99 do
+    boost =
+      (99 - amount)
+      |> Integer.to_string()
+      |> String.pad_leading(3, "0")
+
+    sort_text = boost <> "_" <> item.label
+    %Completion.Item{item | sort_text: sort_text}
   end
 
-  def boost(text, _) do
-    boost(text, 0)
+  def boost(%Completion.Item{} = item, _) do
+    boost(%Completion.Item{} = item, 0)
   end
 
   # end builder behaviour

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/bitstring_option.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/bitstring_option.ex
@@ -15,7 +15,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.BitstringOptio
       kind: :unit,
       label: option.name
     )
-    |> builder.boost(10)
+    |> builder.boost(5)
   end
 
   defp prefix_length(%Env{} = env) do

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/bitstring_option.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/bitstring_option.ex
@@ -9,12 +9,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.BitstringOptio
   def translate(%Result.BitstringOption{} = option, builder, %Env{} = env) do
     start_character = env.position.character - prefix_length(env)
 
-    builder.text_edit(env, option.name, {start_character, env.position.character},
+    env
+    |> builder.text_edit(option.name, {start_character, env.position.character},
       filter_text: option.name,
       kind: :unit,
-      label: option.name,
-      sort_text: builder.boost(option.name, 10)
+      label: option.name
     )
+    |> builder.boost(10)
   end
 
   defp prefix_length(%Env{} = env) do

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
@@ -28,7 +28,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
       kind: :class,
       label: label
     )
-    |> builder.boost(10)
+    |> builder.boost(9)
   end
 
   def translate(%Result.Macro{name: "defp", arity: 2} = macro, builder, env) do
@@ -46,7 +46,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
       kind: :class,
       label: label
     )
-    |> builder.boost(9)
+    |> builder.boost(8)
   end
 
   def translate(%Result.Macro{name: "defmodule"} = macro, builder, env) do
@@ -64,7 +64,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
       kind: :class,
       label: label
     )
-    |> builder.boost(8)
+    |> builder.boost(7)
   end
 
   def translate(%Result.Macro{name: "defmacro", arity: 2} = macro, builder, env) do
@@ -82,7 +82,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
       kind: :class,
       label: label
     )
-    |> builder.boost(7)
+    |> builder.boost(6)
   end
 
   def translate(%Result.Macro{name: "defmacrop", arity: 2} = macro, builder, env) do
@@ -100,7 +100,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
       kind: :class,
       label: label
     )
-    |> builder.boost(6)
+    |> builder.boost(5)
   end
 
   def translate(%Result.Macro{name: "defprotocol"} = macro, builder, env) do

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
@@ -22,12 +22,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label, 10)
+      label: label
     )
+    |> builder.boost(10)
   end
 
   def translate(%Result.Macro{name: "defp", arity: 2} = macro, builder, env) do
@@ -39,12 +40,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label, 9)
+      label: label
     )
+    |> builder.boost(9)
   end
 
   def translate(%Result.Macro{name: "defmodule"} = macro, builder, env) do
@@ -56,12 +58,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label, 8)
+      label: label
     )
+    |> builder.boost(8)
   end
 
   def translate(%Result.Macro{name: "defmacro", arity: 2} = macro, builder, env) do
@@ -73,12 +76,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label, 7)
+      label: label
     )
+    |> builder.boost(7)
   end
 
   def translate(%Result.Macro{name: "defmacrop", arity: 2} = macro, builder, env) do
@@ -90,12 +94,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label, 6)
+      label: label
     )
+    |> builder.boost(6)
   end
 
   def translate(%Result.Macro{name: "defprotocol"} = macro, builder, env) do
@@ -107,12 +112,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "defimpl", arity: 3} = macro, builder, env) do
@@ -124,12 +130,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "defoverridable"} = macro, builder, env) do
@@ -137,12 +144,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
 
     snippet = "defoverridable ${1:keyword or behaviour} $0"
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "defdelegate", arity: 2} = macro, builder, env) do
@@ -152,12 +160,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     defdelegate ${1:call}, to: ${2:module} $0
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "defguard", arity: 1} = macro, builder, env) do
@@ -167,12 +176,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     defguard ${1:call} $0
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "defguardp", arity: 1} = macro, builder, env) do
@@ -182,12 +192,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     defguardp ${1:call} $0
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "defexception", arity: 1} = macro, builder, env) do
@@ -197,12 +208,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     defexception [${1:fields}] $0
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "defstruct", arity: 1} = macro, builder, env) do
@@ -212,12 +224,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     defstruct [${1:fields}] $0
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "alias", arity: 2} = macro, builder, env) do
@@ -225,12 +238,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
 
     snippet = "alias $0"
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "require" <> _, arity: 2} = macro, builder, env) do
@@ -238,12 +252,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
 
     snippet = "require $0"
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "quote" <> _, arity: 2} = macro, builder, env) do
@@ -255,12 +270,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "receive" <> _, arity: 1} = macro, builder, env) do
@@ -272,12 +288,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "try" <> _, arity: 1} = macro, builder, env) do
@@ -289,12 +306,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "with" <> _, arity: 1} = macro, builder, env) do
@@ -306,12 +324,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "case", arity: 2} = macro, builder, env) do
@@ -323,12 +342,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "if", arity: 2} = macro, builder, env) do
@@ -340,12 +360,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "import", arity: 2} = macro, builder, env) do
@@ -353,12 +374,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
 
     snippet = "import $0"
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "unless", arity: 2} = macro, builder, env) do
@@ -370,12 +392,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "cond"} = macro, builder, env) do
@@ -388,12 +411,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "for"} = macro, builder, env) do
@@ -405,39 +429,43 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
     """
 
-    builder.snippet(env, snippet,
+    env
+    |> builder.snippet(snippet,
       detail: macro.spec,
       kind: :class,
-      label: label,
-      sort_text: builder.boost(label)
+      label: label
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: "__MODULE__"} = macro, builder, env) do
     if Env.in_context?(env, :struct_reference) do
-      builder.snippet(env, "%__MODULE__{$1}",
+      env
+      |> builder.snippet("%__MODULE__{$1}",
         detail: "%__MODULE__{}",
         label: "%__MODULE__{}",
         kind: :struct
       )
     else
-      builder.plain_text(env, "__MODULE__",
+      env
+      |> builder.plain_text("__MODULE__",
         detail: macro.spec,
         kind: :constant,
-        label: "__MODULE__",
-        sort_text: builder.boost("__MODULE__")
+        label: "__MODULE__"
       )
+      |> builder.boost()
     end
   end
 
   def translate(%Result.Macro{name: dunder_form} = macro, builder, env)
       when dunder_form in ~w(__CALLER__ __DIR__ __ENV__ __MODULE__ __STACKTRACE__) do
-    builder.plain_text(env, dunder_form,
+    env
+    |> builder.plain_text(dunder_form,
       detail: macro.spec,
       kind: :constant,
-      label: dunder_form,
-      sort_text: builder.boost(dunder_form)
+      label: dunder_form
     )
+    |> builder.boost()
   end
 
   def translate(%Result.Macro{name: dunder_form}, _builder, _env)

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/module_or_behaviour.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/module_or_behaviour.ex
@@ -61,7 +61,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
 
     env
     |> builder.plain_text(module_name, label: module_name, kind: :module, detail: detail)
-    |> builder.boost(20)
+    |> builder.boost(0, 2)
   end
 
   defp local_module_name(parent_module, child_module) do

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/module_or_behaviour.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/module_or_behaviour.ex
@@ -59,7 +59,9 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
   def completion(%Env{} = env, builder, module_name, detail \\ nil) do
     detail = builder.fallback(detail, "#{module_name} (Module)")
 
-    builder.plain_text(env, module_name, label: module_name, kind: :module, detail: detail)
+    env
+    |> builder.plain_text(module_name, label: module_name, kind: :module, detail: detail)
+    |> builder.boost(20)
   end
 
   defp local_module_name(parent_module, child_module) do

--- a/apps/server/test/lexical/server/code_intelligence/completion/env_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/env_test.exs
@@ -1,5 +1,6 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
   alias Lexical.Document
+  alias Lexical.Protocol.Types.Completion.Item, as: CompletionItem
   alias Lexical.Server.CodeIntelligence.Completion
   alias Lexical.Test.CodeSigil
   alias Lexical.Test.CursorSupport
@@ -687,6 +688,55 @@ defmodule Lexical.Server.CodeIntelligence.Completion.EnvTest do
         |> strip_struct_reference()
 
       assert doc == "def my_function(Lo)"
+    end
+  end
+
+  def item(label, opts \\ []) do
+    opts
+    |> Keyword.merge(label: label)
+    |> CompletionItem.new()
+    |> boost(0)
+  end
+
+  defp sort_items(items) do
+    Enum.sort_by(items, &{&1.sort_text, &1.label})
+  end
+
+  describe "boosting" do
+    test "default boost sorts things first" do
+      alpha_first = item("a")
+      alpha_last = "z" |> item() |> boost()
+
+      assert [^alpha_last, ^alpha_first] = sort_items([alpha_first, alpha_last])
+    end
+
+    test "local boost allows you to specify the order" do
+      alpha_first = "a" |> item() |> boost(1)
+      alpha_second = "b" |> item() |> boost(2)
+      alpha_third = "c" |> item() |> boost(3)
+
+      assert [^alpha_third, ^alpha_second, ^alpha_first] =
+               sort_items([alpha_first, alpha_second, alpha_third])
+    end
+
+    test "global boost overrides local boost" do
+      local_max = "a" |> item() |> boost(9)
+      global_min = "z" |> item() |> boost(0, 1)
+
+      assert [^global_min, ^local_max] = sort_items([local_max, global_min])
+    end
+
+    test "items can have a global and local boost" do
+      group_b_min = "a" |> item() |> boost(1)
+      group_b_max = "b" |> item() |> boost(2)
+      group_a_min = "c" |> item |> boost(1, 1)
+      group_a_max = "c" |> item() |> boost(2, 1)
+      global_max = "d" |> item() |> boost(0, 2)
+
+      items = [group_b_min, group_b_max, group_a_min, group_a_max, global_max]
+
+      assert [^global_max, ^group_a_max, ^group_a_min, ^group_b_max, ^group_b_min] =
+               sort_items(items)
     end
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
@@ -603,13 +603,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
   end
 
   describe "sort_text" do
-    test "dunder macros have the dunder removed in their sort_text", %{project: project} do
+    test "dunder macros aren't boosted", %{project: project} do
       assert {:ok, completion} =
                project
                |> complete("Project.__dunder_macro__|")
                |> fetch_completion("__dunder_macro__")
 
-      assert completion.sort_text == "dunder_macro/0"
+      refute boosted?(completion)
     end
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -169,7 +169,7 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
       completions =
         project
         |> complete(code)
-        |> Enum.sort_by(fn result -> result.sort_text || result.insert_text end)
+        |> Enum.sort_by(& &1.sort_text)
 
       module_index = Enum.find_index(completions, &(&1.label == "Foo-module"))
       behaviour_index = Enum.find_index(completions, &(&1.label == "Foo-behaviour"))

--- a/apps/server/test/support/lexical/test/completion_case.ex
+++ b/apps/server/test/support/lexical/test/completion_case.ex
@@ -114,7 +114,6 @@ defmodule Lexical.Test.Server.CompletionCase do
         if expected_amount == :any do
           actual_boost < 99
         else
-          IO.puts("bost: #{99 - expected_amount}")
           actual_boost == 99 - expected_amount
         end
 

--- a/apps/server/test/support/lexical/test/completion_case.ex
+++ b/apps/server/test/support/lexical/test/completion_case.ex
@@ -105,4 +105,21 @@ defmodule Lexical.Test.Server.CompletionCase do
       found when is_list(found) -> {:ok, found}
     end
   end
+
+  def boosted?(%CompletionItem{} = item, expected_amount \\ :any) do
+    case String.split(item.sort_text, "_") do
+      [boost | _rest] ->
+        actual_boost = String.to_integer(boost)
+
+        if expected_amount == :any do
+          actual_boost < 99
+        else
+          IO.puts("bost: #{99 - expected_amount}")
+          actual_boost == 99 - expected_amount
+        end
+
+      _ ->
+        false
+    end
+  end
 end


### PR DESCRIPTION
This pr does two things:

 1. Reorders completions so that modules come before functions
 2. Refactors boost so that it operates on Completion.Item structs

I think the first thing is a welcome change; it's the default for most LS implementations to sort Modules before functions, and the makes boosting things easier. All items now have a default boost of 0, and items can be boosted with a number from 0-9 to boost items of the same kind, or numbers divisible by 10 to boost across item kinds.

Fixes #202 