### PR TITLE
Fixed node naming conflict

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control.ex
+++ b/apps/remote_control/lib/lexical/remote_control.ex
@@ -18,11 +18,10 @@ defmodule Lexical.RemoteControl do
     :ok = ensure_epmd_started()
     entropy = :rand.uniform(65_536)
     start_net_kernel(project, entropy)
-
     apps_to_start = [:elixir | @allowed_apps] ++ [:runtime_tools]
-    node = node_name(project)
 
     with {:ok, node_pid} <- ProjectNode.start(project, project_listener, glob_paths()),
+         node = ProjectNode.node_name(project),
          :ok <- ensure_apps_started(node, apps_to_start) do
       {:ok, node, node_pid}
     end
@@ -60,12 +59,8 @@ defmodule Lexical.RemoteControl do
 
   def call(%Project{} = project, m, f, a \\ []) do
     project
-    |> node_name()
+    |> ProjectNode.node_name()
     |> :erpc.call(m, f, a)
-  end
-
-  defp node_name(%Project{} = project) do
-    :"#{Project.name(project)}@127.0.0.1"
   end
 
   defp start_net_kernel(%Project{} = project, entropy) do

--- a/apps/remote_control/mix.exs
+++ b/apps/remote_control/mix.exs
@@ -2,6 +2,8 @@ defmodule Lexical.RemoteControl.MixProject do
   use Mix.Project
 
   def project do
+    Code.put_compiler_option(:ignore_module_conflict, Mix.env() == :test)
+
     [
       app: :remote_control,
       version: "0.1.0",

--- a/apps/remote_control/test/lexical/remote_control/module_mappings_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/module_mappings_test.exs
@@ -1,6 +1,7 @@
 defmodule Lexical.RemoteControl.ModuleMappingsTest do
   alias Lexical.RemoteControl.ModuleMappings
-  use ExUnit.Case
+
+  use ExUnit.Case, async: false
 
   setup do
     {:ok, _cache} = start_supervised(ModuleMappings)


### PR DESCRIPTION
A reported bug showed that lexical's node names can conflict with other nodes on the same computer. This PR adds a discriminator to the project node name so it won't conflict

Fixes #291