### PR TITLE
Quieted compile warnings in test

### DIFF
--- a/apps/remote_control/test/fixtures/compilation_errors/mix.exs
+++ b/apps/remote_control/test/fixtures/compilation_errors/mix.exs
@@ -2,6 +2,8 @@ defmodule CompilationErrors.MixProject do
   use Mix.Project
 
   def project do
+    Code.put_compiler_option(:ignore_module_conflict, true)
+
     [
       app: :compilation_errors,
       version: "0.1.0",

--- a/apps/remote_control/test/fixtures/compilation_warnings/mix.exs
+++ b/apps/remote_control/test/fixtures/compilation_warnings/mix.exs
@@ -2,6 +2,8 @@ defmodule CompilationWarnings.MixProject do
   use Mix.Project
 
   def project do
+    Code.put_compiler_option(:ignore_module_conflict, true)
+
     [
       app: :compilation_warnings,
       version: "0.1.0",

--- a/apps/remote_control/test/fixtures/navigations/mix.exs
+++ b/apps/remote_control/test/fixtures/navigations/mix.exs
@@ -2,6 +2,8 @@ defmodule Navigations.MixProject do
   use Mix.Project
 
   def project do
+    Code.put_compiler_option(:ignore_module_conflict, true)
+
     [
       app: :navigations,
       version: "0.1.0",

--- a/apps/remote_control/test/fixtures/parse_errors/mix.exs
+++ b/apps/remote_control/test/fixtures/parse_errors/mix.exs
@@ -2,6 +2,8 @@ defmodule ParseErrors.MixProject do
   use Mix.Project
 
   def project do
+    Code.put_compiler_option(:ignore_module_conflict, true)
+
     [
       app: :parse_errors,
       version: "0.1.0",

--- a/apps/remote_control/test/fixtures/project/mix.exs
+++ b/apps/remote_control/test/fixtures/project/mix.exs
@@ -2,6 +2,8 @@ defmodule Project.MixProject do
   use Mix.Project
 
   def project do
+    Code.put_compiler_option(:ignore_module_conflict, true)
+
     [
       app: :project,
       version: "0.1.0",

--- a/apps/remote_control/test/fixtures/project_metadata/mix.exs
+++ b/apps/remote_control/test/fixtures/project_metadata/mix.exs
@@ -2,6 +2,8 @@ defmodule ProjectMetadata.MixProject do
   use Mix.Project
 
   def project do
+    Code.put_compiler_option(:ignore_module_conflict, true)
+
     [
       app: :project_metadata,
       version: "0.1.0",

--- a/apps/remote_control/test/fixtures/umbrella/apps/first/mix.exs
+++ b/apps/remote_control/test/fixtures/umbrella/apps/first/mix.exs
@@ -2,6 +2,8 @@ defmodule Umbrella.First.MixProject do
   use Mix.Project
 
   def project do
+    Code.put_compiler_option(:ignore_module_conflict, true)
+
     [
       app: :first,
       version: "0.1.0",

--- a/apps/remote_control/test/fixtures/umbrella/apps/second/mix.exs
+++ b/apps/remote_control/test/fixtures/umbrella/apps/second/mix.exs
@@ -2,6 +2,8 @@ defmodule Umbrella.Second.MixProject do
   use Mix.Project
 
   def project do
+    Code.put_compiler_option(:ignore_module_conflict, true)
+
     [
       app: :second,
       version: "0.1.0",

--- a/apps/remote_control/test/fixtures/umbrella/mix.exs
+++ b/apps/remote_control/test/fixtures/umbrella/mix.exs
@@ -2,6 +2,8 @@ defmodule Umbrella.MixProject do
   use Mix.Project
 
   def project do
+    Code.put_compiler_option(:ignore_module_conflict, true)
+
     [
       apps_path: "apps",
       version: "0.1.0",


### PR DESCRIPTION
The noise of 
> warning: redefining module CompilationWarnings.MixProject (current version defined in memory)
  /Users/steve/Projects/lexical/apps/remote_control/test/fixtures/compilation_warnings/mix.exs:1

was too much to bear