### PR TITLE
Second attempt to make struct completion more consistent

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct.ex
@@ -1,5 +1,7 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Struct do
   alias Future.Code, as: Code
+  alias Lexical.Formats
+
   alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
@@ -20,10 +22,17 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Struct do
     end
   end
 
+  def completion(%Env{} = _env, _builder, _module_name, _full_name, 0) do
+    nil
+  end
+
   def completion(%Env{} = env, builder, module_name, full_name, more) when is_integer(more) do
+    singular = "${count} more struct"
+    plural = "${count} more structs"
+
     builder_opts = [
       kind: :module,
-      label: "#{module_name}...(#{more} more structs)",
+      label: "#{module_name}...(#{Formats.plural(more, singular, plural)})",
       detail: "#{full_name}."
     ]
 

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct.ex
@@ -1,26 +1,7 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Struct do
   alias Future.Code, as: Code
   alias Lexical.Formats
-
-  alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
-  alias Lexical.Server.CodeIntelligence.Completion.Translatable
-  alias Lexical.Server.CodeIntelligence.Completion.Translations
-
-  use Translatable.Impl, for: Candidate.Struct
-
-  def translate(%Candidate.Struct{} = struct, builder, %Env{} = env) do
-    if Env.in_context?(env, :struct_reference) do
-      completion(env, builder, struct.name, struct.full_name)
-    else
-      Translations.ModuleOrBehaviour.completion(
-        env,
-        builder,
-        struct.name,
-        struct.full_name
-      )
-    end
-  end
 
   def completion(%Env{} = _env, _builder, _module_name, _full_name, 0) do
     nil

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/module_or_behaviour_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/module_or_behaviour_test.exs
@@ -202,15 +202,10 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
     test "should offer no other types of completions", %{project: project} do
       assert [] = complete(project, "%MapSet.|")
 
-      assert [account, order, order_line, user] =
-               project
-               |> complete("%Project.|")
-               |> Enum.sort_by(& &1.label)
+      assert [completion] = complete(project, "%Project.|")
 
-      assert account.label == "Structs.Account"
-      assert order.label == "Structs.Order"
-      assert order_line.label == "Structs.Order.Line"
-      assert user.label == "Structs.User"
+      assert completion.label == "Structs...(4 more structs)"
+      assert completion.detail == "Project.Structs."
     end
 
     test "should offer two completions when there are struct and its descendants", %{
@@ -221,9 +216,9 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
         %Ord|
       ]
 
-      [order_line, order] = complete(project, source)
+      [order, order_line] = complete(project, source)
 
-      assert order_line.label == "Order...(1 more structs)"
+      assert order_line.label == "Order...(1 more struct)"
       assert order_line.kind == :module
       assert apply_completion(order_line) =~ "%Order."
 

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_test.exs
@@ -128,8 +128,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructTest do
       assert apply_completion(completion) == expected
     end
 
-    test "when using %, part child structs are returned", %{project: project} do
-      assert [account, order, user] =
+    test "when using %, child structs are returned", %{project: project} do
+      assert [account, order, order_line, user] =
                project
                |> complete("%Project.Structs.|", "%")
                |> Enum.sort_by(& &1.label)
@@ -137,33 +137,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructTest do
       assert account.label == "Account"
       assert account.detail == "Project.Structs.Account"
 
+      assert user.label == "User"
+      assert user.detail == "Project.Structs.User"
+
       assert order.label == "Order"
       assert order.detail == "Project.Structs.Order"
 
-      assert user.label == "User"
-      assert user.detail == "Project.Structs.User"
-    end
-
-    @tag :skip
-    test "when using %, child structs are returned", %{project: project} do
-      assert [account, order, order_line, user] =
-               project
-               |> complete("%Project.Structs.|", "%")
-               |> Enum.sort_by(& &1.label)
-
-      assert account.label == "Structs.Account"
-      assert account.detail == "Project.Structs.Account"
-
-      assert user.label == "Structs.User"
-      assert user.detail == "Project.Structs.User"
-
-      assert order.label == "Structs.Order"
-      assert order.detail == "Project.Structs.Order"
-
-      # NOTE: though we have stripped the "%" symbol, ElixirSense still returns structs,
-      # so I think we need to handle it in the same way as the module,
-      # which will bring more consistency.
-      assert order_line.label == "Structs.Order...(1 more struct)"
+      assert order_line.label == "Order...(1 more struct)"
       assert order_line.detail == "Project.Structs.Order."
     end
 

--- a/apps/server/test/lexical/server/project/intelligence_test.exs
+++ b/apps/server/test/lexical/server/project/intelligence_test.exs
@@ -119,7 +119,10 @@ defmodule Lexical.Server.Project.IntelligenceTest do
                Intelligence.collect_struct_modules(project, "Parent", from: :child, to: :child)
 
       assert ["Parent.Child.GrandchildWithStruct"] =
-               Intelligence.collect_struct_modules(project, Parent.Child, from: :child, to: :child)
+               Intelligence.collect_struct_modules(project, Parent.Child,
+                 from: :child,
+                 to: :child
+               )
     end
 
     test "collecting a range of structs", %{project: project} do
@@ -171,6 +174,15 @@ defmodule Lexical.Server.Project.IntelligenceTest do
 
       assert ["Parent.Child.GrandchildWithStruct"] =
                Intelligence.collect_struct_modules(project, "Parent", 2..3)
+    end
+
+    test "collecting modules using `:infinity`", %{project: project} do
+      collected = Intelligence.collect_struct_modules(project, "Parent", :infinity)
+
+      assert [grandchild_struct, child_struct] = collected
+
+      assert child_struct == "Parent.ChildWithStruct"
+      assert grandchild_struct == "Parent.Child.GrandchildWithStruct"
     end
   end
 end

--- a/projects/lexical_shared/lib/lexical/formats.ex
+++ b/projects/lexical_shared/lib/lexical/formats.ex
@@ -88,4 +88,17 @@ defmodule Lexical.Formats do
   defp to_milliseconds(millis, :millisecond) do
     millis
   end
+
+  def plural(count, singular, plural) do
+    case count do
+      0 -> templatize(count, plural)
+      1 -> templatize(count, singular)
+      _n -> templatize(count, plural)
+    end
+  end
+
+  defp templatize(count, template) do
+    count_string = Integer.to_string(count)
+    String.replace(template, "${count}", count_string)
+  end
 end

--- a/projects/lexical_shared/test/lexical/formats_test.exs
+++ b/projects/lexical_shared/test/lexical/formats_test.exs
@@ -33,4 +33,16 @@ defmodule Lexical.FormatsTest do
       assert "0.02 ms" = Formats.time(20)
     end
   end
+
+  describe "plural/3" do
+    test "returns singular when count is 1" do
+      assert Formats.plural(1, "${count} apple", "${count} apples") == "1 apple"
+    end
+
+    test "returns plural when count is not 1" do
+      assert Formats.plural(0, "${count} apple", "${count} apples") == "0 apples"
+      assert Formats.plural(2, "${count} apple", "${count} apples") == "2 apples"
+      assert Formats.plural(3, "${count} apple", "${count} apples") == "3 apples"
+    end
+  end
 end


### PR DESCRIPTION
I think this is what we want.

Two things here:

### 1. Make module completions translation more consistent

The execution steps of new new algorithm are as follows:

1. If there is only one module within three generations, only that module will be returned, e.g.: `%Lexical.Document.Changes{}`
<img width="606" alt="CleanShot 2023-07-29 at 14 32 57@2x" src="https://github.com/lexical-lsp/lexical/assets/12830256/0dc3f4eb-0e65-41ed-829a-3862a15c21f6">

2. If there are more structs within three generations and the first layer of the struct has ancestor structs, the ancestor structs and more will be mixedly returned, but not the ancestor module.
<img width="576" alt="CleanShot 2023-07-29 at 14 32 39@2x" src="https://github.com/lexical-lsp/lexical/assets/12830256/e1e635b8-9024-45fe-be18-e3d7e567a5ec">

3. If there are no ancestor structs, only more will be returned.
<img width="389" alt="CleanShot 2023-07-29 at 14 33 22@2x" src="https://github.com/lexical-lsp/lexical/assets/12830256/31c57604-0cdc-4271-b199-5ed5ee73c6ee">


In addition, we do not return any structs beyond two generations due to `dots_count + 1`.

### 2. Make struct completions translation consistent as module translation

<img width="628" alt="CleanShot 2023-07-29 at 21 25 01@2x" src="https://github.com/lexical-lsp/lexical/assets/12830256/9e1ca8bb-a35e-470d-9c18-06d760813485">

When our completion is triggered by a dot, ElixirSense still provides us with struct completion, so we need a consistent approach.

Fixes part of #182 