### PR TITLE
Refactor: Completion.Results are now Completion.Candidates

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/completion.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion.ex
@@ -1,6 +1,6 @@
 defmodule Lexical.RemoteControl.Completion do
   alias Lexical.Document.Position
-  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.RemoteControl.Completion.Candidate
 
   def elixir_sense_expand(doc_string, %Position{} = position) do
     # Add one to both the line and character, because elixir sense
@@ -15,7 +15,7 @@ defmodule Lexical.RemoteControl.Completion do
     else
       doc_string
       |> ElixirSense.suggestions(line, character)
-      |> Enum.map(&Result.from_elixir_sense/1)
+      |> Enum.map(&Candidate.from_elixir_sense/1)
     end
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
@@ -1,5 +1,5 @@
-defmodule Lexical.RemoteControl.Completion.Result do
-  alias Lexical.RemoteControl.Completion.Result.ArgumentNames
+defmodule Lexical.RemoteControl.Completion.Candidate do
+  alias Lexical.RemoteControl.Completion.Candidate.ArgumentNames
 
   defmodule Function do
     @moduledoc false

--- a/apps/remote_control/lib/lexical/remote_control/completion/candidate/argument_names.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion/candidate/argument_names.ex
@@ -1,4 +1,4 @@
-defmodule Lexical.RemoteControl.Completion.Result.ArgumentNames do
+defmodule Lexical.RemoteControl.Completion.Candidate.ArgumentNames do
   @moduledoc """
   Elixir sense, for whatever reason returns all the argument names when asked to do a completion on a function.
   This means that the arity of the function might differ from the argument names returned. Furthermore, the

--- a/apps/remote_control/test/fixtures/dependency/lib/dependency/structs.ex
+++ b/apps/remote_control/test/fixtures/dependency/lib/dependency/structs.ex
@@ -1,0 +1,3 @@
+defmodule Dependency.Structs.Service do
+  defstruct [:name, :host, :port]
+end

--- a/apps/remote_control/test/lexical/remote_control/completion/candidate/argument_names_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/completion/candidate/argument_names_test.exs
@@ -1,5 +1,5 @@
-defmodule Lexical.RemoteControl.Completion.Result.ArgumentNamesTest do
-  alias Lexical.RemoteControl.Completion.Result.ArgumentNames
+defmodule Lexical.RemoteControl.Completion.Candidate.ArgumentNamesTest do
+  alias Lexical.RemoteControl.Completion.Candidate.ArgumentNames
 
   use ExUnit.Case
   import ArgumentNames

--- a/apps/server/lib/lexical/server/code_intelligence/completion.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion.ex
@@ -7,7 +7,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
   alias Lexical.Protocol.Types.Completion
   alias Lexical.Protocol.Types.InsertTextFormat
   alias Lexical.RemoteControl
-  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.Project.Intelligence
 
@@ -140,23 +140,28 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
     struct_reference? = Env.in_context?(env, :struct_reference)
 
     cond do
-      struct_reference? and struct_module == Result.Struct ->
+      struct_reference? and struct_module == Candidate.Struct ->
         true
 
-      struct_reference? and struct_module == Result.Module ->
+      struct_reference? and struct_module == Candidate.Module ->
         Intelligence.defines_struct?(env.project, result.full_name, to: :child)
 
-      struct_reference? and match?(%Result.Macro{name: "__MODULE__"}, result) ->
+      struct_reference? and match?(%Candidate.Macro{name: "__MODULE__"}, result) ->
         true
 
       struct_reference? ->
         false
 
       Env.in_context?(env, :bitstring) ->
-        struct_module in [Result.BitstringOption, Result.Variable]
+        struct_module in [Candidate.BitstringOption, Candidate.Variable]
 
       Env.in_context?(env, :alias) ->
-        struct_module in [Result.Behaviour, Result.Module, Result.Protocol, Result.Struct]
+        struct_module in [
+          Candidate.Behaviour,
+          Candidate.Module,
+          Candidate.Protocol,
+          Candidate.Struct
+        ]
 
       true ->
         true
@@ -168,10 +173,10 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
          trigger_character: "%"
        }) do
     case result do
-      %Result.Module{} = result ->
+      %Candidate.Module{} = result ->
         Intelligence.defines_struct?(project, result.full_name, from: :child, to: :child)
 
-      %Result.Struct{} ->
+      %Candidate.Struct{} ->
         true
 
       _other ->

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/bitstring_option.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/bitstring_option.ex
@@ -1,12 +1,12 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.BitstringOption do
-  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
 
-  use Translatable.Impl, for: Result.BitstringOption
+  use Translatable.Impl, for: Candidate.BitstringOption
   require Logger
 
-  def translate(%Result.BitstringOption{} = option, builder, %Env{} = env) do
+  def translate(%Candidate.BitstringOption{} = option, builder, %Env{} = env) do
     start_character = env.position.character - prefix_length(env)
 
     env

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
@@ -1,8 +1,8 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
-  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
 
-  @callables [Result.Function, Result.Macro, Result.Callback]
+  @callables [Candidate.Function, Candidate.Macro, Candidate.Callback]
 
   def completion(%callable_module{arity: 0} = callable, %Env{} = env)
       when callable_module in @callables do

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
@@ -1,12 +1,12 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callback do
-  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
   alias Lexical.Server.CodeIntelligence.Completion.Translations.Callable
 
-  use Translatable.Impl, for: Result.Callback
+  use Translatable.Impl, for: Candidate.Callback
 
-  def translate(%Result.Callback{} = callback, _builder, %Env{} = env) do
+  def translate(%Candidate.Callback{} = callback, _builder, %Env{} = env) do
     Callable.completion(callback, env)
   end
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/function.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/function.ex
@@ -1,12 +1,12 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Function do
-  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
   alias Lexical.Server.CodeIntelligence.Completion.Translations.Callable
 
-  use Translatable.Impl, for: Result.Function
+  use Translatable.Impl, for: Candidate.Function
 
-  def translate(%Result.Function{} = function, _builder, %Env{} = env) do
+  def translate(%Candidate.Function{} = function, _builder, %Env{} = env) do
     if Env.in_context?(env, :function_capture) do
       Callable.capture_completions(function, env)
     else

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
@@ -1,19 +1,19 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
-  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
   alias Lexical.Server.CodeIntelligence.Completion.Translations.Callable
 
-  use Translatable.Impl, for: Result.Macro
+  use Translatable.Impl, for: Candidate.Macro
 
   @snippet_macros ~w(def defp defmacro defmacrop defimpl defmodule defprotocol defguard defguardp defexception)
 
-  def translate(%Result.Macro{name: name}, _builder, _env)
+  def translate(%Candidate.Macro{name: name}, _builder, _env)
       when name in ["__before_compile__", "__using__", "__after_compile__"] do
     :skip
   end
 
-  def translate(%Result.Macro{name: "def", arity: 2} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "def", arity: 2} = macro, builder, env) do
     label = "#{macro.name} (Define a function)"
 
     snippet = """
@@ -31,7 +31,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost(9)
   end
 
-  def translate(%Result.Macro{name: "defp", arity: 2} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "defp", arity: 2} = macro, builder, env) do
     label = "#{macro.name} (Define a private function)"
 
     snippet = """
@@ -49,7 +49,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost(8)
   end
 
-  def translate(%Result.Macro{name: "defmodule"} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "defmodule"} = macro, builder, env) do
     label = "defmodule (Define a module)"
 
     snippet = """
@@ -67,7 +67,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost(7)
   end
 
-  def translate(%Result.Macro{name: "defmacro", arity: 2} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "defmacro", arity: 2} = macro, builder, env) do
     label = "#{macro.name} (Define a macro)"
 
     snippet = """
@@ -85,7 +85,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost(6)
   end
 
-  def translate(%Result.Macro{name: "defmacrop", arity: 2} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "defmacrop", arity: 2} = macro, builder, env) do
     label = "#{macro.name} (Define a private macro)"
 
     snippet = """
@@ -103,7 +103,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost(5)
   end
 
-  def translate(%Result.Macro{name: "defprotocol"} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "defprotocol"} = macro, builder, env) do
     label = "#{macro.name} (Define a protocol)"
 
     snippet = """
@@ -121,7 +121,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "defimpl", arity: 3} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "defimpl", arity: 3} = macro, builder, env) do
     label = "#{macro.name} (Define a protocol implementation)"
 
     snippet = """
@@ -139,7 +139,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "defoverridable"} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "defoverridable"} = macro, builder, env) do
     label = "#{macro.name} (Mark a function as overridable)"
 
     snippet = "defoverridable ${1:keyword or behaviour} $0"
@@ -153,7 +153,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "defdelegate", arity: 2} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "defdelegate", arity: 2} = macro, builder, env) do
     label = "#{macro.name} (Define a delegate function)"
 
     snippet = """
@@ -169,7 +169,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "defguard", arity: 1} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "defguard", arity: 1} = macro, builder, env) do
     label = "#{macro.name} (Define a guard macro)"
 
     snippet = """
@@ -185,7 +185,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "defguardp", arity: 1} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "defguardp", arity: 1} = macro, builder, env) do
     label = "#{macro.name} (Define a private guard macro)"
 
     snippet = """
@@ -201,7 +201,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "defexception", arity: 1} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "defexception", arity: 1} = macro, builder, env) do
     label = "#{macro.name} (Define an exception)"
 
     snippet = """
@@ -217,7 +217,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "defstruct", arity: 1} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "defstruct", arity: 1} = macro, builder, env) do
     label = "#{macro.name} (Define a struct)"
 
     snippet = """
@@ -233,7 +233,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "alias", arity: 2} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "alias", arity: 2} = macro, builder, env) do
     label = "#{macro.name} (alias a module's name)"
 
     snippet = "alias $0"
@@ -247,7 +247,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "require" <> _, arity: 2} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "require" <> _, arity: 2} = macro, builder, env) do
     label = "#{macro.name} (require a module's macros)"
 
     snippet = "require $0"
@@ -261,7 +261,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "quote" <> _, arity: 2} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "quote" <> _, arity: 2} = macro, builder, env) do
     label = "#{macro.name} (quote block)"
 
     snippet = """
@@ -279,7 +279,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "receive" <> _, arity: 1} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "receive" <> _, arity: 1} = macro, builder, env) do
     label = "#{macro.name} (receive block)"
 
     snippet = """
@@ -297,7 +297,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "try" <> _, arity: 1} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "try" <> _, arity: 1} = macro, builder, env) do
     label = "#{macro.name} (try / catch / rescue block)"
 
     snippet = """
@@ -315,7 +315,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "with" <> _, arity: 1} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "with" <> _, arity: 1} = macro, builder, env) do
     label = "with block"
 
     snippet = """
@@ -333,7 +333,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "case", arity: 2} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "case", arity: 2} = macro, builder, env) do
     label = "#{macro.name} (Case statement)"
 
     snippet = """
@@ -351,7 +351,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "if", arity: 2} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "if", arity: 2} = macro, builder, env) do
     label = "#{macro.name} (If statement)"
 
     snippet = """
@@ -369,7 +369,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "import", arity: 2} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "import", arity: 2} = macro, builder, env) do
     label = "#{macro.name} (import a module's functions)"
 
     snippet = "import $0"
@@ -383,7 +383,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "unless", arity: 2} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "unless", arity: 2} = macro, builder, env) do
     label = "#{macro.name} (Unless statement)"
 
     snippet = """
@@ -401,7 +401,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "cond"} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "cond"} = macro, builder, env) do
     label = "#{macro.name} (Cond statement)"
 
     snippet = """
@@ -420,7 +420,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "for"} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "for"} = macro, builder, env) do
     label = "#{macro.name} (comprehension)"
 
     snippet = """
@@ -438,7 +438,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: "__MODULE__"} = macro, builder, env) do
+  def translate(%Candidate.Macro{name: "__MODULE__"} = macro, builder, env) do
     if Env.in_context?(env, :struct_reference) do
       env
       |> builder.snippet("%__MODULE__{$1}",
@@ -457,7 +457,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     end
   end
 
-  def translate(%Result.Macro{name: dunder_form} = macro, builder, env)
+  def translate(%Candidate.Macro{name: dunder_form} = macro, builder, env)
       when dunder_form in ~w(__CALLER__ __DIR__ __ENV__ __MODULE__ __STACKTRACE__) do
     env
     |> builder.plain_text(dunder_form,
@@ -468,17 +468,17 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost()
   end
 
-  def translate(%Result.Macro{name: dunder_form}, _builder, _env)
+  def translate(%Candidate.Macro{name: dunder_form}, _builder, _env)
       when dunder_form in ~w(__aliases__ __block__) do
     :skip
   end
 
-  def translate(%Result.Macro{name: name} = macro, _builder, env)
+  def translate(%Candidate.Macro{name: name} = macro, _builder, env)
       when name not in @snippet_macros do
     Callable.completion(macro, env)
   end
 
-  def translate(%Result.Macro{}, _builder, _env) do
+  def translate(%Candidate.Macro{}, _builder, _env) do
     :skip
   end
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/module_attribute.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/module_attribute.ex
@@ -1,10 +1,10 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleAttribute do
-  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
 
-  use Translatable.Impl, for: Result.ModuleAttribute
+  use Translatable.Impl, for: Candidate.ModuleAttribute
 
-  def translate(%Result.ModuleAttribute{name: "@moduledoc"}, builder, env) do
+  def translate(%Candidate.ModuleAttribute{name: "@moduledoc"}, builder, env) do
     doc_snippet = ~s(
       @moduledoc """
       $0
@@ -28,7 +28,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleAttribut
     [with_doc, without_doc]
   end
 
-  def translate(%Result.ModuleAttribute{name: "@doc"}, builder, env) do
+  def translate(%Candidate.ModuleAttribute{name: "@doc"}, builder, env) do
     doc_snippet = ~s(
       @doc """
       $0
@@ -52,7 +52,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleAttribut
     [with_doc, without_doc]
   end
 
-  def translate(%Result.ModuleAttribute{} = attribute, builder, env) do
+  def translate(%Candidate.ModuleAttribute{} = attribute, builder, env) do
     builder.plain_text(env, attribute.name,
       detail: "module attribute",
       kind: :constant,

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/module_or_behaviour.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/module_or_behaviour.ex
@@ -1,21 +1,21 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehaviour do
-  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
   alias Lexical.Server.CodeIntelligence.Completion.Translations
   alias Lexical.Server.Project.Intelligence
 
-  use Translatable.Impl, for: [Result.Module, Result.Behaviour, Result.Protocol]
+  use Translatable.Impl, for: [Candidate.Module, Candidate.Behaviour, Candidate.Protocol]
 
-  def translate(%Result.Module{} = module, builder, %Env{} = env) do
+  def translate(%Candidate.Module{} = module, builder, %Env{} = env) do
     do_translate(module, builder, env)
   end
 
-  def translate(%Result.Behaviour{} = behaviour, builder, %Env{} = env) do
+  def translate(%Candidate.Behaviour{} = behaviour, builder, %Env{} = env) do
     do_translate(behaviour, builder, env)
   end
 
-  def translate(%Result.Protocol{} = protocol, builder, %Env{} = env) do
+  def translate(%Candidate.Protocol{} = protocol, builder, %Env{} = env) do
     do_translate(protocol, builder, env)
   end
 

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct.ex
@@ -1,12 +1,12 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Struct do
-  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
   alias Lexical.Server.CodeIntelligence.Completion.Translations
 
-  use Translatable.Impl, for: Result.Struct
+  use Translatable.Impl, for: Candidate.Struct
 
-  def translate(%Result.Struct{} = struct, builder, %Env{} = env) do
+  def translate(%Candidate.Struct{} = struct, builder, %Env{} = env) do
     if Env.in_context?(env, :struct_reference) do
       completion(env, builder, struct.name, struct.full_name)
     else

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct_field.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct_field.ex
@@ -1,15 +1,15 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructField do
-  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
 
-  use Translatable.Impl, for: Result.StructField
+  use Translatable.Impl, for: Candidate.StructField
 
-  def translate(%Result.StructField{name: "__struct__"}, _builder, _env) do
+  def translate(%Candidate.StructField{name: "__struct__"}, _builder, _env) do
     :skip
   end
 
-  def translate(%Result.StructField{} = struct_field, builder, %Env{} = env) do
+  def translate(%Candidate.StructField{} = struct_field, builder, %Env{} = env) do
     builder.plain_text(env, struct_field.name,
       detail: struct_field.name,
       label: struct_field.name,

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/variable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/variable.ex
@@ -1,11 +1,11 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Variable do
-  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
 
-  use Translatable.Impl, for: Result.Variable
+  use Translatable.Impl, for: Candidate.Variable
 
-  def translate(%Result.Variable{} = variable, builder, %Env{} = env) do
+  def translate(%Candidate.Variable{} = variable, builder, %Env{} = env) do
     builder.plain_text(env, variable.name,
       detail: variable.name,
       kind: :variable,

--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -1,7 +1,7 @@
 defmodule Lexical.Server.CodeIntelligence.CompletionTest do
   alias Lexical.Document
   alias Lexical.Protocol.Types.Completion
-  alias Lexical.RemoteControl.Completion.Result
+  alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
 
   use Lexical.Test.Server.CompletionCase
@@ -117,26 +117,26 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
     full_name = "A.B.Foo"
 
     all_completions = [
-      %Result.Behaviour{name: "#{name}-behaviour", full_name: full_name},
-      %Result.BitstringOption{name: "#{name}-bitstring", type: "integer"},
-      %Result.Callback{
+      %Candidate.Behaviour{name: "#{name}-behaviour", full_name: full_name},
+      %Candidate.BitstringOption{name: "#{name}-bitstring", type: "integer"},
+      %Candidate.Callback{
         name: "#{name}-callback",
         origin: full_name,
         argument_names: [],
         metadata: %{}
       },
-      %Result.Exception{name: "#{name}-exception", full_name: full_name},
-      %Result.Function{name: "my_func", origin: full_name, argument_names: [], metadata: %{}},
-      %Result.Macro{name: "my_macro", origin: full_name, argument_names: [], metadata: %{}},
-      %Result.MixTask{name: "#{name}-mix-task", full_name: full_name},
-      %Result.Module{name: "#{name}-module", full_name: full_name},
-      %Result.Module{name: "#{name}-submodule", full_name: "#{full_name}.Bar"},
-      %Result.ModuleAttribute{name: "#{name}-module-attribute"},
-      %Result.Protocol{name: "#{name}-protocol", full_name: full_name},
-      %Result.Struct{name: "#{name}-struct", full_name: full_name},
-      %Result.StructField{name: "#{name}-struct-field", origin: full_name},
-      %Result.Typespec{name: "#{name}-typespec"},
-      %Result.Variable{name: "#{name}-variable"}
+      %Candidate.Exception{name: "#{name}-exception", full_name: full_name},
+      %Candidate.Function{name: "my_func", origin: full_name, argument_names: [], metadata: %{}},
+      %Candidate.Macro{name: "my_macro", origin: full_name, argument_names: [], metadata: %{}},
+      %Candidate.MixTask{name: "#{name}-mix-task", full_name: full_name},
+      %Candidate.Module{name: "#{name}-module", full_name: full_name},
+      %Candidate.Module{name: "#{name}-submodule", full_name: "#{full_name}.Bar"},
+      %Candidate.ModuleAttribute{name: "#{name}-module-attribute"},
+      %Candidate.Protocol{name: "#{name}-protocol", full_name: full_name},
+      %Candidate.Struct{name: "#{name}-struct", full_name: full_name},
+      %Candidate.StructField{name: "#{name}-struct-field", origin: full_name},
+      %Candidate.Typespec{name: "#{name}-typespec"},
+      %Candidate.Variable{name: "#{name}-variable"}
     ]
 
     patch(Lexical.RemoteControl.Api, :complete, all_completions)


### PR DESCRIPTION
There are a lot of things called `Result` in this codebase. Upon using the completion results, it's pretty clear that they're not really "results", but they're candidates, ready for further refinement by the language server. Hopefully, this nomenclature is more clear.