### PR TITLE
Load project config before compiling

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/state.ex
@@ -185,6 +185,7 @@ defmodule Lexical.RemoteControl.Build.State do
         Mix.Task.clear()
 
         with_progress building_label(project), fn ->
+          Mix.Task.run(:loadconfig)
           result = Mix.Task.run(:compile, mix_compile_opts(force?))
           Mix.Task.run(:loadpaths)
           result
@@ -295,6 +296,7 @@ defmodule Lexical.RemoteControl.Build.State do
           Mix.ProjectStack.pop()
         end
 
+        Mix.Task.run(:loadconfig)
         Code.compile_quoted(quoted_ast, document.path)
       rescue
         exception ->

--- a/apps/remote_control/test/fixtures/project_metadata/config/config.exs
+++ b/apps/remote_control/test/fixtures/project_metadata/config/config.exs
@@ -1,0 +1,3 @@
+import Config
+
+config :project_metadata, date_module: Date

--- a/apps/remote_control/test/lexical/remote_control/build_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build_test.exs
@@ -488,6 +488,23 @@ defmodule Lexical.BuildTest do
     end
   end
 
+  describe "app config" do
+    setup [:with_metadata_project]
+
+    test "allows config to be read", %{project: project} do
+      initial = ~S[
+        defmodule WithConfig do
+          @date_module Application.compile_env(:project_metadata, :date_module)
+          @date_module.utc_today()
+        end
+      ]
+
+      compile_document(project, initial)
+      assert_receive file_compile_requested(uri: file_uri), 500
+      assert_receive file_diagnostics(uri: ^file_uri, diagnostics: []), 500
+    end
+  end
+
   def loaded?(project, module) do
     RemoteControl.call(project, Code, :ensure_loaded?, [module])
   end


### PR DESCRIPTION
We were not loading project config before compiling, which can cause issues, as seen in #214. The solution is to call loadconfig before compiling

Fixes #214

FYI, @crbelaus
