### PR TITLE
Fix extraneous logging in test

### DIFF
--- a/apps/plugin_runner/mix.exs
+++ b/apps/plugin_runner/mix.exs
@@ -28,6 +28,7 @@ defmodule Lexical.Plugin.Runner.MixProject do
   defp deps do
     [
       {:common, in_umbrella: true},
+      {:lexical_test, path: "../../projects/lexical_test", only: :test},
       {:lexical_plugin, path: "../../projects/lexical_plugin", only: :test}
     ]
   end

--- a/apps/remote_control/lib/lexical/remote_control/project_node.ex
+++ b/apps/remote_control/lib/lexical/remote_control/project_node.ex
@@ -224,6 +224,11 @@ defmodule Lexical.RemoteControl.ProjectNode do
   end
 
   @impl true
+  def handle_info({:EXIT, port, _}, state) when is_port(port) do
+    {:noreply, state}
+  end
+
+  @impl true
   def handle_info(:timeout, %State{} = state) do
     state = State.halt(state)
     GenServer.reply(state.stopped_by, :ok)

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,3 @@
 import Config
-alias Lexical.Server.JsonRpc.Backend, as: JsonRpcBackend
 
 import_config("#{Mix.env()}.exs")

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,10 +2,13 @@ import Config
 alias Lexical.Server.JsonRpc
 alias Lexical.Test.Transport.NoOp
 
-Logger.remove_backend(:console)
-Logger.remove_backend(JsonRpc.Backend)
-config :logger, level: :error, backends: []
-
+config :logger, level: :none
 config :remote_control, edit_window_millis: 10
-
 config :server, transport: NoOp
+
+if Version.match?(System.version(), ">= 1.15.0") do
+  Logger.configure(level: :none)
+else
+  Logger.remove_backend(:console)
+  Logger.remove_backend(JsonRpc.Backend)
+end

--- a/projects/lexical_plugin/config/test.exs
+++ b/projects/lexical_plugin/config/test.exs
@@ -1,4 +1,4 @@
 import Config
 
 Logger.remove_backend(:console)
-config :logger, level: :error
+config :logger, level: :none


### PR DESCRIPTION
This PR is two commits, the first shuts up logging in test, but I don't understand why it's broken in the first place. More investigation is warranted.

The second cleans up the config files a bit and removes an unhandled message log message.