### PR TITLE
Bump erlang to 25.3.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-erlang 25.2.1
+erlang 25.3.2
 elixir 1.14.3-otp-25
 nodejs 12.16.3
 yarn 1.22.4


### PR DESCRIPTION
Per discussion [here](https://elixirforum.com/t/how-to-make-a-release-for-a-system-with-erlang-installed/35241/3) the erlang version should be identical in both the extension and lexical when building yourself.

This PR brings the erlang version in line with lexical-lsp/vscode-lexical repo.

```
=erl_crash_dump:0.5
Slogan: init terminating in do_boot ({load_failed,[lists,logger,logger_simple_h,logger_config,supervisor,logger_server,logger_filters,filename,heart,gen,error_logger,gen_server,code_server,file,ets,erl_parse,erl_eval,code,application_master,application_controller,application,error_handler,gen_event,file_io_server,file_server,erl_lint,proc_lib,logger_backend,kernel]})
```