### PR TITLE
Update paths to start_lexical.sh in installation.md

### DIFF
--- a/pages/installation.md
+++ b/pages/installation.md
@@ -85,7 +85,7 @@ emacs configuration), insert the following code:
 (use-package elixir-mode
   :ensure t
   :custom
-  (lsp-elixir-server-command '("/my/home/projects/_build/dev/package/lexical/start_lexical.sh")))
+  (lsp-elixir-server-command '("/my/home/projects/_build/dev/package/lexical/bin/start_lexical.sh")))
 
 ```
 
@@ -125,7 +125,7 @@ configuration below as a reference:
 
     local lexical_config = {
       filetypes = { "elixir", "eelixir", },
-      cmd = { "/my/home/projects/_build/dev/package/lexical/start_lexical.sh" },
+      cmd = { "/my/home/projects/_build/dev/package/lexical/bin/start_lexical.sh" },
       settings = {},
     }
 
@@ -169,7 +169,7 @@ call minpac#add("prabirshrestha/vim-lsp")
 if executable("elixir")
     augroup lsp_lexical
     autocmd!
-    autocmd User lsp_setup call lsp#register_server({ name: "lexical", cmd: (server_info) => "{{path_to_lexical}}/lexical-lsp/lexical/_build/dev/rel/lexical/start_lexical.sh", allowlist: ["elixir", "eelixir"] })
+    autocmd User lsp_setup call lsp#register_server({ name: "lexical", cmd: (server_info) => "{{path_to_lexical}}/lexical-lsp/lexical/_build/dev/package/lexical/bin/start_lexical.sh", allowlist: ["elixir", "eelixir"] })
     autocmd FileType elixir setlocal omnifunc=lsp#complete
     autocmd FileType eelixir setlocal omnifunc=lsp#complete
     augroup end


### PR DESCRIPTION
Adjusted the paths to `start_lexical.sh`.
The new packaging has moved this shell script into a different location, and that is now reflected in these installation instructions..