### PR TITLE
Re-enabled multiple version support

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control.ex
+++ b/apps/remote_control/lib/lexical/remote_control.ex
@@ -93,7 +93,7 @@ defmodule Lexical.RemoteControl do
   def elixir_executable(%Project{} = project) do
     root_path = Project.root_path(project)
     version_manager = version_manager()
-    env = reset_env(version_manager)
+    env = reset_env(version_manager, root_path)
 
     path_result =
       case version_manager() do
@@ -124,7 +124,7 @@ defmodule Lexical.RemoteControl do
         {:error, :no_elixir}
 
       executable when is_binary(executable) ->
-        {:ok, executable}
+        {:ok, executable, env}
     end
   end
 
@@ -158,7 +158,7 @@ defmodule Lexical.RemoteControl do
   # We launch lexical by asking the version managers to provide an environment,
   # which contains path munging. This initial environment is present in the running
   # VM, and needs to be undone so we can find the correct elixir executable in the project.
-  defp reset_env(:asdf) do
+  defp reset_env(:asdf, _root_path) do
     orig_path = System.get_env("PATH_SAVE", System.get_env("PATH"))
 
     Enum.map(System.get_env(), fn
@@ -169,7 +169,23 @@ defmodule Lexical.RemoteControl do
     end)
   end
 
-  defp reset_env(_) do
+  defp reset_env(:rtx, root_path) do
+    {env, _} = System.cmd("rtx", ~w(), cd: root_path)
+
+    env
+    |> String.trim()
+    |> String.split("\n")
+    |> Enum.map(fn "export " <> key_and_value ->
+      [key, value] =
+        key_and_value
+        |> String.split("=")
+        |> Enum.map(&String.trim/1)
+
+      {key, value}
+    end)
+  end
+
+  defp reset_env(_, _) do
     System.get_env()
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control.ex
+++ b/apps/remote_control/lib/lexical/remote_control.ex
@@ -178,7 +178,7 @@ defmodule Lexical.RemoteControl do
     |> Enum.map(fn "export " <> key_and_value ->
       [key, value] =
         key_and_value
-        |> String.split("=")
+        |> String.split("=", parts: 2)
         |> Enum.map(&String.trim/1)
 
       {key, value}

--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,7 @@ defmodule Lexical.LanguageServer.MixProject do
           mix: :load
         ],
         include_executables_for: [:unix],
-        include_erts: false,
+        include_erts: true,
         cookie: "lexical",
         rel_templates_path: "rel/deploy",
         strip_beams: false,

--- a/rel/deploy/overlays/start_lexical.sh
+++ b/rel/deploy/overlays/start_lexical.sh
@@ -1,15 +1,5 @@
 #!/usr/bin/env bash
 
-set_up_version_manager() {
-    if [ -e $HOME/.asdf ]; then
-        VERSION_MANAGER="asdf"
-    elif [ -e $HOME/.rtx ]; then
-        VERSION_MANAGER="rtx"
-    else
-        VERSION_MANAGER="none"
-    fi
-}
-
 readlink_f () {
   cd "$(dirname "$1")" > /dev/null || exit 1
   filename="$(basename "$1")"
@@ -26,16 +16,4 @@ else
   dir=${ELS_INSTALL_PREFIX}
 fi
 
-set_up_version_manager
-
-case "$VERSION_MANAGER" in
-    asdf)
-        asdf env elixir "${dir}/bin/lexical" start
-        ;;
-    rtx)
-        rtx env -s bash elixir "${dir}/bin/lexical" start
-        ;;
-    *)
-        "${dir}/bin/lexical" start
-        ;;
-esac
+"${dir}/bin/lexical" start


### PR DESCRIPTION
Prior to this change, running a project in a different version of elixir or erlang than lexical was compiled under would cause an error.

There were two reasons for this:

 1. The release is extremely sensitive to the version of elixir / erlang, and would not start if they didn't match. This would happen if include_erts is false.
 2. Even if include_erts is true, finding the elixir executable to run would use the inherited environment variables from the server process. ASDF munges the path, and would find the version of elixir that was used to start lexical, not the one the project requests.

The solution is to enable `use_erts` and to undo the path munging that asdf performs. We need to do something similar with rtx.

Fixes #234 
Also fixes #267 