### PR TITLE
Removed double compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - v*
+env:
+  NAMESPACE: 1
 
 jobs:
   release:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,3 @@ compile.projects:
 	cd projects
 	$(foreach dir, $(project_dirs), cd projects/$(dir) && mix deps.get && mix do clean, compile --warnings-as-errors && cd ../..;)
 
-release.namespaced:
-	mix do deps.clean --all, clean, deps.get 
-	mix release lexical --overwrite 
-	NAMESPACE=1 mix release lexical --overwrite

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ faster.
 Follow the [Detailed Installation Instructions](pages/installation.md)
 
  ```
-make release.namespaced
+NAMESPACE=1 mix release lexical --overwrite
  ```
 
  Lexical will now be available in `_build/dev/rel/lexical`

--- a/mix.exs
+++ b/mix.exs
@@ -68,7 +68,7 @@ defmodule Lexical.LanguageServer.MixProject do
         cookie: "lexical",
         rel_templates_path: "rel/deploy",
         strip_beams: false,
-        steps: [&maybe_namespace/1, :assemble, &maybe_namespace_release/1]
+        steps: release_steps()
       ],
       lexical_debug: [
         applications: [
@@ -92,31 +92,49 @@ defmodule Lexical.LanguageServer.MixProject do
     ]
   end
 
-  defp maybe_namespace(%Mix.Release{} = release) do
-    if System.get_env("NAMESPACE") do
-      Mix.Task.run("namespace.beams", [release.path])
-    end
-
+  def unconsolidate_jason(%Mix.Release{} = release) do
+    # Consolidating Jason breaks the server for some reason. We need to investigate this
+    jason_beam = Path.join([release.version_path, "consolidated", "Elixir.Jason.Encoder.beam"])
+    File.rm(jason_beam)
     release
   end
 
-  defp maybe_namespace_release(%Mix.Release{} = release) do
+  defp release_steps do
     if System.get_env("NAMESPACE") do
-      Mix.Task.run("namespace.release")
+      [&namespace/1, :assemble, &namespace_release/1, &unconsolidate_jason/1]
+    else
+      [:assemble]
     end
+  end
 
+  defp namespace(%Mix.Release{} = release) do
+    Mix.Task.run("namespace.beams", [release.path])
     release
   end
 
-  defp maybe_clean(_) do
+  defp namespace_release(%Mix.Release{} = release) do
+    Mix.Task.run("namespace.release")
+    release
+  end
+
+  defp clean(_) do
+    Mix.Task.clear()
+    Mix.Task.run("deps.clean", ~w(--all))
+    Mix.Task.run("clean")
+    Mix.Task.run("deps.get")
+  end
+
+  defp release_alias do
     if System.get_env("NAMESPACE") do
-      Mix.Task.run("clean")
+      [&clean/1, "release", &clean/1]
+    else
+      "release"
     end
   end
 
   defp aliases do
     [
-      release: [&maybe_clean/1, "release", &maybe_clean/1],
+      release: release_alias(),
       compile: "compile --docs --debug-info",
       docs: "docs --html",
       test: "test --no-start"

--- a/pages/installation.md
+++ b/pages/installation.md
@@ -35,7 +35,7 @@ cd lexical
 ...and build the project
 
 ```shell
-make release.namespaced
+NAMESPACE=1 mix release lexical --overwrite
 ```
 
 If things complete successfully, you will then have a release in your


### PR DESCRIPTION
We noticed that when we'd do a release, we would have to build twice or the server didn't work. This always irked me, as that makes no sense, builds should be deterministic.

What was happening is that the Jason.Encoder protocol was being consolidated, and _this_ breaks the server. Simply removing the consolidation (which is what the double builds did) fixes the problem.

I also reworked the mix.exs file to make it a little easier to understand.

Now we need to research why Jason.Encoder's consolidation breaks things.