### PR TITLE
Fixed protocol consolidation

### DIFF
--- a/apps/common/lib/mix/tasks/namespace/beams.ex
+++ b/apps/common/lib/mix/tasks/namespace/beams.ex
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.Namespace.Beams do
       |> Path.wildcard()
 
     consolidated_beams =
-      [Mix.Project.consolidation_path(), "**", "Elixir.*Lexical*.beam"]
+      [Mix.Project.consolidation_path(), "**", "*.beam"]
       |> Path.join()
       |> Path.wildcard()
 


### PR DESCRIPTION
Turns out that protocols are consolidated into files named after the protocol, and not the module that's being consolidated. Our old patterns would only apply namespacing to beam files with certain names, which wouldn't catch stuff like `Enumerable`.

A small change to the glob fixes the issue.

Fixes #262