### PR TITLE
Raise timeout on plugin document diagnose

### DIFF
--- a/apps/plugin_runner/lib/lexical/plugin/runner.ex
+++ b/apps/plugin_runner/lib/lexical/plugin/runner.ex
@@ -36,7 +36,7 @@ defmodule Lexical.Plugin.Runner do
 
   @doc false
   def diagnose(%Document{} = document, on_complete) do
-    Runner.Coordinator.run_all(document, :diagnostic, on_complete, 50)
+    Runner.Coordinator.run_all(document, :diagnostic, on_complete, 250)
   end
 
   @doc false


### PR DESCRIPTION
On my machine, which is relatively powerful, the `lexical_credo` plugin takes ~150ms to complete it's diagnostics on a `%Document{}`. With the timeout being 50ms it never receives results. I tested on larger files and small files and it didn't seem to make a difference.  250ms might still be too low; let me know what you think.