### PR TITLE
Enforced project name validity

### DIFF
--- a/projects/lexical_shared/test/lexical/project_test.exs
+++ b/projects/lexical_shared/test/lexical/project_test.exs
@@ -1,0 +1,36 @@
+defmodule Lexical.ProjectTest do
+  alias Lexical.Project
+
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+  use Patch
+
+  def project do
+    root = Lexical.Document.Path.to_uri(__DIR__)
+    Project.new(root)
+  end
+
+  describe "name/1" do
+    test "a project's name starts with a lowercase character and contains alphanumeric characters and _" do
+      check all folder_name <- string(:ascii, min_length: 1) do
+        patch Project, :folder_name, folder_name
+        assert Regex.match?(~r/[a-z][a-zA-Z_]*/, Project.name(project()))
+      end
+    end
+
+    test "periods are repleaced with underscores" do
+      patch(Project, :folder_name, "foo.bar")
+      assert Project.name(project()) == "foo_bar"
+    end
+
+    test "leading capital letters are downcased" do
+      patch(Project, :folder_name, "FooBar")
+      assert Project.name(project()) == "fooBar"
+    end
+
+    test "leading numbers are replaced with p_" do
+      patch(Project, :folder_name, "3bar")
+      assert Project.name(project()) == "p_3bar"
+    end
+  end
+end


### PR DESCRIPTION
Project names must conform to elixir's rules, and while they're inferred from their paths, they must start with a lowercase character and only contain alphanumeric characters and _. This error is given if you try to start a new project with `mix new`.

This change enforces the same rules.

Fixes #256 