### PR TITLE
Fix the issue of project name being too long

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/state.ex
@@ -185,7 +185,7 @@ defmodule Lexical.RemoteControl.Build.State do
   end
 
   def building_label(%Project{} = project) do
-    "Building #{Project.name(project)}"
+    "Building #{Project.display_name(project)}"
   end
 
   defp now do

--- a/apps/remote_control/test/lexical/remote_control/build_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build_test.exs
@@ -69,7 +69,7 @@ defmodule Lexical.BuildTest do
 
       assert_receive project_compiled(status: :success), 500
       assert_receive project_progress(label: "Building " <> project_name), 500
-      assert project_name == "ProjectMetadata"
+      assert project_name == "project_metadata"
     end
 
     test "receives metadata about the defined modules" do
@@ -105,7 +105,7 @@ defmodule Lexical.BuildTest do
       assert {:arity_2, 2} in functions
 
       assert_receive project_progress(label: "Building " <> project_name), 500
-      assert project_name == "Umbrella"
+      assert project_name == "umbrella"
     end
   end
 

--- a/apps/remote_control/test/lexical/remote_control/build_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build_test.exs
@@ -68,6 +68,8 @@ defmodule Lexical.BuildTest do
       Build.schedule_compile(project, true)
 
       assert_receive project_compiled(status: :success), 500
+      assert_receive project_progress(label: "Building " <> project_name), 500
+      assert project_name == "ProjectMetadata"
     end
 
     test "receives metadata about the defined modules" do
@@ -101,6 +103,9 @@ defmodule Lexical.BuildTest do
       assert {:arity_0, 0} in functions
       assert {:arity_1, 1} in functions
       assert {:arity_2, 2} in functions
+
+      assert_receive project_progress(label: "Building " <> project_name), 500
+      assert project_name == "Umbrella"
     end
   end
 

--- a/projects/lexical_shared/lib/lexical/project.ex
+++ b/projects/lexical_shared/lib/lexical/project.ex
@@ -51,25 +51,22 @@ defmodule Lexical.Project do
   @spec name(t) :: String.t()
 
   def name(%__MODULE__{project_module: nil} = project) do
-    project
-    |> root_path()
-    |> Path.split()
-    |> List.last()
+    folder_name(project)
   end
 
   def name(%__MODULE__{project_module: project_module}) do
-    module_string = to_string(project_module)
-
-    with ["Elixir" | tail] <- String.split(module_string, "."),
-         true <- ends_with_mix_project?(tail) do
-      tail |> List.delete_at(-1) |> Enum.join(".")
-    else
-      _ -> module_string
-    end
+    Atom.to_string(project_module)
   end
 
-  defp ends_with_mix_project?(module_path) do
-    List.last(module_path) == "MixProject"
+  @doc """
+  Returns the the name definied in the `project/0` of mix.exs file
+  """
+  def display_name(%__MODULE__{project_module: nil} = project) do
+    folder_name(project)
+  end
+
+  def display_name(%__MODULE__{project_module: project_module} = project) do
+    Keyword.get(project_module.project(), :name, folder_name(project))
   end
 
   @doc """
@@ -257,5 +254,12 @@ defmodule Lexical.Project do
 
   defp mix_exs_exists?(mix_exs_path) do
     File.exists?(mix_exs_path)
+  end
+
+  defp folder_name(project) do
+    project
+    |> root_path()
+    |> Path.split()
+    |> List.last()
   end
 end

--- a/projects/lexical_shared/lib/lexical/project.ex
+++ b/projects/lexical_shared/lib/lexical/project.ex
@@ -58,7 +58,18 @@ defmodule Lexical.Project do
   end
 
   def name(%__MODULE__{project_module: project_module}) do
-    Atom.to_string(project_module)
+    module_string = to_string(project_module)
+
+    with ["Elixir" | tail] <- String.split(module_string, "."),
+         true <- ends_with_mix_project?(tail) do
+      tail |> List.delete_at(-1) |> Enum.join(".")
+    else
+      _ -> module_string
+    end
+  end
+
+  defp ends_with_mix_project?(module_path) do
+    List.last(module_path) == "MixProject"
   end
 
   @doc """


### PR DESCRIPTION
Currently, we only support mix projects. Therefore, `Elixir` and `MixProject` do not provide any additional information. Removing them can make the UI look better and the project name clearer.

### Before

![image](https://github.com/lexical-lsp/lexical/assets/12830256/67657e76-a69b-4411-84f8-f7f1537cbf9a)

### After

<img width="489" alt="image" src="https://github.com/lexical-lsp/lexical/assets/12830256/a23eaadb-e414-4387-8f18-e579bd3f8501">
