### PR TITLE
Suggest a module name for defmodule completion

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
@@ -1,4 +1,5 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
+  alias Lexical.Document
   alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Env
   alias Lexical.Server.CodeIntelligence.Completion.Translatable
@@ -50,11 +51,15 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost(8)
   end
 
+  require Logger
+
   def translate(%Candidate.Macro{name: "defmodule"} = macro, builder, env) do
     label = "defmodule (Define a module)"
+    suggestion = suggest_module_name(env.document)
+    Logger.info("Suggestion is #{suggestion}")
 
     snippet = """
-    defmodule ${1:module name} do
+    defmodule ${1:#{suggestion}} do
       $0
     end
     """
@@ -548,5 +553,45 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
 
   def translate(%Candidate.Macro{}, _builder, _env) do
     :skip
+  end
+
+  def suggest_module_name(%Document{} = document) do
+    result =
+      document.path
+      |> Path.split()
+      |> Enum.reduce(false, fn
+        "lib", _ ->
+          {:lib, []}
+
+        "test", _ ->
+          {:test, []}
+
+        "support", {:test, _} ->
+          {:lib, []}
+
+        _, false ->
+          false
+
+        element, {type, elements} ->
+          camelized =
+            element
+            |> Path.rootname()
+            |> Macro.camelize()
+
+          {type, [camelized | elements]}
+      end)
+
+    case result do
+      {_, parts} ->
+        parts
+        |> Enum.reverse()
+        |> Enum.join(".")
+
+      false ->
+        document.path
+        |> Path.basename()
+        |> Path.rootname()
+        |> Macro.camelize()
+    end
   end
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
@@ -51,12 +51,9 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
     |> builder.boost(8)
   end
 
-  require Logger
-
   def translate(%Candidate.Macro{name: "defmodule"} = macro, builder, env) do
     label = "defmodule (Define a module)"
     suggestion = suggest_module_name(env.document)
-    Logger.info("Suggestion is #{suggestion}")
 
     snippet = """
     defmodule ${1:#{suggestion}} do

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
@@ -107,7 +107,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert %Completion.Item{} = completion
     end
 
-    test "defmodule", %{project: project} do
+    test "defmodule for lib paths", %{project: project} do
       assert {:ok, completion} =
                project
                |> complete("defmodule|")
@@ -118,7 +118,58 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.insert_text_format == :snippet
 
       assert completion.insert_text == """
-             defmodule ${1:module name} do
+             defmodule ${1:File} do
+               $0
+             end
+             """
+    end
+
+    test "defmodule for test paths", %{project: project} do
+      assert {:ok, completion} =
+               project
+               |> complete("defmodule|", path: "test/foo/project/my_test.exs")
+               |> fetch_completion("defmodule ")
+
+      assert completion.detail
+      assert completion.label == "defmodule (Define a module)"
+      assert completion.insert_text_format == :snippet
+
+      assert completion.insert_text == """
+             defmodule ${1:Foo.Project.MyTest} do
+               $0
+             end
+             """
+    end
+
+    test "defmodule for test/support paths", %{project: project} do
+      assert {:ok, completion} =
+               project
+               |> complete("defmodule|", path: "test/support/path/to/file.ex")
+               |> fetch_completion("defmodule ")
+
+      assert completion.detail
+      assert completion.label == "defmodule (Define a module)"
+      assert completion.insert_text_format == :snippet
+
+      assert completion.insert_text == """
+             defmodule ${1:Path.To.File} do
+               $0
+             end
+             """
+    end
+
+    test "defmodule for other paths", %{project: project} do
+      assert {:ok, completion} =
+               project
+               |> complete("defmodule|", path: "/this/is/another/path.ex")
+               |> fetch_completion("defmodule ")
+
+      assert completion.detail
+      assert completion.label == "defmodule (Define a module)"
+      assert completion.insert_text_format == :snippet
+
+      assert completion.insert_text == """
+             defmodule ${1:Path} do
                $0
              end
              """

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_test.exs
@@ -131,7 +131,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructTest do
     test "when using %, child structs are returned", %{project: project} do
       assert [account, order, order_line, user] =
                project
-               |> complete("%Project.Structs.|", "%")
+               |> complete("%Project.Structs.|", trigger_character: "%")
                |> Enum.sort_by(& &1.label)
 
       assert account.label == "Account"
@@ -150,7 +150,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructTest do
     test "when using % and child is not a struct, just `more` snippet is returned", %{
       project: project
     } do
-      assert [more] = complete(project, "%Project.|", "%")
+      assert [more] = complete(project, "%Project.|", trigger_character: "%")
       assert more.label == "Structs...(4 more structs)"
       assert more.detail == "Project.Structs."
     end


### PR DESCRIPTION
The defmodule completion snippet now does a best-effort attempt to guess the module name.

The guessing takes into account lib, test and test/support directories, and if it doesn't detect any of them, just uses the file name.