### PR TITLE
Config compiler

### DIFF
--- a/apps/common/lib/elixir/features.ex
+++ b/apps/common/lib/elixir/features.ex
@@ -1,6 +1,6 @@
 defmodule Elixir.Features do
   def with_diagnostics? do
-    Version.match?(System.version(), ">= 1.15.3")
+    function_exported?(Code, :with_diagnostics, 1)
   end
 
   def compile_wont_change_directory? do

--- a/apps/common/lib/elixir/features.ex
+++ b/apps/common/lib/elixir/features.ex
@@ -6,4 +6,8 @@ defmodule Elixir.Features do
   def compile_wont_change_directory? do
     Version.match?(System.version(), ">= 1.15.0")
   end
+
+  def config_reader? do
+    Version.match?(System.version(), ">= 1.11.0")
+  end
 end

--- a/apps/remote_control/lib/lexical/remote_control/build/document.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document.ex
@@ -3,7 +3,7 @@ defmodule Lexical.RemoteControl.Build.Document do
   alias Lexical.Document
   alias Lexical.RemoteControl.Build.Document.Compilers
 
-  @compilers [Compilers.Elixir, Compilers.EEx, Compilers.NoOp]
+  @compilers [Compilers.Config, Compilers.Elixir, Compilers.EEx, Compilers.NoOp]
 
   def compile(%Document{} = document) do
     compiler = Enum.find(@compilers, & &1.recognizes?(document))

--- a/apps/remote_control/lib/lexical/remote_control/build/document/compilers/config.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document/compilers/config.ex
@@ -57,9 +57,12 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.Config do
 
   defp compile_with_diagnostics(%Document{} = document) do
     {result, diagnostics} =
-      Code.with_diagnostics(fn ->
-        raw_compile(document)
-      end)
+      apply(Code, :with_diagnostics, [
+        # credo:disable-for-previous-line
+        fn ->
+          raw_compile(document)
+        end
+      ])
 
     diagnostic_results = Enum.map(diagnostics, &to_result(document, &1))
 

--- a/apps/remote_control/lib/lexical/remote_control/build/document/compilers/config.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document/compilers/config.ex
@@ -49,6 +49,7 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.Config do
 
     try do
       Config.Reader.eval!(document.path, contents)
+      {:ok, []}
     rescue
       e ->
         {:error, [to_result(document, e)]}

--- a/apps/remote_control/test/lexical/remote_control/build/document/compilers/config_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/document/compilers/config_test.exs
@@ -1,0 +1,111 @@
+defmodule Lexical.RemoteControl.Build.Document.Compilers.ConfigTest do
+  alias Lexical.Document
+  alias Lexical.RemoteControl.Build.Document.Compilers
+
+  use ExUnit.Case
+  import Lexical.Test.CodeSigil
+  import Compilers.Config
+
+  def document_with_path(left, right) do
+    left
+    |> Path.join(right)
+    |> document_with_path()
+  end
+
+  def document_with_path(path) when is_list(path) do
+    path
+    |> Path.join()
+    |> document_with_path()
+  end
+
+  def document_with_path(path) do
+    Document.new(path, "", 1)
+  end
+
+  def document(contents) do
+    config_dir()
+    |> Path.join("config.exs")
+    |> Document.new(contents, 0)
+  end
+
+  def config_dir do
+    Mix.Project.config()
+    |> Keyword.get(:config_path)
+    |> Path.expand()
+    |> Path.dirname()
+  end
+
+  describe "recognizes/1" do
+    test "files in the config directory are recognized" do
+      assert recognizes?(document_with_path(config_dir(), "test.exs"))
+      assert recognizes?(document_with_path(config_dir(), "foo.exs"))
+      assert recognizes?(document_with_path([config_dir(), "other", "foo.exs"]))
+    end
+
+    test "files in the config directory with relative paths are recognized" do
+      assert recognizes?(document_with_path("../../config/test.exs"))
+    end
+
+    test "files outside the config directory are not recognized" do
+      refute recognizes?(document_with_path(__ENV__.file))
+    end
+
+    test "only .exs files are recognized" do
+      refute recognizes?(document_with_path(config_dir(), "foo.ex"))
+      refute recognizes?(document_with_path(config_dir(), "foo.yaml"))
+      refute recognizes?(document_with_path(config_dir(), "foo.eex"))
+      refute recognizes?(document_with_path(config_dir(), "foo.heex"))
+    end
+  end
+
+  describe "compile/1" do
+    test "it produces diagnostics for syntax errors" do
+      assert {:error, [result]} =
+               ",="
+               |> document()
+               |> compile()
+
+      assert result.message =~ "syntax error before"
+      assert result.position == {1, 1}
+      assert result.severity == :error
+      assert result.source == "Elixir"
+    end
+
+    test "it produces diagnostics for compile errors" do
+      assert {:error, [result]} =
+               ~q[
+                 import Config
+                 configure :my_app, key: 3
+               ]
+               |> document()
+               |> compile()
+
+      assert result.message =~ "undefined function"
+      assert result.position == 2
+      assert result.severity == :error
+      assert result.source == "Elixir"
+    end
+
+    test "it produces diagnostics for Token missing errors" do
+      assert {:error, [result]} =
+               "fn foo -> e"
+               |> document()
+               |> compile()
+
+      assert result.message =~ "missing terminator"
+      assert result.position == {1, 12}
+      assert result.severity == :error
+      assert result.source == "Elixir"
+    end
+
+    test "it produces no diagnostics on success" do
+      assert {:ok, []} =
+               ~q[
+                 import Config
+                 config :my_app, key: 3, other_key: 6
+               ]
+               |> document()
+               |> compile()
+    end
+  end
+end


### PR DESCRIPTION
We were treating configuration files in the project's config directory
like normal elixir source files, but they're slightly different, and
compiling them will cause errors to appear.

This change adds a config compiler that uses Config.Reader to compile
configuration.

Fixes https://github.com/lexical-lsp/lexical/issues/301