### PR TITLE
Update .tool-versions to match GH Actions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-erlang 24.3.4.12
-elixir 1.13.4-otp-24
+erlang 25.2.1
+elixir 1.14.3-otp-25
 nodejs 12.16.3
 yarn 1.22.4


### PR DESCRIPTION
Updated to have the same versions as:

https://github.com/lexical-lsp/lexical/blob/main/.github/workflows/release.yml#L18-L19