### PR TITLE
Fix package task generating empty ZIPs

### DIFF
--- a/apps/server/lib/mix/tasks/package.ex
+++ b/apps/server/lib/mix/tasks/package.ex
@@ -96,8 +96,8 @@ defmodule Mix.Tasks.Package do
     File.rm_rf!(scratch_directory)
 
     if Keyword.get(opts, :zip, false) do
-      File.rm_rf(package_root)
       zip(package_root)
+      File.rm_rf(package_root)
     end
   end
 


### PR DESCRIPTION
I was testing out support for the new packaging structure in vscode and was wondering why nothing was getting extracted from the zip :sweat_smile: 