### PR TITLE
Handle presense of multiple version managers

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control.ex
+++ b/apps/remote_control/lib/lexical/remote_control.ex
@@ -87,31 +87,11 @@ defmodule Lexical.RemoteControl do
 
   def elixir_executable(%Project{} = project) do
     root_path = Project.root_path(project)
-    version_manager = version_manager()
-    env = reset_env(version_manager, root_path)
 
-    path_result =
-      case version_manager() do
-        :asdf ->
-          case System.cmd("asdf", ~w(which elixir), cd: root_path, env: env) do
-            {path, 0} ->
-              String.trim(path)
-
-            _ ->
-              nil
-          end
-
-        :rtx ->
-          case System.cmd("rtx", ~w(which elixir), cd: root_path, env: env) do
-            {path, 0} ->
-              String.trim(path)
-
-            _ ->
-              nil
-          end
-
-        :none ->
-          File.cd!(root_path, fn -> System.find_executable("elixir") end)
+    {path_result, env} =
+      with nil <- version_manager_path_and_env("asdf", root_path),
+           nil <- version_manager_path_and_env("rtx", root_path) do
+        {File.cd!(root_path, fn -> System.find_executable("elixir") end), System.get_env()}
       end
 
     case path_result do
@@ -133,27 +113,21 @@ defmodule Lexical.RemoteControl do
     end
   end
 
-  defp version_manager do
-    cond do
-      asdf?() ->
-        :asdf
-
-      rtx?() ->
-        :rtx
-
-      true ->
-        :none
+  defp version_manager_path_and_env(manager, root_path) do
+    with true <- is_binary(System.find_executable(manager)),
+         env = reset_env(manager, root_path),
+         {path, 0} <- System.cmd(manager, ~w(which elixir), cd: root_path, env: env) do
+      {String.trim(path), env}
+    else
+      _ ->
+        nil
     end
   end
-
-  defp asdf?, do: is_binary(System.find_executable("asdf"))
-
-  defp rtx?, do: is_binary(System.find_executable("rtx"))
 
   # We launch lexical by asking the version managers to provide an environment,
   # which contains path munging. This initial environment is present in the running
   # VM, and needs to be undone so we can find the correct elixir executable in the project.
-  defp reset_env(:asdf, _root_path) do
+  defp reset_env("asdf", _root_path) do
     orig_path = System.get_env("PATH_SAVE", System.get_env("PATH"))
 
     Enum.map(System.get_env(), fn
@@ -164,7 +138,7 @@ defmodule Lexical.RemoteControl do
     end)
   end
 
-  defp reset_env(:rtx, root_path) do
+  defp reset_env("rtx", root_path) do
     {env, _} = System.cmd("rtx", ~w(env -s bash), cd: root_path)
 
     env
@@ -178,9 +152,5 @@ defmodule Lexical.RemoteControl do
 
       {key, value}
     end)
-  end
-
-  defp reset_env(_, _) do
-    System.get_env()
   end
 end

--- a/apps/remote_control/priv/port_wrapper.sh
+++ b/apps/remote_control/priv/port_wrapper.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 set_up_version_manager() {
-    if [ -e $HOME/.asdf ]; then
+    if [ -e $HOME/.asdf && ! asdf which erl ]; then
         VERSION_MANAGER="asdf"
-    elif [ -e $HOME/.rtx ]; then
+    elif [ -e $HOME/.rtx && ! rtx which erl ]; then
         VERSION_MANAGER="rtx"
     else
         VERSION_MANAGER="none"


### PR DESCRIPTION
Hi 👋 

Had an issue locally when both `asdf` and `rtx` were installed, but Elixir/Erlang versions were handled by `rtx`, so that the elixir executable was not found, and looked into it. 

I'm aware it's an unusual case, but feel the changes couldn't hurt. 

My thinking is also that although version managers are installed, they may not be used to handle Elixir/Erlang, in which case the fallback of checking for the executables directly is still handy.

The changes here basically combine the check for a version manager _and_ the executable into one step, also making it possible to use executables installed by different means.