### PR TITLE
The start line can be the end line

### DIFF
--- a/apps/server/test/document_test.exs
+++ b/apps/server/test/document_test.exs
@@ -724,5 +724,17 @@ defmodule Lexical.DocumentTest do
 
       assert "e\nt" == doc
     end
+
+    test "works if the start line is the end line" do
+      doc =
+        "this is the first line\nthis is the second"
+        |> document()
+        |> Document.fragment(
+          Position.new(line: 0, character: 5),
+          Position.new(line: 0, character: 7)
+        )
+
+      assert doc == "is"
+    end
   end
 end

--- a/projects/lexical_shared/lib/lexical/document.ex
+++ b/projects/lexical_shared/lib/lexical/document.ex
@@ -144,6 +144,10 @@ defmodule Lexical.Document do
             line_text = text <> ending
 
             cond do
+              line_number == from_line and line_number == to_line ->
+                slice_length = to_character - from_character
+                String.slice(line_text, from_character, slice_length)
+
               line_number == from_line ->
                 slice_length = String.length(line_text) - from_character
                 String.slice(line_text, from_character, slice_length)


### PR DESCRIPTION
Document.fragment missed a case when the start line and end line are the same.