### PR TITLE
Preparing for 0.2.0 release

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -160,12 +160,8 @@ jobs:
             otp: "25.3"
           - elixir: "1.14.5-otp-25"
             otp: "25.3"
-          - elixir: "1.14.5-otp-24"
-            otp: "24.3.4.12"
           - elixir: "1.13.4-otp-25"
             otp: "25.3"
-          - elixir: "1.13.4-otp-24"
-            otp: "24.3.4.12"
     steps:
       # Step: Check out the code.
       - name: Checkout code

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -156,12 +156,16 @@ jobs:
       # and running the workflow steps.
       matrix:
         include:
-          - elixir: '1.15.3-otp-25'
-            otp: '25.3'
-          - elixir: '1.14.5-otp-25'
-            otp: '25.3'
-          - elixir: '1.13.4-otp-25'
-            otp: '25.3'
+          - elixir: "1.15.3-otp-25"
+            otp: "25.3"
+          - elixir: "1.14.5-otp-25"
+            otp: "25.3"
+          - elixir: "1.14.5-otp-24"
+            otp: "24.3.4.12"
+          - elixir: "1.13.4-otp-25"
+            otp: "25.3"
+          - elixir: "1.13.4-otp-24"
+            otp: "24.3.4.12"
     steps:
       # Step: Check out the code.
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: "25.2.1"
-          elixir-version: "1.14.3-otp-25"
+          otp-version: "24.3.4.12"
+          elixir-version: "1.13.4-otp-24"
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/apps/proto/mix.exs
+++ b/apps/proto/mix.exs
@@ -9,7 +9,7 @@ defmodule Proto.MixProject do
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
-      elixir: "~> 1.14",
+      elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]

--- a/apps/protocol/mix.exs
+++ b/apps/protocol/mix.exs
@@ -9,7 +9,7 @@ defmodule Lexical.Protocol.MixProject do
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
-      elixir: "~> 1.14",
+      elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       consolidate_protocols: Mix.env() != :test,

--- a/apps/server/mix.exs
+++ b/apps/server/mix.exs
@@ -9,7 +9,7 @@ defmodule Lexical.Server.MixProject do
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
-      elixir: "~> 1.14",
+      elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Lexical.LanguageServer.MixProject do
   def project do
     [
       apps_path: "apps",
-      version: "0.1.0",
+      version: "0.2.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       releases: releases(),

--- a/pages/installation.md
+++ b/pages/installation.md
@@ -7,18 +7,28 @@ you.
 
 ## Caveats
 
- * Presently, Lexical works on Elixir 1.13 and 1.14 under Erlang
- 24 and 25. Additionally, we support versions >= 1.15.3 (there are
- compiler bugs in 1.15.0 - 1.15.2 that prevent lexical from working).
- Erlang 26 support is still a work in progress.
+Lexical supports the following versions of Elixir and Erlang:
 
- * While it's within Lexical's capabilities to run your project in a
- different elixir and erlang version than Lexical is built with,
- presently, we don't support running your project in a different
- elixir and or erlang version.  We aim to fix this very shortly, as
- this dramatically limits Lexical's usefulness when working with
- multiple projects.
+| Erlang      | Version range    | Notes  |
+| ----------- |----------------- | ------ |
+|  24         | `>= 24.3.4.12`   | Might run on older versions; this was the lowest that would compile on arm |
+|  25         | `>= 25.0`        |        |
+|  26         | In progress      |        |
 
+| Elixir   | Version Range  | Notes    |
+| -------- | -------------- | -------- |
+| 1.13     |    `>= 1.13.4` |          |
+| 1.14     |    `all`       |          |
+| 1.15     | `>= 1.15.3`    | `1.15.0` - `1.15.2` had compiler bugs that prevented lexical from working |
+
+Lexical can run projects in any version of Elixir and Erlang that it supports, but it's important to understand that Lexical needs to be compiled under the lowest version of elixir and erlang that you intend to use it with. That means if you have the following projects:
+ 
+   * `first`: elixir `1.14.4` erlang `24.3.2`
+   * `second`: elixir `1.14.3` erlang `25.0`
+   * `third`: elixir: `1.13.3` erlang `25.2.3`
+
+Lexical would need to be compiled with Erlang `24.3.2` and Elixir `1.13.3`. 
+Lexical's prepackaged builds use Erlang `24.3.4.12` and Elixir `1.13.4`
 
 ## Prerequisites
 


### PR DESCRIPTION
Updated documentation to be clearer about which versions lexical supports, and ensured all projects would compile under the lowest versions.