### PR TITLE
Fix markdown formatting for supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Lexical will be available in `/path/to/lexical`.
 
 ## Development
 
-Lexical is intended to run on any version of Erlang >= 24 and Elixir
->= 1.13. Before beginning development, you should install Erlang
+Lexical is intended to run on any version of Erlang 24+ and Elixir
+1.13+. Before beginning development, you should install Erlang
 `24.3.4.12` and Elixir `1.13.4` and use those versions when you're
 building code.
 


### PR DESCRIPTION
The markdown rendering of README is confusing because of the `>` being interpreted as quote start.

**Before this change:**
<img width="820" alt="Screenshot 2023-09-04 at 09 43 42" src="https://github.com/lexical-lsp/lexical/assets/992835/7575205a-b74f-4090-bdfc-44c1acc4a6f6">

**After this change:**
<img width="1056" alt="Screenshot 2023-09-04 at 09 44 30" src="https://github.com/lexical-lsp/lexical/assets/992835/3713822a-8526-4e82-ac7d-39c722e1364f">
