### PR TITLE
Remove logger for debugging port stdin/sdtout

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/project_node.ex
+++ b/apps/remote_control/lib/lexical/remote_control/project_node.ex
@@ -220,8 +220,7 @@ defmodule Lexical.RemoteControl.ProjectNode do
   end
 
   @impl true
-  def handle_info({_port, {:data, message}}, %State{} = state) do
-    Logger.warning("Port: #{inspect(IO.iodata_to_binary(message))}")
+  def handle_info({_port, {:data, _message}}, %State{} = state) do
     {:noreply, state}
   end
 


### PR DESCRIPTION
This was a mistake on our part.
We merged too quickly and didn't have a chance to delete this line.