### PR TITLE
make sure not to choke on non-export prefixed path lines

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control.ex
+++ b/apps/remote_control/lib/lexical/remote_control.ex
@@ -179,7 +179,9 @@ defmodule Lexical.RemoteControl do
         |> Enum.map(&String.trim/1)
 
       {key, value}
+     _ -> nil
     end)
+    |> Enum.reject(&is_nil/1)
   end
 
   defp reset_env(_, _) do


### PR DESCRIPTION
This fixes the crash I was experiencing in https://github.com/lexical-lsp/lexical/issues/299