### PR TITLE
Added default case

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/completion/candidate/argument_names.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion/candidate/argument_names.ex
@@ -95,6 +95,9 @@ defmodule Lexical.RemoteControl.Completion.Candidate.ArgumentNames do
         argument
         |> String.split("=")
         |> find_local_in_pattern_match(index)
+
+      _ ->
+        argument
     end
   end
 

--- a/apps/remote_control/test/lexical/remote_control/completion/candidate/argument_names_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/completion/candidate/argument_names_test.exs
@@ -64,6 +64,10 @@ defmodule Lexical.RemoteControl.Completion.Candidate.ArgumentNamesTest do
       assert ~w(arg_1) = from_elixir_sense(["{a, b, c}"], 1)
     end
 
+    test "handles empty arguments" do
+      assert ["foo", ""] == from_elixir_sense(["foo", ""], 2)
+    end
+
     test "handles incorrect arity" do
       args = ~w(first second third)
       assert :error == from_elixir_sense(args, 1)


### PR DESCRIPTION
Argument names is surprisingly complete syntax! This adds a default case that returns the argument names unmodified so we don't crash.

Fixes #303