### PR TITLE
Replace with underscore can fail

### DIFF
--- a/apps/server/lib/lexical/server/provider/code_action/replace_with_underscore.ex
+++ b/apps/server/lib/lexical/server/provider/code_action/replace_with_underscore.ex
@@ -40,9 +40,6 @@ defmodule Lexical.Server.Provider.CodeAction.ReplaceWithUnderscore do
            line_number,
            variable_name
          ) do
-      {:ok, []} ->
-        :error
-
       {:ok, %Changes{} = document_edits} ->
         reply =
           CodeActionResult.new(
@@ -52,6 +49,9 @@ defmodule Lexical.Server.Provider.CodeAction.ReplaceWithUnderscore do
           )
 
         {:ok, reply}
+
+      _ ->
+        :error
     end
   end
 


### PR DESCRIPTION
Fixed case error where syntactically invalid code is fed to replace underscore.

Fixes 272