### PR TITLE
Refactor: Extracted Build.Project

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build/document.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document.ex
@@ -1,4 +1,4 @@
-defmodule Lexical.RemoteControl.Build.File do
+defmodule Lexical.RemoteControl.Build.Document do
   alias Elixir.Features
   alias Lexical.Document
   alias Lexical.RemoteControl.Build
@@ -105,9 +105,9 @@ defmodule Lexical.RemoteControl.Build.File do
   @dialyzer {:nowarn_function, compile_quoted_with_diagnostics: 2}
 
   defp compile_quoted_with_diagnostics(quoted_ast, path) do
-    Code.with_diagnostics(fn ->
-      safe_compile_quoted(quoted_ast, path)
-    end)
+    # Using apply to prevent a compile warning on elixir < 1.15
+    # credo:disable-for-next-line
+    apply(Code, :with_diagnostics, [fn -> safe_compile_quoted(quoted_ast, path) end])
   end
 
   defp safe_compile_quoted(quoted_ast, path) do

--- a/apps/remote_control/lib/lexical/remote_control/build/project.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/project.ex
@@ -1,0 +1,121 @@
+defmodule Lexical.RemoteControl.Build.Project do
+  alias Lexical.Project
+  alias Lexical.RemoteControl
+  alias Lexical.RemoteControl.Build
+  alias Lexical.RemoteControl.Plugin
+
+  use Build.Progress
+  require Logger
+
+  def compile(%Project{} = project, force?) do
+    RemoteControl.Mix.in_project(fn _ ->
+      Mix.Task.clear()
+
+      prepare_for_project_build(force?)
+
+      compile_fun = fn ->
+        Mix.Task.clear()
+
+        with_progress building_label(project), fn ->
+          result = Mix.Task.run(:compile, mix_compile_opts(force?))
+          Mix.Task.run(:loadpaths)
+          result
+        end
+      end
+
+      case compile_fun.() do
+        {:error, diagnostics} ->
+          diagnostics =
+            diagnostics
+            |> List.wrap()
+            |> Build.Error.refine_diagnostics()
+
+          {:error, diagnostics}
+
+        {status, diagnostics} when status in [:ok, :noop] ->
+          Logger.info(
+            "Compile completed with status #{status} " <>
+              "Produced #{length(diagnostics)} diagnostics " <>
+              inspect(diagnostics)
+          )
+
+          Build.Error.refine_diagnostics(diagnostics)
+      end
+    end)
+  end
+
+  defp prepare_for_project_build(false = _force?) do
+    :ok
+  end
+
+  defp prepare_for_project_build(true = _force?) do
+    if connected_to_internet?() do
+      with_progress "mix local.hex", fn ->
+        Mix.Task.run("local.hex", ~w(--force --if-missing))
+      end
+
+      with_progress "mix local.rebar", fn ->
+        Mix.Task.run("local.rebar", ~w(--force --if-missing))
+      end
+
+      with_progress "mix deps.get", fn ->
+        Mix.Task.run("deps.get")
+      end
+    else
+      Logger.warning("Could not connect to hex.pm, dependencies will not be fetched")
+    end
+
+    with_progress "mix loadconfig", fn ->
+      Mix.Task.run(:loadconfig)
+    end
+
+    with_progress "mix deps.compile", fn ->
+      deps_compile =
+        if Features.compile_wont_change_directory?() do
+          "deps.compile"
+        else
+          "deps.safe_compile"
+        end
+
+      Mix.Task.run(deps_compile, ~w(--skip-umbrella-children))
+    end
+
+    with_progress "loading plugins", fn ->
+      Plugin.Discovery.run()
+    end
+
+    Mix.Task.run("clean")
+  end
+
+  defp connected_to_internet? do
+    # While there's no perfect way to check if a computer is connected to the internet,
+    # it seems reasonable to gate pulling dependenices on a resolution check for hex.pm.
+    # Yes, it's entirely possible that the DNS server is local, and that the entry is in cache,
+    # but that's an edge case, and the build will just time out anyways.
+    case :inet_res.getbyname(~c"hex.pm", :a, 250) do
+      {:ok, _} -> true
+      _ -> false
+    end
+  end
+
+  def building_label(%Project{} = project) do
+    "Building #{Project.display_name(project)}"
+  end
+
+  defp mix_compile_opts(force?) do
+    opts = ~w(
+        --return-errors
+        --ignore-module-conflict
+        --all-warnings
+        --docs
+        --debug-info
+        --no-protocol-consolidation
+    )
+
+    if force? do
+      ["--force " | opts]
+    else
+      opts
+    end
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/build/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/state.ex
@@ -62,7 +62,7 @@ defmodule Lexical.RemoteControl.Build.State do
         project_compile_requested(project: project, build_number: state.build_number)
 
       RemoteControl.notify_listener(compile_requested_message)
-      {elapsed_us, result} = :timer.tc(fn -> safe_compile_project(project, force?) end)
+      {elapsed_us, result} = :timer.tc(fn -> Build.Project.compile(project, force?) end)
       elapsed_ms = to_ms(elapsed_us)
 
       {compile_message, diagnostics} =
@@ -112,7 +112,7 @@ defmodule Lexical.RemoteControl.Build.State do
       RemoteControl.notify_listener(file_compile_requested(uri: document.uri))
 
       safe_compile_func = fn ->
-        RemoteControl.Mix.in_project(fn _ -> Build.File.compile(document) end)
+        RemoteControl.Mix.in_project(fn _ -> Build.Document.compile(document) end)
       end
 
       {elapsed_us, result} = :timer.tc(fn -> safe_compile_func.() end)
@@ -197,97 +197,6 @@ defmodule Lexical.RemoteControl.Build.State do
   defp should_compile?(last_edit_time) do
     millis_since_last_edit = now() - last_edit_time
     millis_since_last_edit >= edit_window_millis()
-  end
-
-  defp safe_compile_project(%Project{} = project, force?) do
-    RemoteControl.Mix.in_project(fn _ ->
-      Mix.Task.clear()
-
-      prepare_for_project_build(force?)
-
-      compile_fun = fn ->
-        Mix.Task.clear()
-
-        with_progress building_label(project), fn ->
-          result = Mix.Task.run(:compile, mix_compile_opts(force?))
-          Mix.Task.run(:loadpaths)
-          result
-        end
-      end
-
-      case compile_fun.() do
-        {:error, diagnostics} ->
-          diagnostics =
-            diagnostics
-            |> List.wrap()
-            |> Build.Error.refine_diagnostics()
-
-          {:error, diagnostics}
-
-        {status, diagnostics} when status in [:ok, :noop] ->
-          Logger.info(
-            "Compile completed with status #{status} " <>
-              "Produced #{length(diagnostics)} diagnostics " <>
-              inspect(diagnostics)
-          )
-
-          Build.Error.refine_diagnostics(diagnostics)
-      end
-    end)
-  end
-
-  defp prepare_for_project_build(false = _force?) do
-    :ok
-  end
-
-  defp prepare_for_project_build(true = _force?) do
-    if connected_to_internet?() do
-      with_progress "mix local.hex", fn ->
-        Mix.Task.run("local.hex", ~w(--force --if-missing))
-      end
-
-      with_progress "mix local.rebar", fn ->
-        Mix.Task.run("local.rebar", ~w(--force --if-missing))
-      end
-
-      with_progress "mix deps.get", fn ->
-        Mix.Task.run("deps.get")
-      end
-    else
-      Logger.warning("Could not connect to hex.pm, dependencies will not be fetched")
-    end
-
-    with_progress "mix loadconfig", fn ->
-      Mix.Task.run(:loadconfig)
-    end
-
-    with_progress "mix deps.compile", fn ->
-      deps_compile =
-        if Features.compile_wont_change_directory?() do
-          "deps.compile"
-        else
-          "deps.safe_compile"
-        end
-
-      Mix.Task.run(deps_compile, ~w(--skip-umbrella-children))
-    end
-
-    with_progress "loading plugins", fn ->
-      Plugin.Discovery.run()
-    end
-
-    Mix.Task.run("clean")
-  end
-
-  defp connected_to_internet? do
-    # While there's no perfect way to check if a computer is connected to the internet,
-    # it seems reasonable to gate pulling dependenices on a resolution check for hex.pm.
-    # Yes, it's entirely possible that the DNS server is local, and that the entry is in cache,
-    # but that's an edge case, and the build will just time out anyways.
-    case :inet_res.getbyname(~c"hex.pm", :a, 250) do
-      {:ok, _} -> true
-      _ -> false
-    end
   end
 
   defp to_ms(microseconds) do

--- a/apps/remote_control/test/lexical/remote_control/build/error_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/error_test.exs
@@ -16,7 +16,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
 
   def compile(source) do
     doc = Document.new("file:///unknown.ex", source, 0)
-    Build.File.compile(doc)
+    Build.Document.compile(doc)
   end
 
   def diagnostics({:error, diagnostics}) do


### PR DESCRIPTION
Step 1 of the two step process to make .heex.* and .eex.* files compile.

Pulled out `Build.Project` into its own module, renamed `Build.File` to `Build.Document`