### PR TITLE
Fix: Argument names crashes in light of a literal atom

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/completion/candidate/argument_names.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion/candidate/argument_names.ex
@@ -85,6 +85,9 @@ defmodule Lexical.RemoteControl.Completion.Candidate.ArgumentNames do
 
   defp extract_name(argument, index) do
     case Code.Fragment.cursor_context(argument) do
+      {:unquoted_atom, atom} ->
+        ":#{atom}"
+
       {:local_or_var, name} ->
         List.to_string(name)
 

--- a/apps/remote_control/test/lexical/remote_control/completion/candidate/argument_names_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/completion/candidate/argument_names_test.exs
@@ -70,5 +70,10 @@ defmodule Lexical.RemoteControl.Completion.Candidate.ArgumentNamesTest do
       assert :error == from_elixir_sense(args, 2)
       assert :error == from_elixir_sense(args, 4)
     end
+
+    test "handles atoms in names" do
+      # Note: having a raw atom in there crashed ArgumentNames before
+      assert ~w(handlerId :level level) = from_elixir_sense(~w(handlerId :level level), 3)
+    end
   end
 end


### PR DESCRIPTION
Sometimes, arguments to a function are a literal atom, and argument names wouldn't properly handle them. Passing them through unmodified seems to do the right thing and gives the atom as a result in completion.

This would occur when completing the following: 
```elixir
:logger.|
```
This was because one of the functions had argument names of `["handlerId", ":level", "level"]`