### PR TITLE
Support for erlang 26

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -158,6 +158,8 @@ jobs:
       # and running the workflow steps.
       matrix:
         include:
+          - elixir: "1.15.3-otp-26"
+            otp: "26.0.2"
           - elixir: "1.15.3-otp-25"
             otp: "25.3"
           - elixir: "1.14.5-otp-25"

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_field_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_field_test.exs
@@ -97,31 +97,39 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructFieldTes
       """
     end
 
+    def find_by_label(completions, label_substring) do
+      Enum.find(completions, &String.contains?(&1.label, label_substring))
+    end
+
     test "should complete when after the curly", %{project: project} do
-      {:ok, [completion, _]} =
+      {:ok, completions} =
         project
         |> complete(wrap_with_module("%Project.Structs.Account{|}"))
         |> fetch_completion(kind: :field)
 
+      completion = find_by_label(completions, "last_login_at")
       expected = "%Project.Structs.Account{last_login_at: ${1:last_login_at}}"
       assert apply_completion(completion) =~ expected
     end
 
     test "should complete when typed a field character", %{project: project} do
-      {:ok, [completion, _]} =
+      {:ok, completions} =
         project
         |> complete(wrap_with_module("%Project.Structs.Account{la|}"))
         |> fetch_completion(kind: :field)
 
+      completion = find_by_label(completions, "last_login_at")
       expected = "%Project.Structs.Account{last_login_at: ${1:last_login_at}}"
       assert apply_completion(completion) =~ expected
     end
 
     test "should complete when after the comma", %{project: project} do
-      {:ok, [_, completion]} =
+      {:ok, completions} =
         project
         |> complete(wrap_with_module("%Project.Structs.Account{last_login_at: nil, |}"))
         |> fetch_completion(kind: :field)
+
+      completion = find_by_label(completions, "user")
 
       expected = "%Project.Structs.Account{last_login_at: nil, user: ${1:user}}"
       assert apply_completion(completion) =~ expected
@@ -157,11 +165,12 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructFieldTes
         end
       ]
 
-      {:ok, [_, completion]} =
+      {:ok, completions} =
         project
         |> complete(source)
         |> fetch_completion(kind: :field)
 
+      completion = find_by_label(completions, "user")
       assert apply_completion(completion) == expected
     end
 
@@ -186,11 +195,12 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructFieldTes
         end
       ]
 
-      {:ok, [completion, _]} =
+      {:ok, completions} =
         project
         |> complete(source)
         |> fetch_completion(kind: :field)
 
+      completion = find_by_label(completions, "last_login_at")
       assert apply_completion(completion) == expected
     end
 

--- a/pages/installation.md
+++ b/pages/installation.md
@@ -13,7 +13,7 @@ Lexical supports the following versions of Elixir and Erlang:
 | ----------- |----------------- | ------ |
 |  24         | `>= 24.3.4.12`   | Might run on older versions; this was the lowest that would compile on arm |
 |  25         | `>= 25.0`        |        |
-|  26         | In progress      |        |
+|  26         | `>= 26.0.2`      |        |
 
 | Elixir   | Version Range  | Notes    |
 | -------- | -------------- | -------- |


### PR DESCRIPTION
I tried erlang 26.0.2, and lo and behold, it worked with lexical. There were a few unit test failures due to completion results being ordered differently, but otherwise, lexical works great under 26.

Fixes #244