### PR TITLE
Support map fields completion

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
@@ -106,6 +106,15 @@ defmodule Lexical.RemoteControl.Completion.Candidate do
     end
   end
 
+  defmodule MapField do
+    @moduledoc false
+    defstruct [:call?, :name]
+
+    def new(%{} = elixir_sense_map) do
+      struct(__MODULE__, elixir_sense_map)
+    end
+  end
+
   defmodule ModuleAttribute do
     @moduledoc false
     defstruct [:name]
@@ -212,6 +221,10 @@ defmodule Lexical.RemoteControl.Completion.Candidate do
 
   def from_elixir_sense(%{type: :field, subtype: :struct_field} = elixir_sense_map) do
     StructField.new(elixir_sense_map)
+  end
+
+  def from_elixir_sense(%{type: :field, subtype: :map_key} = elixir_sense_map) do
+    MapField.new(elixir_sense_map)
   end
 
   def from_elixir_sense(%{type: :callback} = elixir_sense_map) do

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/map_field.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/map_field.ex
@@ -1,0 +1,15 @@
+defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MapField do
+  alias Lexical.RemoteControl.Completion.Candidate
+  alias Lexical.Server.CodeIntelligence.Completion.Env
+  alias Lexical.Server.CodeIntelligence.Completion.Translatable
+
+  use Translatable.Impl, for: Candidate.MapField
+
+  def translate(%Candidate.MapField{} = map_field, builder, %Env{} = env) do
+    builder.plain_text(env, map_field.name,
+      detail: map_field.name,
+      label: map_field.name,
+      kind: :field
+    )
+  end
+end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/map_field_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/map_field_test.exs
@@ -1,0 +1,37 @@
+defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MapFieldTest do
+  # alias Lexical.Server.CodeIntelligence.Completion.Translations.MapField
+  use Lexical.Test.Server.CompletionCase
+
+  use ExUnit.Case, async: true
+
+  test "a map's fields are completed", %{project: project} do
+    source = ~q[
+      user = %{first_name: "John", last_name: "Doe"}
+      user.f|
+    ]
+
+    assert {:ok, completion} =
+             project
+             |> complete(source)
+             |> fetch_completion(kind: :field)
+
+    assert completion.insert_text == "first_name"
+    assert completion.detail == "first_name"
+    assert completion.label == "first_name"
+  end
+
+  test "a map's fields are completed after a dot", %{project: project} do
+    source = ~q[
+      user = %{first_name: "John", last_name: "Doe"}
+      user.|
+    ]
+
+    assert {:ok, [first_name, last_name]} =
+             project
+             |> complete(source)
+             |> fetch_completion(kind: :field)
+
+    assert first_name.insert_text == "first_name"
+    assert last_name.insert_text == "last_name"
+  end
+end


### PR DESCRIPTION
fix this:

```elixir
17:28:51.342 [info] Completion for %Lexical.Document.Position{line: 9, character: 7}
17:28:52.711 [error] ** (ErlangError) Erlang error: {:exception, :function_clause, [{Lexical.RemoteControl.Completion.Candidate, :from_elixir_sense, [%{call?: true, name: "a", origin: nil, subtype: :map_key, type: :field, type_spec: nil}], [file: 'lib/lexical/remote_control/completion/candidate.ex', line: 161]}, {Enum, :"-map/2-lists^map/1-0-", 2, [file: 'lib/enum.ex', line: 1658]}, {Lexical.RemoteControl.Completion, :elixir_sense_expand, 2, []}]}
    (kernel 8.5.3) erpc.erl:702: :erpc.call/5
    (server 0.1.0) lib/lexical/server/code_intelligence/completion.ex:68: Lexical.Server.CodeIntelligence.Completion.completions/3
    (server 0.1.0) lib/lexical/server/code_intelligence/completion.ex:37: Lexical.Server.CodeIntelligence.Completion.complete/4
    (server 0.1.0) lib/lexical/server/provider/handlers/completion.ex:12: Lexical.Server.Provider.Handlers.Completion.handle/2
    (server 0.1.0) lib/lexical/server/provider/queue.ex:99: anonymous fn/2 in Lexical.Server.Provider.Queue.State.as_task/2
    (elixir 1.14.3) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (elixir 1.14.3) lib/task/supervised.ex:34: Task.Supervised.reply/4
    (stdlib 4.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
    
```

<img width="417" alt="image" src="https://github.com/lexical-lsp/lexical/assets/12830256/04faee88-2a01-4c12-8b80-704baa49ee3f">

    