### PR TITLE
Allow release workflow to update existing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,3 +51,4 @@ jobs:
           artifacts: lexical*.zip
           makeLatest: true
           generateReleaseNotes: true
+          allowUpdates: true


### PR DESCRIPTION
Allows the release workflow to update an existing release.

This will let us create releases through Github’s UI without having the workflow fail afterwards.