### PR TITLE
Rebuild PLT files on projects dep changes

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -81,6 +81,10 @@ jobs:
   dialyzer:
     runs-on: ubuntu-latest
     name: Run Dialyzer
+    env:
+      project_mix_lock: ${{ format('{0}{1}', github.workspace, '/mix.lock') }}
+      projects_ex_blob: ${{ format('{0}{1}', github.workspace, '/projects/**/*.ex') }}
+      projects_locks_blob: ${{ format('{0}{1}', github.workspace, '/projects/*/mix.lock') }}
     steps:
       # Step: Setup Elixir + Erlang image as the base.
       - name: Set up Elixir
@@ -96,8 +100,9 @@ jobs:
       - name: Set Variables
         id: set_mix_lock_hash
         run: |
-          mix_lock_hash="${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}"
-          echo "mix_lock_hash=$mix_lock_hash" >> "$GITHUB_OUTPUT"
+          mix_lock_hash="${{ hashFiles(env.project_mix_lock) }}"
+          projects_hash="${{ hashFiles(env.project_ex_blob, env.projects_locks_blob) }}"
+          echo "mix_lock_hash=$mix_lock_hash::$projects_hash" >> "$GITHUB_OUTPUT"
 
       # Step: Define how to cache deps. Restores existing cache if present.
       - name: Cache deps


### PR DESCRIPTION
This fix will rebuild PLTs on any changes to our deps, or our projects apps' `.ex` files. 

When we merged a PR with changes to the projects directory, it complained about a missing function, but the function was present; this is because changes in the projects directories weren't taken into account when calculating the cache key for the .plt files. This PR adds that calculation.

I still feel like there must be a simpler way to do this, and am welcome to any suggestions.