### PR TITLE
Fixed bug in path namespacing

### DIFF
--- a/apps/remote_control/lib/mix/tasks/namespace/path.ex
+++ b/apps/remote_control/lib/mix/tasks/namespace/path.ex
@@ -17,17 +17,12 @@ defmodule Mix.Tasks.Namespace.Path do
 
   defp replace_namespaced_apps(path_component) do
     Enum.reduce(Namespace.app_names(), path_component, fn app_name, path ->
-      string_name = Atom.to_string(app_name)
-
-      namespaced_name =
+      if path == Atom.to_string(app_name) do
         app_name
         |> Namespace.Module.apply()
         |> Atom.to_string()
-
-      if String.contains?(path, namespaced_name) do
-        path
       else
-        String.replace(path, string_name, namespaced_name)
+        path
       end
     end)
   end

--- a/apps/remote_control/lib/mix/tasks/namespace/transform/app_directories.ex
+++ b/apps/remote_control/lib/mix/tasks/namespace/transform/app_directories.ex
@@ -10,8 +10,8 @@ defmodule Mix.Tasks.Namespace.Transform.AppDirectories do
   def apply(app_path) do
     namespaced_app_path = Namespace.Path.apply(app_path)
 
-    with {:ok, _} <- File.rm_rf(namespaced_app_path),
-         :ok <- File.rename(app_path, namespaced_app_path) do
+    with {:ok, _} <- File.rm_rf(namespaced_app_path) do
+      File.rename!(app_path, namespaced_app_path)
     end
   end
 


### PR DESCRIPTION
I was using String.replace to apply namespacing to a path. This would cause issues if lexical resided in a directory whose parents had a substring of one of its app names (e.g. language_server).

Instead of using replace, we should only apply namespacing to subdirectories that are exactly equal to one of lexical's apps.

Fixes #341