### PR TITLE
Added versions to plugins

### DIFF
--- a/apps/protocol/lib/lexical/protocol/convertibles/lexical.plugin.diagnostic.result.ex
+++ b/apps/protocol/lib/lexical/protocol/convertibles/lexical.plugin.diagnostic.result.ex
@@ -1,9 +1,9 @@
-defimpl Lexical.Convertible, for: Lexical.Plugin.Diagnostic.Result do
+defimpl Lexical.Convertible, for: Lexical.Plugin.V1.Diagnostic.Result do
   alias Lexical.Document
   alias Lexical.Document.Position
   alias Lexical.Document.Range
   alias Lexical.Math
-  alias Lexical.Plugin.Diagnostic
+  alias Lexical.Plugin.V1.Diagnostic
   alias Lexical.Protocol.Conversions
   alias Lexical.Protocol.Types
   alias Lexical.Text

--- a/apps/protocol/test/lexical/protocol/convertibles/lexical.plugin.diagnostic.result_test.exs
+++ b/apps/protocol/test/lexical/protocol/convertibles/lexical.plugin.diagnostic.result_test.exs
@@ -1,6 +1,6 @@
-defmodule Lexical.Convertibles.Lexical.Plugin.Diagnostic.ResultTest do
+defmodule Lexical.Convertibles.Lexical.Plugin.V1.Diagnostic.ResultTest do
   alias Lexical.Document
-  alias Lexical.Plugin.Diagnostic
+  alias Lexical.Plugin.V1.Diagnostic
   use Lexical.Test.Protocol.ConvertibleSupport
 
   import Lexical.Test.CodeSigil

--- a/apps/remote_control/lib/lexical/remote_control/build/error.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/error.ex
@@ -1,6 +1,6 @@
 defmodule Lexical.RemoteControl.Build.Error do
   alias Lexical.Document
-  alias Lexical.Plugin.Diagnostic.Result
+  alias Lexical.Plugin.V1.Diagnostic.Result
   alias Mix.Task.Compiler
 
   require Logger

--- a/apps/remote_control/test/lexical/remote_control/build/error_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/error_test.exs
@@ -1,6 +1,6 @@
 defmodule Lexical.RemoteControl.Build.ErrorTest do
   alias Lexical.Document
-  alias Lexical.Plugin.Diagnostic
+  alias Lexical.Plugin.V1.Diagnostic
   alias Lexical.RemoteControl.Build.Error
 
   use ExUnit.Case, async: true

--- a/apps/remote_control/test/lexical/remote_control/build_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build_test.exs
@@ -1,6 +1,6 @@
 defmodule Lexical.BuildTest do
   alias Lexical.Document
-  alias Lexical.Plugin.Diagnostic
+  alias Lexical.Plugin.V1.Diagnostic
   alias Lexical.Project
   alias Lexical.RemoteControl
   alias Lexical.RemoteControl.Api.Messages

--- a/apps/server/lib/lexical/server/project/diagnostics/state.ex
+++ b/apps/server/lib/lexical/server/project/diagnostics/state.ex
@@ -29,7 +29,7 @@ defmodule Lexical.Server.Project.Diagnostics.State do
   end
 
   alias Lexical.Document
-  alias Lexical.Plugin.Diagnostic
+  alias Lexical.Plugin.V1.Diagnostic
   alias Lexical.Project
 
   defstruct project: nil, entries_by_uri: %{}

--- a/apps/server/test/lexical/server/project/diagnostics/state_test.exs
+++ b/apps/server/test/lexical/server/project/diagnostics/state_test.exs
@@ -1,7 +1,7 @@
 defmodule Lexical.Project.Diagnostics.StateTest do
   alias Lexical.Document
   alias Lexical.Document.Edit
-  alias Lexical.Plugin.Diagnostic
+  alias Lexical.Plugin.V1.Diagnostic
   alias Lexical.Project
   alias Lexical.Server.Project.Diagnostics.State
 

--- a/apps/server/test/lexical/server/project/diagnostics_test.exs
+++ b/apps/server/test/lexical/server/project/diagnostics_test.exs
@@ -1,6 +1,6 @@
 defmodule Lexical.Server.Project.DiagnosticsTest do
   alias Lexical.Document
-  alias Lexical.Plugin.Diagnostic
+  alias Lexical.Plugin.V1.Diagnostic
   alias Lexical.Project
   alias Lexical.Protocol.Notifications.PublishDiagnostics
   alias Lexical.Server.Project

--- a/projects/lexical_credo/lib/lexical_credo.ex
+++ b/projects/lexical_credo/lib/lexical_credo.ex
@@ -1,6 +1,6 @@
 defmodule LexicalCredo do
   alias Lexical.Document
-  alias Lexical.Plugin.Diagnostic
+  alias Lexical.Plugin.V1.Diagnostic
   alias Lexical.Project
 
   use Diagnostic, name: :lexical_credo

--- a/projects/lexical_credo/test/lexical_credo_test.exs
+++ b/projects/lexical_credo/test/lexical_credo_test.exs
@@ -1,5 +1,5 @@
 defmodule LexicalCredoTest do
-  alias Lexical.Plugin.Diagnostic.Result
+  alias Lexical.Plugin.V1.Diagnostic.Result
   alias Lexical.Document
 
   import LexicalCredo

--- a/projects/lexical_plugin/README.md
+++ b/projects/lexical_plugin/README.md
@@ -6,7 +6,7 @@ Extend lexical's functionality
 Plugins are used to extend lexical's functionality and provide opt-in diagnostics, completion, and code intelligence features without having to build inside of Lexical itself.
 
 ## Plugin Types
-The goal of the plugin project is to have different types of plugins that affect lexical in different ways. Presently, only diagnostic plugins are supported. A diagnostic examines a mix project or a document and emits `Lexical.Plugin.Diagnostic.Result` structs to direct the user's attention to any issues it finds.
+The goal of the plugin project is to have different types of plugins that affect lexical in different ways. Presently, only diagnostic plugins are supported. A diagnostic examines a mix project or a document and emits `Lexical.Plugin.V1.Diagnostic.Result` structs to direct the user's attention to any issues it finds.
 Diagnostic plugins can be used to integrate code linters like `credo` or to enforce project-specific rules and coding practices.
 
 ### Creating a diagnostic plugin
@@ -36,7 +36,7 @@ Now we implement the plugin module. In our module, we're going to emit an error 
 ```elixir
 defmodule NoisyPlugin do
   alias Lexical.Document
-  alias Lexical.Plugin.Diagnostic
+  alias Lexical.Plugin.V1.Diagnostic
   alias Lexical.Project
 
   use Diagnostic, name: :noisy_example_plugin

--- a/projects/lexical_plugin/lib/lexical/plugin/v1/diagnostic.ex
+++ b/projects/lexical_plugin/lib/lexical/plugin/v1/diagnostic.ex
@@ -1,6 +1,6 @@
-defmodule Lexical.Plugin.Diagnostic do
+defmodule Lexical.Plugin.V1.Diagnostic do
   alias Lexical.Document
-  alias Lexical.Plugin.Diagnostic
+  alias Lexical.Plugin.V1.Diagnostic
   alias Lexical.Project
 
   @type state :: any()

--- a/projects/lexical_plugin/lib/lexical/plugin/v1/diagnostic/result.ex
+++ b/projects/lexical_plugin/lib/lexical/plugin/v1/diagnostic/result.ex
@@ -1,4 +1,4 @@
-defmodule Lexical.Plugin.Diagnostic.Result do
+defmodule Lexical.Plugin.V1.Diagnostic.Result do
   @moduledoc """
   The result of a diagnostic run
 

--- a/projects/lexical_plugin/test/lexical/coordinator/state_test.exs
+++ b/projects/lexical_plugin/test/lexical/coordinator/state_test.exs
@@ -1,7 +1,7 @@
 defmodule Lexical.Plugin.Coordinator.StateTest do
   alias Lexical.Document
-  alias Lexical.Plugin
   alias Lexical.Plugin.Coordinator.State
+  alias Lexical.Plugin
 
   use ExUnit.Case
 
@@ -17,7 +17,7 @@ defmodule Lexical.Plugin.Coordinator.StateTest do
   end
 
   defmodule FailsInit do
-    use Plugin.Diagnostic, name: :fails_init
+    use Plugin.V1.Diagnostic, name: :fails_init
 
     def init do
       {:error, :failed}
@@ -34,7 +34,7 @@ defmodule Lexical.Plugin.Coordinator.StateTest do
   end
 
   defmodule Echo do
-    use Plugin.Diagnostic, name: :echo
+    use Plugin.V1.Diagnostic, name: :echo
 
     def handle(subject) do
       {:ok, [subject]}
@@ -42,7 +42,7 @@ defmodule Lexical.Plugin.Coordinator.StateTest do
   end
 
   defmodule MultipleResults do
-    use Plugin.Diagnostic, name: :multiple_results
+    use Plugin.V1.Diagnostic, name: :multiple_results
 
     def handle(subject) do
       {:ok, [subject, subject]}
@@ -67,7 +67,7 @@ defmodule Lexical.Plugin.Coordinator.StateTest do
 
   describe "failure modes" do
     defmodule TimesOut do
-      use Plugin.Diagnostic, name: :times_out
+      use Plugin.V1.Diagnostic, name: :times_out
 
       def handle(subject) do
         Process.sleep(5000)
@@ -76,7 +76,7 @@ defmodule Lexical.Plugin.Coordinator.StateTest do
     end
 
     defmodule Crashes do
-      use Plugin.Diagnostic, name: :crashes
+      use Plugin.V1.Diagnostic, name: :crashes
 
       def handle(subject) do
         45 = subject
@@ -85,7 +85,7 @@ defmodule Lexical.Plugin.Coordinator.StateTest do
     end
 
     defmodule Errors do
-      use Plugin.Diagnostic, name: :errors
+      use Plugin.V1.Diagnostic, name: :errors
 
       def handle(_) do
         {:error, :invalid_subject}
@@ -93,7 +93,7 @@ defmodule Lexical.Plugin.Coordinator.StateTest do
     end
 
     defmodule BadReturn do
-      use Plugin.Diagnostic, name: :bad_return
+      use Plugin.V1.Diagnostic, name: :bad_return
 
       def handle(subject) do
         {:ok, subject}

--- a/projects/lexical_plugin/test/lexical/coordinator_test.exs
+++ b/projects/lexical_plugin/test/lexical/coordinator_test.exs
@@ -20,7 +20,7 @@ defmodule Lexical.Plugin.CoordinatorTest do
     alias Lexical.Document
     alias Lexical.Project
 
-    use Lexical.Plugin.Diagnostic, name: :report_back
+    use Lexical.Plugin.V1.Diagnostic, name: :report_back
 
     def handle(%Document{} = doc) do
       {:ok, [doc]}
@@ -77,7 +77,7 @@ defmodule Lexical.Plugin.CoordinatorTest do
 
   describe "handling exceptional conditions" do
     defmodule Crashy do
-      use Lexical.Plugin.Diagnostic, name: :crashy
+      use Lexical.Plugin.V1.Diagnostic, name: :crashy
 
       def handle(_) do
         raise "Bad"
@@ -85,7 +85,7 @@ defmodule Lexical.Plugin.CoordinatorTest do
     end
 
     defmodule Slow do
-      use Lexical.Plugin.Diagnostic, name: :slow
+      use Lexical.Plugin.V1.Diagnostic, name: :slow
 
       def handle(_) do
         Process.sleep(500)
@@ -94,7 +94,7 @@ defmodule Lexical.Plugin.CoordinatorTest do
     end
 
     defmodule BadReturn do
-      use Lexical.Plugin.Diagnostic, name: :bad_return
+      use Lexical.Plugin.V1.Diagnostic, name: :bad_return
 
       def handle(_) do
         {:ok, 34}
@@ -102,7 +102,7 @@ defmodule Lexical.Plugin.CoordinatorTest do
     end
 
     defmodule Exits do
-      use Lexical.Plugin.Diagnostic, name: :exits
+      use Lexical.Plugin.V1.Diagnostic, name: :exits
 
       def handle(_) do
         exit(:bad)


### PR DESCRIPTION
Before we release plugins, we need to make sure we have wiggle room in the future to change things if need be. Hopefully, versioning like this will allow us to release incompatible changes in the future.