### PR TITLE
Fixed project node naming conflicts

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -127,7 +127,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: "priv/plts"
-          key: lexical-plts-${{ env.DEFAULT_OTP }}-${{ env.DEFAULT_ELIXIR }}-${{ steps.set_mix_lock_hash.outputs.mix_lock_hash }}
+          key: lexical-plts-1-${{ env.DEFAULT_OTP }}-${{ env.DEFAULT_ELIXIR }}-${{ steps.set_mix_lock_hash.outputs.mix_lock_hash }}
 
       # Step: Download project dependencies. If unchanged, uses
       # the cached version.

--- a/projects/lexical_shared/lib/lexical/project.ex
+++ b/projects/lexical_shared/lib/lexical/project.ex
@@ -13,13 +13,15 @@ defmodule Lexical.Project do
             mix_env: nil,
             mix_target: nil,
             env_variables: %{},
-            project_module: nil
+            project_module: nil,
+            entropy: 1
 
   @type message :: String.t()
   @type restart_notification :: {:restart, Logger.level(), String.t()}
   @type t :: %__MODULE__{
           root_uri: Lexical.uri() | nil,
-          mix_exs_uri: Lexical.uri() | nil
+          mix_exs_uri: Lexical.uri() | nil,
+          entropy: non_neg_integer()
           # mix_env: atom(),
           # mix_target: atom(),
           # env_variables: %{String.t() => String.t()}
@@ -31,7 +33,9 @@ defmodule Lexical.Project do
   # Public
   @spec new(Lexical.uri()) :: t
   def new(root_uri) do
-    %__MODULE__{}
+    entropy = :rand.uniform(65_536)
+
+    %__MODULE__{entropy: entropy}
     |> maybe_set_root_uri(root_uri)
     |> maybe_set_mix_exs_uri()
   end
@@ -81,10 +85,7 @@ defmodule Lexical.Project do
   end
 
   def entropy(%__MODULE__{} = project) do
-    project
-    |> name()
-    |> :erlang.phash2()
-    |> rem(65_536)
+    project.entropy
   end
 
   @doc """

--- a/projects/lexical_shared/lib/lexical/project.ex
+++ b/projects/lexical_shared/lib/lexical/project.ex
@@ -74,6 +74,20 @@ defmodule Lexical.Project do
   end
 
   @doc """
+  The project node's name
+  """
+  def node_name(%__MODULE__{} = project) do
+    :"project-#{name(project)}-#{entropy(project)}@127.0.0.1"
+  end
+
+  def entropy(%__MODULE__{} = project) do
+    project
+    |> name()
+    |> :erlang.phash2()
+    |> rem(65_536)
+  end
+
+  @doc """
   Returns the the name definied in the `project/0` of mix.exs file
   """
   def display_name(%__MODULE__{project_module: nil} = project) do


### PR DESCRIPTION
As reported in #291, lexical's node names can conflict with other nodes on the same computer.
This PR adds entropy to the project and uses that value to influence the node names of both the manager and the project

Fixes #291 and #91