### PR TITLE
Fixing flaky tests

### DIFF
--- a/apps/plugin_runner/.formatter.exs
+++ b/apps/plugin_runner/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  import_deps: [:common]
 ]

--- a/apps/plugin_runner/test/lexical/plugin/runner/coordinator/state_test.exs
+++ b/apps/plugin_runner/test/lexical/plugin/runner/coordinator/state_test.exs
@@ -128,7 +128,7 @@ defmodule Lexical.Plugin.Coordinator.StateTest do
       assert State.failure_count(state, BadReturn) == 1
     end
 
-    test "a plugin is disabled if it fails 3 times", %{state: state} do
+    test "a plugin is disabled if it fails 10 times", %{state: state} do
       Runner.register(Crashes)
 
       assert :crashes in Runner.enabled_plugins()

--- a/apps/remote_control/test/lexical/remote_control/build/state_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/state_test.exs
@@ -15,6 +15,7 @@ defmodule Lexical.RemoteControl.Build.StateTest do
     {:ok, _} = start_supervised(Build.CaptureServer)
     {:ok, _} = start_supervised(RemoteControl.ModuleMappings)
     {:ok, _} = start_supervised(Lexical.Plugin.Runner.Coordinator)
+    {:ok, _} = start_supervised(Lexical.Plugin.Runner.Supervisor)
     :ok
   end
 


### PR DESCRIPTION
The tests here were failing occasionally, and the coordinator test was actually not cleaning up after itself *and* was not testing the right things. This fixes all of those problems.