### PR TITLE
Added default candidate case

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/completion.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion.ex
@@ -13,9 +13,11 @@ defmodule Lexical.RemoteControl.Completion do
     if String.trim(hint) == "" do
       []
     else
-      doc_string
-      |> ElixirSense.suggestions(line, character)
-      |> Enum.map(&Candidate.from_elixir_sense/1)
+      for suggestion <- ElixirSense.suggestions(doc_string, line, character),
+          candidate = Candidate.from_elixir_sense(suggestion),
+          candidate != nil do
+        candidate
+      end
     end
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
@@ -1,5 +1,6 @@
 defmodule Lexical.RemoteControl.Completion.Candidate do
   alias Lexical.RemoteControl.Completion.Candidate.ArgumentNames
+  require Logger
 
   defmodule Function do
     @moduledoc false
@@ -229,5 +230,10 @@ defmodule Lexical.RemoteControl.Completion.Candidate do
 
   def from_elixir_sense(%{type: :callback} = elixir_sense_map) do
     Callback.new(elixir_sense_map)
+  end
+
+  def from_elixir_sense(elixir_sense_map) do
+    Logger.warning("Unhandled compleetion suggestion: #{inspect(elixir_sense_map)}")
+    nil
   end
 end


### PR DESCRIPTION
Elixir sense has a seemingly infinite set of maps that it returns from completion, and if we didn't explicitly handle one, the app would crash. This is not acceptable, so I added a default case and a log.

I also had to change the place where candidates were created so nil candidates were omitted.