### PR TITLE
Generate `.gitignore` for `.lexical` project workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,11 +22,10 @@ erl_crash.dump
 # Temporary files, for example, from tests.
 /tmp/
 
-.lexical
-
 lexical.log
 
 lexical_debug
 
 priv/plts
+
 apps/common/src/future_elixir_parser.erl

--- a/apps/remote_control/lib/lexical/remote_control/bootstrap.ex
+++ b/apps/remote_control/lib/lexical/remote_control/bootstrap.ex
@@ -28,7 +28,7 @@ defmodule Lexical.RemoteControl.Bootstrap do
       ExUnit.start()
       start_logger(project)
       maybe_change_directory(project)
-      Project.ensure_workspace_exists(project)
+      Project.ensure_workspace(project)
     end
   end
 

--- a/apps/remote_control/test/fixtures/compilation_errors/.gitignore
+++ b/apps/remote_control/test/fixtures/compilation_errors/.gitignore
@@ -24,5 +24,3 @@ compilation_errors-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
-
-.lexical

--- a/apps/remote_control/test/fixtures/compilation_warnings/.gitignore
+++ b/apps/remote_control/test/fixtures/compilation_warnings/.gitignore
@@ -24,5 +24,3 @@ compilation_warnings-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
-
-.lexical

--- a/apps/remote_control/test/fixtures/project_metadata/.gitignore
+++ b/apps/remote_control/test/fixtures/project_metadata/.gitignore
@@ -24,5 +24,3 @@ project_metadata-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
-
-.lexical

--- a/apps/remote_control/test/fixtures/umbrella/.gitignore
+++ b/apps/remote_control/test/fixtures/umbrella/.gitignore
@@ -21,5 +21,3 @@ erl_crash.dump
 
 # Temporary files, for example, from tests.
 /tmp/
-
-.lexical

--- a/apps/server/.gitignore
+++ b/apps/server/.gitignore
@@ -24,5 +24,3 @@ server-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
-
-**/.lexical

--- a/projects/lexical_shared/lib/lexical/project.ex
+++ b/projects/lexical_shared/lib/lexical/project.ex
@@ -157,9 +157,15 @@ defmodule Lexical.Project do
   end
 
   @doc """
-  Creates lexical's workspace directory if it doesn't already exist
+  Creates and initializes lexical's workspace directory if it doesn't already exist
   """
-  def ensure_workspace_exists(%__MODULE__{} = project) do
+  def ensure_workspace(%__MODULE__{} = project) do
+    with :ok <- ensure_workspace_directory(project) do
+      ensure_git_ignore(project)
+    end
+  end
+
+  defp ensure_workspace_directory(project) do
     workspace_path = workspace_path(project)
 
     cond do
@@ -175,7 +181,19 @@ defmodule Lexical.Project do
     end
   end
 
-  # private
+  defp ensure_git_ignore(project) do
+    contents = """
+    *
+    """
+
+    path = workspace_path(project, ".gitignore")
+
+    if File.exists?(path) do
+      :ok
+    else
+      File.write(path, contents)
+    end
+  end
 
   defp maybe_set_root_uri(%__MODULE__{} = project, nil),
     do: %__MODULE__{project | root_uri: nil}


### PR DESCRIPTION
During the bootstrap process, Lexical creates a `.lexical` directory containing logs and build artifacts. Creating a `.gitignore` in this directory by default means developers don't have to modify their own per-project when using Lexical.