### PR TITLE
Loadconfig needs to be called before deps are compiled

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/state.ex
@@ -209,7 +209,6 @@ defmodule Lexical.RemoteControl.Build.State do
         Mix.Task.clear()
 
         with_progress building_label(project), fn ->
-          Mix.Task.run(:loadconfig)
           result = Mix.Task.run(:compile, mix_compile_opts(force?))
           Mix.Task.run(:loadpaths)
           result
@@ -256,6 +255,10 @@ defmodule Lexical.RemoteControl.Build.State do
       end
     else
       Logger.warning("Could not connect to hex.pm, dependencies will not be fetched")
+    end
+
+    with_progress "mix loadconfig", fn ->
+      Mix.Task.run(:loadconfig)
     end
 
     with_progress "mix deps.compile", fn ->


### PR DESCRIPTION
Some dependencies need to have their configuration set before they're compiled, and we were loading the project's configuration after the compilation step.

All this PR does is change the place loadconfig is called.

Fixes #273