### PR TITLE
Improved hover support: Structs, qualified calls and types, more info for modules

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -106,7 +106,7 @@ jobs:
         id: set_mix_lock_hash
         run: |
           mix_lock_hash="${{ hashFiles(env.project_mix_lock) }}"
-          projects_hash="${{ hashFiles(env.project_ex_blob, env.projects_locks_blob) }}"
+          projects_hash="${{ hashFiles(env.projects_ex_blob, env.projects_locks_blob) }}"
           echo "mix_lock_hash=$mix_lock_hash::$projects_hash" >> "$GITHUB_OUTPUT"
 
       # Step: Define how to cache deps. Restores existing cache if present.

--- a/apps/common/lib/future/code/typespec.ex
+++ b/apps/common/lib/future/code/typespec.ex
@@ -1,0 +1,424 @@
+# Copied from https://github.com/elixir-lang/elixir/blob/d87aadf8bd280d4ac969a6825637fcbd1e412f81/lib/elixir/lib/code/typespec.ex
+defmodule Future.Code.Typespec do
+  @moduledoc false
+
+  @doc """
+  Converts a spec clause back to Elixir quoted expression.
+  """
+  @spec spec_to_quoted(atom, tuple) :: {atom, keyword, [Macro.t()]}
+  def spec_to_quoted(name, spec)
+
+  def spec_to_quoted(name, {:type, anno, :fun, [{:type, _, :product, args}, result]})
+      when is_atom(name) do
+    meta = meta(anno)
+    body = {name, meta, Enum.map(args, &typespec_to_quoted/1)}
+
+    vars =
+      for type_expr <- args ++ [result],
+          var <- collect_vars(type_expr),
+          uniq: true,
+          do: {var, {:var, meta, nil}}
+
+    spec = {:"::", meta, [body, typespec_to_quoted(result)]}
+
+    if vars == [] do
+      spec
+    else
+      {:when, meta, [spec, vars]}
+    end
+  end
+
+  def spec_to_quoted(name, {:type, anno, :fun, []}) when is_atom(name) do
+    meta = meta(anno)
+    {:"::", meta, [{name, meta, []}, quote(do: term)]}
+  end
+
+  def spec_to_quoted(name, {:type, anno, :bounded_fun, [type, constrs]}) when is_atom(name) do
+    meta = meta(anno)
+    {:type, _, :fun, [{:type, _, :product, args}, result]} = type
+
+    guards =
+      for {:type, _, :constraint, [{:atom, _, :is_subtype}, [{:var, _, var}, type]]} <- constrs do
+        {erl_to_ex_var(var), typespec_to_quoted(type)}
+      end
+
+    ignore_vars = Keyword.keys(guards)
+
+    vars =
+      for type_expr <- args ++ [result],
+          var <- collect_vars(type_expr),
+          var not in ignore_vars,
+          uniq: true,
+          do: {var, {:var, meta, nil}}
+
+    args = for arg <- args, do: typespec_to_quoted(arg)
+
+    when_args = [
+      {:"::", meta, [{name, meta, args}, typespec_to_quoted(result)]},
+      guards ++ vars
+    ]
+
+    {:when, meta, when_args}
+  end
+
+  @doc """
+  Converts a type clause back to Elixir AST.
+  """
+  def type_to_quoted(type)
+
+  def type_to_quoted({{:record, record}, fields, args}) when is_atom(record) do
+    fields = for field <- fields, do: typespec_to_quoted(field)
+    args = for arg <- args, do: typespec_to_quoted(arg)
+    type = {:{}, [], [record | fields]}
+    quote(do: unquote(record)(unquote_splicing(args)) :: unquote(type))
+  end
+
+  def type_to_quoted({name, type, args}) when is_atom(name) do
+    args = for arg <- args, do: typespec_to_quoted(arg)
+    quote(do: unquote(name)(unquote_splicing(args)) :: unquote(typespec_to_quoted(type)))
+  end
+
+  @doc """
+  Returns all types available from the module's BEAM code.
+
+  The result is returned as a list of tuples where the first
+  element is the type (`:typep`, `:type` and `:opaque`).
+
+  The module must have a corresponding BEAM file which can be
+  located by the runtime system. The types will be in the Erlang
+  Abstract Format.
+  """
+  @spec fetch_types(module | binary) :: {:ok, [tuple]} | :error
+  def fetch_types(module) when is_atom(module) or is_binary(module) do
+    case typespecs_abstract_code(module) do
+      {:ok, abstract_code} ->
+        exported_types = for {:attribute, _, :export_type, types} <- abstract_code, do: types
+        exported_types = List.flatten(exported_types)
+
+        types =
+          for {:attribute, _, kind, {name, _, args} = type} <- abstract_code,
+              kind in [:opaque, :type] do
+            cond do
+              kind == :opaque -> {:opaque, type}
+              {name, length(args)} in exported_types -> {:type, type}
+              true -> {:typep, type}
+            end
+          end
+
+        {:ok, types}
+
+      _ ->
+        :error
+    end
+  end
+
+  @doc """
+  Returns all specs available from the module's BEAM code.
+
+  The result is returned as a list of tuples where the first
+  element is spec name and arity and the second is the spec.
+
+  The module must have a corresponding BEAM file which can be
+  located by the runtime system. The types will be in the Erlang
+  Abstract Format.
+  """
+  @spec fetch_specs(module | binary) :: {:ok, [tuple]} | :error
+  def fetch_specs(module) when is_atom(module) or is_binary(module) do
+    case typespecs_abstract_code(module) do
+      {:ok, abstract_code} ->
+        {:ok, for({:attribute, _, :spec, value} <- abstract_code, do: value)}
+
+      :error ->
+        :error
+    end
+  end
+
+  @doc """
+  Returns all callbacks available from the module's BEAM code.
+
+  The result is returned as a list of tuples where the first
+  element is spec name and arity and the second is the spec.
+
+  The module must have a corresponding BEAM file
+  which can be located by the runtime system. The types will be
+  in the Erlang Abstract Format.
+  """
+  @spec fetch_callbacks(module | binary) :: {:ok, [tuple]} | :error
+  def fetch_callbacks(module) when is_atom(module) or is_binary(module) do
+    case typespecs_abstract_code(module) do
+      {:ok, abstract_code} ->
+        {:ok, for({:attribute, _, :callback, value} <- abstract_code, do: value)}
+
+      :error ->
+        :error
+    end
+  end
+
+  defp typespecs_abstract_code(module) do
+    with {module, binary} <- get_module_and_beam(module),
+         {:ok, {_, [debug_info: {:debug_info_v1, backend, data}]}} <-
+           :beam_lib.chunks(binary, [:debug_info]) do
+      case data do
+        {:elixir_v1, %{}, specs} ->
+          # Fast path to avoid translation to Erlang from Elixir.
+          {:ok, specs}
+
+        _ ->
+          case backend.debug_info(:erlang_v1, module, data, []) do
+            {:ok, abstract_code} -> {:ok, abstract_code}
+            _ -> :error
+          end
+      end
+    else
+      _ -> :error
+    end
+  end
+
+  defp get_module_and_beam(module) when is_atom(module) do
+    with {^module, beam, _filename} <- :code.get_object_code(module),
+         {:ok, ^module} <- beam |> :beam_lib.info() |> Keyword.fetch(:module) do
+      {module, beam}
+    else
+      _ -> :error
+    end
+  end
+
+  defp get_module_and_beam(beam) when is_binary(beam) do
+    case :beam_lib.info(beam) do
+      [_ | _] = info -> {info[:module], beam}
+      _ -> :error
+    end
+  end
+
+  ## To AST conversion
+
+  defp collect_vars({:ann_type, _anno, args}) when is_list(args) do
+    []
+  end
+
+  defp collect_vars({:type, _anno, _kind, args}) when is_list(args) do
+    Enum.flat_map(args, &collect_vars/1)
+  end
+
+  defp collect_vars({:remote_type, _anno, args}) when is_list(args) do
+    Enum.flat_map(args, &collect_vars/1)
+  end
+
+  defp collect_vars({:typed_record_field, _anno, type}) do
+    collect_vars(type)
+  end
+
+  defp collect_vars({:paren_type, _anno, [type]}) do
+    collect_vars(type)
+  end
+
+  defp collect_vars({:var, _anno, var}) do
+    [erl_to_ex_var(var)]
+  end
+
+  defp collect_vars(_) do
+    []
+  end
+
+  defp typespec_to_quoted({:user_type, anno, name, args}) do
+    args = for arg <- args, do: typespec_to_quoted(arg)
+    {name, meta(anno), args}
+  end
+
+  defp typespec_to_quoted({:type, anno, :tuple, :any}) do
+    {:tuple, meta(anno), []}
+  end
+
+  defp typespec_to_quoted({:type, anno, :tuple, args}) do
+    args = for arg <- args, do: typespec_to_quoted(arg)
+    {:{}, meta(anno), args}
+  end
+
+  defp typespec_to_quoted({:type, _anno, :list, [{:type, _, :union, unions} = arg]}) do
+    case unpack_typespec_kw(unions, []) do
+      {:ok, ast} -> ast
+      :error -> [typespec_to_quoted(arg)]
+    end
+  end
+
+  defp typespec_to_quoted({:type, anno, :list, []}) do
+    {:list, meta(anno), []}
+  end
+
+  defp typespec_to_quoted({:type, _anno, :list, [arg]}) do
+    [typespec_to_quoted(arg)]
+  end
+
+  defp typespec_to_quoted({:type, anno, :nonempty_list, []}) do
+    [{:..., meta(anno), nil}]
+  end
+
+  defp typespec_to_quoted({:type, anno, :nonempty_list, [arg]}) do
+    [typespec_to_quoted(arg), {:..., meta(anno), nil}]
+  end
+
+  defp typespec_to_quoted({:type, anno, :map, :any}) do
+    {:map, meta(anno), []}
+  end
+
+  defp typespec_to_quoted({:type, anno, :map, fields}) do
+    fields =
+      Enum.map(fields, fn
+        {:type, _, :map_field_assoc, :any} ->
+          {{:optional, [], [{:any, [], []}]}, {:any, [], []}}
+
+        {:type, _, :map_field_exact, [{:atom, _, k}, v]} ->
+          {k, typespec_to_quoted(v)}
+
+        {:type, _, :map_field_exact, [k, v]} ->
+          {{:required, [], [typespec_to_quoted(k)]}, typespec_to_quoted(v)}
+
+        {:type, _, :map_field_assoc, [k, v]} ->
+          {{:optional, [], [typespec_to_quoted(k)]}, typespec_to_quoted(v)}
+      end)
+
+    case List.keytake(fields, :__struct__, 0) do
+      {{:__struct__, struct}, fields_pruned} when is_atom(struct) and struct != nil ->
+        map_pruned = {:%{}, meta(anno), fields_pruned}
+        {:%, meta(anno), [struct, map_pruned]}
+
+      _ ->
+        {:%{}, meta(anno), fields}
+    end
+  end
+
+  defp typespec_to_quoted({:type, anno, :binary, [arg1, arg2]}) do
+    [arg1, arg2] = for arg <- [arg1, arg2], do: typespec_to_quoted(arg)
+    line = meta(anno)[:line]
+
+    case {typespec_to_quoted(arg1), typespec_to_quoted(arg2)} do
+      {arg1, 0} ->
+        quote(line: line, do: <<_::unquote(arg1)>>)
+
+      {0, arg2} ->
+        quote(line: line, do: <<_::_*unquote(arg2)>>)
+
+      {arg1, arg2} ->
+        quote(line: line, do: <<_::unquote(arg1), _::_*unquote(arg2)>>)
+    end
+  end
+
+  defp typespec_to_quoted({:type, anno, :union, args}) do
+    args = for arg <- args, do: typespec_to_quoted(arg)
+    Enum.reduce(Enum.reverse(args), fn arg, expr -> {:|, meta(anno), [arg, expr]} end)
+  end
+
+  defp typespec_to_quoted({:type, anno, :fun, [{:type, _, :product, args}, result]}) do
+    args = for arg <- args, do: typespec_to_quoted(arg)
+    [{:->, meta(anno), [args, typespec_to_quoted(result)]}]
+  end
+
+  defp typespec_to_quoted({:type, anno, :fun, [args, result]}) do
+    [{:->, meta(anno), [[typespec_to_quoted(args)], typespec_to_quoted(result)]}]
+  end
+
+  defp typespec_to_quoted({:type, anno, :fun, []}) do
+    typespec_to_quoted({:type, anno, :fun, [{:type, anno, :any}, {:type, anno, :any, []}]})
+  end
+
+  defp typespec_to_quoted({:type, anno, :range, [left, right]}) do
+    {:.., meta(anno), [typespec_to_quoted(left), typespec_to_quoted(right)]}
+  end
+
+  defp typespec_to_quoted({:type, _anno, nil, []}) do
+    []
+  end
+
+  defp typespec_to_quoted({:type, anno, name, args}) do
+    args = for arg <- args, do: typespec_to_quoted(arg)
+    {name, meta(anno), args}
+  end
+
+  defp typespec_to_quoted({:var, anno, var}) do
+    {erl_to_ex_var(var), meta(anno), nil}
+  end
+
+  defp typespec_to_quoted({:op, anno, op, arg}) do
+    {op, meta(anno), [typespec_to_quoted(arg)]}
+  end
+
+  defp typespec_to_quoted({:remote_type, anno, [mod, name, args]}) do
+    remote_type(anno, mod, name, args)
+  end
+
+  defp typespec_to_quoted({:ann_type, anno, [var, type]}) do
+    {:"::", meta(anno), [typespec_to_quoted(var), typespec_to_quoted(type)]}
+  end
+
+  defp typespec_to_quoted(
+         {:typed_record_field, {:record_field, anno1, {:atom, anno2, name}}, type}
+       ) do
+    typespec_to_quoted({:ann_type, anno1, [{:var, anno2, name}, type]})
+  end
+
+  defp typespec_to_quoted({:type, _, :any}) do
+    quote(do: ...)
+  end
+
+  defp typespec_to_quoted({:paren_type, _, [type]}) do
+    typespec_to_quoted(type)
+  end
+
+  defp typespec_to_quoted({type, _anno, atom}) when is_atom(type) do
+    atom
+  end
+
+  defp typespec_to_quoted(other), do: other
+
+  ## Helpers
+
+  defp remote_type(anno, {:atom, _, :elixir}, {:atom, _, :charlist}, []) do
+    typespec_to_quoted({:type, anno, :charlist, []})
+  end
+
+  defp remote_type(anno, {:atom, _, :elixir}, {:atom, _, :nonempty_charlist}, []) do
+    typespec_to_quoted({:type, anno, :nonempty_charlist, []})
+  end
+
+  defp remote_type(anno, {:atom, _, :elixir}, {:atom, _, :struct}, []) do
+    typespec_to_quoted({:type, anno, :struct, []})
+  end
+
+  defp remote_type(anno, {:atom, _, :elixir}, {:atom, _, :as_boolean}, [arg]) do
+    typespec_to_quoted({:type, anno, :as_boolean, [arg]})
+  end
+
+  defp remote_type(anno, {:atom, _, :elixir}, {:atom, _, :keyword}, args) do
+    typespec_to_quoted({:type, anno, :keyword, args})
+  end
+
+  defp remote_type(anno, mod, name, args) do
+    args = for arg <- args, do: typespec_to_quoted(arg)
+    dot = {:., meta(anno), [typespec_to_quoted(mod), typespec_to_quoted(name)]}
+    {dot, meta(anno), args}
+  end
+
+  defp erl_to_ex_var(var) do
+    case Atom.to_string(var) do
+      <<"_", c::utf8, rest::binary>> ->
+        String.to_atom("_#{String.downcase(<<c::utf8>>)}#{rest}")
+
+      <<c::utf8, rest::binary>> ->
+        String.to_atom("#{String.downcase(<<c::utf8>>)}#{rest}")
+    end
+  end
+
+  defp unpack_typespec_kw([{:type, _, :tuple, [{:atom, _, atom}, type]} | t], acc) do
+    unpack_typespec_kw(t, [{atom, typespec_to_quoted(type)} | acc])
+  end
+
+  defp unpack_typespec_kw([], acc) do
+    {:ok, Enum.reverse(acc)}
+  end
+
+  defp unpack_typespec_kw(_, _acc) do
+    :error
+  end
+
+  defp meta(anno), do: [line: :erl_anno.line(anno)]
+end

--- a/apps/common/lib/lexical/ast.ex
+++ b/apps/common/lib/lexical/ast.ex
@@ -89,6 +89,18 @@ defmodule Lexical.Ast do
   @type alias_segments :: [short_alias]
 
   @doc """
+  Guard used to determined whether an AST node is a call.
+
+  ## Example
+
+      def my_fun({call, _meta, args}) when is_call(call, args), do: ...
+
+  """
+  @non_call_nodes [:., :__aliases__, :__block__, :"::", :{}, :|>, :%, :%{}]
+  defguard is_call(call, args)
+           when is_atom(call) and is_list(args) and call not in @non_call_nodes
+
+  @doc """
   Returns an AST generated from a valid document or string.
   """
   @spec from(Document.t() | String.t()) :: {:ok, Macro.t()} | {:error, parse_error()}

--- a/apps/common/lib/lexical/ast.ex
+++ b/apps/common/lib/lexical/ast.ex
@@ -89,32 +89,14 @@ defmodule Lexical.Ast do
   @type alias_segments :: [short_alias]
 
   @doc """
-  Guard used to determined whether an AST node is an unqualified call.
-
-  ## Example
-
-      def my_fun({form, _meta, args}) when is_unqualified_call(form, args), do: ...
-
-  """
-  @non_local_calls [:., :__aliases__, :__block__, :"::", :{}, :|>, :%, :%{}]
-  defguard is_unqualified_call(form, args)
-           when is_atom(form) and is_list(args) and form not in @non_local_calls
-
-  @doc """
-  Guard used to determine whether an AST node is a dot call.
-
-  ## Example
-
-      def my_fun({form, _meta, args}) when is_dot_call(form, args), do: ...
-
-  """
-  defguard is_dot_call(form, args)
-           when is_tuple(form) and tuple_size(form) == 3 and elem(form, 0) == :. and is_list(args)
-
-  @doc """
   Guard used to determine whether an AST node is a call, either local or qualified.
   """
-  defguard is_call(form, args) when is_unqualified_call(form, args) or is_dot_call(form, args)
+  @non_call_forms [:__aliases__, :__block__, :.]
+  defguard is_call(quoted)
+           when is_tuple(quoted) and
+                  tuple_size(quoted) == 3 and
+                  is_list(elem(quoted, 2)) and
+                  elem(quoted, 0) not in @non_call_forms
 
   @doc """
   Returns an AST generated from a valid document or string.

--- a/apps/common/lib/lexical/ast.ex
+++ b/apps/common/lib/lexical/ast.ex
@@ -313,11 +313,6 @@ defmodule Lexical.Ast do
     end
   end
 
-  def path_at(s, pos) when is_binary(s) do
-    {:ok, ast} = from(s)
-    path_at(ast, pos)
-  end
-
   @spec path_at(Macro.t(), Position.t()) :: {:ok, [Macro.t(), ...]} | {:error, :not_found}
   def path_at(ast, %Position{} = position) do
     path =

--- a/apps/common/lib/lexical/ast.ex
+++ b/apps/common/lib/lexical/ast.ex
@@ -89,16 +89,6 @@ defmodule Lexical.Ast do
   @type alias_segments :: [short_alias]
 
   @doc """
-  Guard used to determine whether an AST node is a call, either local or qualified.
-  """
-  @non_call_forms [:__aliases__, :__block__, :.]
-  defguard is_call(quoted)
-           when is_tuple(quoted) and
-                  tuple_size(quoted) == 3 and
-                  is_list(elem(quoted, 2)) and
-                  elem(quoted, 0) not in @non_call_forms
-
-  @doc """
   Returns an AST generated from a valid document or string.
   """
   @spec from(Document.t() | String.t()) :: {:ok, Macro.t()} | {:error, parse_error()}

--- a/apps/common/mix.exs
+++ b/apps/common/mix.exs
@@ -33,7 +33,7 @@ defmodule Common.MixProject do
   defp deps do
     [
       {:lexical_shared, path: "../../projects/lexical_shared"},
-      {:sourceror, "~> 0.12"},
+      {:sourceror, github: "zachallaun/sourceror", ref: "nil-get-range"},
       {:stream_data, "~> 0.6", only: [:test], runtime: false},
       {:patch, "~> 0.12", only: [:test], optional: true, runtime: false}
     ]

--- a/apps/common/mix.exs
+++ b/apps/common/mix.exs
@@ -33,7 +33,7 @@ defmodule Common.MixProject do
   defp deps do
     [
       {:lexical_shared, path: "../../projects/lexical_shared"},
-      {:sourceror, github: "zachallaun/sourceror", ref: "nil-get-range"},
+      {:sourceror, github: "doorgan/sourceror", ref: "eaf0cc6"},
       {:stream_data, "~> 0.6", only: [:test], runtime: false},
       {:patch, "~> 0.12", only: [:test], optional: true, runtime: false}
     ]

--- a/apps/common/mix.exs
+++ b/apps/common/mix.exs
@@ -33,7 +33,7 @@ defmodule Common.MixProject do
   defp deps do
     [
       {:lexical_shared, path: "../../projects/lexical_shared"},
-      {:sourceror, github: "doorgan/sourceror", ref: "b0ec3cc"},
+      {:sourceror, "~> 0.14.0"},
       {:stream_data, "~> 0.6", only: [:test], runtime: false},
       {:patch, "~> 0.12", only: [:test], optional: true, runtime: false}
     ]

--- a/apps/common/mix.exs
+++ b/apps/common/mix.exs
@@ -33,7 +33,7 @@ defmodule Common.MixProject do
   defp deps do
     [
       {:lexical_shared, path: "../../projects/lexical_shared"},
-      {:sourceror, github: "doorgan/sourceror", ref: "eaf0cc6"},
+      {:sourceror, github: "doorgan/sourceror", ref: "b0ec3cc"},
       {:stream_data, "~> 0.6", only: [:test], runtime: false},
       {:patch, "~> 0.12", only: [:test], optional: true, runtime: false}
     ]

--- a/apps/common/test/lexical/ast/aliases_test.exs
+++ b/apps/common/test/lexical/ast/aliases_test.exs
@@ -1,20 +1,14 @@
 defmodule Lexical.Ast.AliasesTest do
   alias Lexical.Ast.Aliases
-  alias Lexical.Document
-  alias Lexical.Test.CodeSigil
-  alias Lexical.Test.CursorSupport
 
-  import Aliases
-  import CursorSupport
-  import CodeSigil
+  import Lexical.Test.CursorSupport
+  import Lexical.Test.CodeSigil
 
   use ExUnit.Case
 
   def aliases_at_cursor(text) do
-    pos = cursor_position(text)
-    text = strip_cursor(text)
-    doc = Document.new("file:///file.ex", text, 0)
-    at(doc, pos)
+    {position, document} = pop_cursor(text, as: :document)
+    Aliases.at(document, position)
   end
 
   describe "top level aliases" do

--- a/apps/common/test/lexical/ast/env_test.exs
+++ b/apps/common/test/lexical/ast/env_test.exs
@@ -1,24 +1,14 @@
 defmodule Lexical.Ast.EnvTest do
-  alias Lexical.Document
-  alias Lexical.Test.CodeSigil
-  alias Lexical.Test.CursorSupport
-  alias Lexical.Test.Fixtures
-
   use ExUnit.Case, async: true
 
-  import CodeSigil
   import Lexical.Ast.Env
-  import CursorSupport
-  import Fixtures
+  import Lexical.Test.CodeSigil
+  import Lexical.Test.CursorSupport
+  import Lexical.Test.Fixtures
 
   def new_env(text) do
     project = project()
-    {line, column} = cursor_position(text)
-    stripped_text = strip_cursor(text)
-    document = Document.new("file://foo.ex", stripped_text, 0)
-
-    position = Document.Position.new(document, line, column)
-
+    {position, document} = pop_cursor(text, as: :document)
     {:ok, env} = new(project, document, position)
     env
   end

--- a/apps/common/test/lexical/ast_test.exs
+++ b/apps/common/test/lexical/ast_test.exs
@@ -69,20 +69,21 @@ defmodule Lexical.AstTest do
       {:ok, document: document}
     end
 
-    defp underscore_variable({{var_name, meta, nil}, zipper_meta}) do
-      {{:"_#{var_name}", meta, nil}, zipper_meta}
+    defp underscore_variable(%Zipper{node: {var_name, meta, nil}} = zipper) do
+      Zipper.replace(zipper, {:"_#{var_name}", meta, nil})
     end
 
     defp underscore_variable(zipper), do: zipper
 
-    defp underscore_variable({{var_name, meta, nil}, zipper_meta}, acc) do
-      {{{:"_#{var_name}", meta, nil}, zipper_meta}, acc + 1}
+    defp underscore_variable(%Zipper{node: {_var_name, _meta, nil}} = zipper, acc) do
+      zipper = underscore_variable(zipper)
+      {zipper, acc + 1}
     end
 
     defp underscore_variable(zipper, acc), do: {zipper, acc}
 
     defp modify({:ok, zipper}) do
-      {ast, _} = Zipper.top(zipper)
+      %Zipper{node: ast} = Zipper.top(zipper)
       Sourceror.to_string(ast)
     end
 

--- a/apps/common/test/lexical/ast_test.exs
+++ b/apps/common/test/lexical/ast_test.exs
@@ -11,14 +11,12 @@ defmodule Lexical.AstTest do
 
   use ExUnit.Case, async: true
 
-  def cursor_path(text) do
-    pos = cursor_position(text)
-    text = strip_cursor(text)
-    doc = Document.new("file:///file.ex", text, 0)
-    Ast.cursor_path(doc, pos)
-  end
-
   describe "cursor_path/2" do
+    defp cursor_path(text) do
+      {position, document} = pop_cursor(text, as: :document)
+      Ast.cursor_path(document, position)
+    end
+
     test "contains the parent AST" do
       text = ~q[
       defmodule Foo do

--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -72,8 +72,8 @@ defmodule Lexical.RemoteControl.Api do
   end
 
   @spec docs(Project.t(), module()) :: {:ok, CodeIntelligence.Docs.t()} | {:error, any()}
-  def docs(%Project{} = project, module) when is_atom(module) do
-    RemoteControl.call(project, CodeIntelligence.Docs, :for_module, [module])
+  def docs(%Project{} = project, module, opts \\ []) when is_atom(module) do
+    RemoteControl.call(project, CodeIntelligence.Docs, :for_module, [module, opts])
   end
 
   def register_listener(%Project{} = project, listener_pid, message_types)

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/docs.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/docs.ex
@@ -4,6 +4,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Docs do
   """
 
   alias Lexical.RemoteControl.CodeIntelligence.Docs.Entry
+  alias Lexical.RemoteControl.Modules
 
   defstruct [:module, :doc, functions_and_macros: [], callbacks: [], types: []]
 
@@ -20,30 +21,32 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Docs do
   """
   @spec for_module(module()) :: {:ok, t} | {:error, any()}
   def for_module(module) when is_atom(module) do
-    with :ok <- ensure_ready(module),
-         {:docs_v1, _anno, _lang, _fmt, module_doc, _meta, docs} <- Code.fetch_docs(module) do
-      {:ok, parse_docs(module, module_doc, docs)}
+    with {:ok, beam} <- Modules.ensure_beam(module) do
+      {:ok, parse_docs(module, beam)}
     end
   end
 
-  defp parse_docs(module, module_doc, entries) do
-    entries_by_kind = Enum.group_by(entries, &doc_kind/1)
-    function_entries = Map.get(entries_by_kind, :function, [])
-    macro_entries = Map.get(entries_by_kind, :macro, [])
-    callback_entries = Map.get(entries_by_kind, :callback, [])
-    type_entries = Map.get(entries_by_kind, :type, [])
+  defp parse_docs(module, beam) do
+    with {:ok, {:docs_v1, _anno, _lang, _format, module_doc, _meta, entries}} <-
+           Modules.fetch_docs(beam) do
+      entries_by_kind = Enum.group_by(entries, &doc_kind/1)
+      function_entries = Map.get(entries_by_kind, :function, [])
+      macro_entries = Map.get(entries_by_kind, :macro, [])
+      callback_entries = Map.get(entries_by_kind, :callback, [])
+      type_entries = Map.get(entries_by_kind, :type, [])
 
-    spec_defs = get_spec_defs(module)
-    callback_defs = get_callback_defs(module)
-    type_defs = get_type_defs(module)
+      spec_defs = beam |> Modules.fetch_specs() |> ok_or([])
+      callback_defs = beam |> Modules.fetch_callbacks() |> ok_or([])
+      type_defs = beam |> Modules.fetch_types() |> ok_or([])
 
-    %__MODULE__{
-      module: module,
-      doc: Entry.parse_doc(module_doc),
-      functions_and_macros: parse_entries(module, function_entries ++ macro_entries, spec_defs),
-      callbacks: parse_entries(module, callback_entries, callback_defs),
-      types: parse_entries(module, type_entries, type_defs)
-    }
+      %__MODULE__{
+        module: module,
+        doc: Entry.parse_doc(module_doc),
+        functions_and_macros: parse_entries(module, function_entries ++ macro_entries, spec_defs),
+        callbacks: parse_entries(module, callback_entries, callback_defs),
+        types: parse_entries(module, type_entries, type_defs)
+      }
+    end
   end
 
   defp doc_kind({{kind, _name, _arity}, _anno, _sig, _doc, _meta}) do
@@ -54,8 +57,8 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Docs do
     defs_by_name_arity =
       Enum.group_by(
         defs,
-        fn {name, arity, _formatted} -> {name, arity} end,
-        fn {_name, _arity, formatted} -> formatted end
+        fn {name, arity, _formatted, _quoted} -> {name, arity} end,
+        fn {_name, _arity, formatted, _quoted} -> formatted end
       )
 
     raw_entries
@@ -67,79 +70,6 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Docs do
     |> Enum.group_by(& &1.name)
   end
 
-  defp ensure_ready(module) do
-    with {:module, _} <- Code.ensure_compiled(module),
-         path when is_list(path) and path != [] <- :code.which(module) do
-      ensure_file_exists(path)
-    else
-      _ -> {:error, :not_found}
-    end
-  end
-
-  @timeout 10
-  defp ensure_file_exists(path, attempts \\ 10)
-
-  defp ensure_file_exists(_, 0) do
-    {:error, :beam_file_timeout}
-  end
-
-  defp ensure_file_exists(path, attempts) do
-    if File.exists?(path) do
-      :ok
-    else
-      Process.sleep(@timeout)
-      ensure_file_exists(path, attempts - 1)
-    end
-  end
-
-  defp get_spec_defs(module) do
-    case Code.Typespec.fetch_specs(module) do
-      {:ok, specs} ->
-        for {{name, arity}, defs} <- specs,
-            def <- defs do
-          formatted = name |> Code.Typespec.spec_to_quoted(def) |> format_def()
-          {name, arity, formatted}
-        end
-
-      _ ->
-        []
-    end
-  end
-
-  defp get_callback_defs(module) do
-    case Code.Typespec.fetch_callbacks(module) do
-      {:ok, callbacks} ->
-        for {{name, arity}, defs} <- callbacks,
-            def <- defs do
-          formatted = name |> Code.Typespec.spec_to_quoted(def) |> format_def()
-          {name, arity, formatted}
-        end
-
-      _ ->
-        []
-    end
-  end
-
-  defp get_type_defs(module) do
-    case Code.Typespec.fetch_types(module) do
-      {:ok, types} ->
-        for {kind, {name, _body, args} = type} <- types do
-          arity = length(args)
-          quoted_type = Code.Typespec.type_to_quoted(type)
-          quoted = {:@, [], [{kind, [], [quoted_type]}]}
-
-          {name, arity, format_def(quoted)}
-        end
-
-      _ ->
-        []
-    end
-  end
-
-  defp format_def(quoted) do
-    quoted
-    |> Future.Code.quoted_to_algebra()
-    |> Inspect.Algebra.format(60)
-    |> IO.iodata_to_binary()
-  end
+  defp ok_or({:ok, value}, _default), do: value
+  defp ok_or(_, default), do: default
 end

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/docs.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/docs.ex
@@ -65,7 +65,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Docs do
     |> Enum.map(fn raw_entry ->
       entry = Entry.from_docs_v1(module, raw_entry)
       defs = Map.get(defs_by_name_arity, {entry.name, entry.arity}, [])
-      Map.replace!(entry, :defs, defs)
+      %Entry{entry | defs: defs}
     end)
     |> Enum.group_by(& &1.name)
   end

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/docs.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/docs.ex
@@ -140,5 +140,6 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Docs do
     quoted
     |> Future.Code.quoted_to_algebra()
     |> Inspect.Algebra.format(60)
+    |> IO.iodata_to_binary()
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/docs/entry.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/docs/entry.ex
@@ -10,7 +10,8 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Docs.Entry do
     :arity,
     :signature,
     :doc,
-    :metadata
+    :metadata,
+    defs: []
     # :spec
   ]
 
@@ -21,7 +22,8 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Docs.Entry do
           arity: arity(),
           signature: [String.t()],
           doc: content(),
-          metadata: metadata()
+          metadata: metadata(),
+          defs: [String.t()]
           # spec: String.t() | nil
         }
 

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/docs/entry.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/docs/entry.ex
@@ -12,7 +12,6 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Docs.Entry do
     :doc,
     :metadata,
     defs: []
-    # :spec
   ]
 
   @type t(kind) :: %__MODULE__{
@@ -24,7 +23,6 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Docs.Entry do
           doc: content(),
           metadata: metadata(),
           defs: [String.t()]
-          # spec: String.t() | nil
         }
 
   @type content :: String.t() | :none | :hidden

--- a/apps/remote_control/lib/lexical/remote_control/code_mod/replace_with_underscore.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_mod/replace_with_underscore.ex
@@ -2,6 +2,7 @@ defmodule Lexical.RemoteControl.CodeMod.ReplaceWithUnderscore do
   alias Lexical.Ast
   alias Lexical.Document
   alias Lexical.Document.Changes
+  alias Sourceror.Zipper
 
   @spec edits(Document.t(), non_neg_integer(), String.t() | atom) ::
           {:ok, Changes.t()} | :error
@@ -30,7 +31,7 @@ defmodule Lexical.RemoteControl.CodeMod.ReplaceWithUnderscore do
 
     result =
       Ast.traverse_line(document, line_number, [], fn
-        {{^unused_variable_name, _meta, nil} = node, _} = zipper, patches ->
+        %Zipper{node: {^unused_variable_name, _meta, nil} = node} = zipper, patches ->
           [patch] = Sourceror.Patch.rename_identifier(node, underscored_variable_name)
           {zipper, [patch | patches]}
 

--- a/apps/remote_control/lib/lexical/remote_control/modules.ex
+++ b/apps/remote_control/lib/lexical/remote_control/modules.ex
@@ -1,8 +1,4 @@
 defmodule Lexical.RemoteControl.Modules do
-  @moduledoc """
-  Utilities for dealing with modules on the remote control node
-  """
-
   defmodule Predicate.Syntax do
     @moduledoc """
     Syntax helpers for the predicate syntax
@@ -47,6 +43,12 @@ defmodule Lexical.RemoteControl.Modules do
       end)
     end
   end
+
+  @moduledoc """
+  Utilities for dealing with modules on the remote control node
+  """
+
+  alias Future.Code.Typespec
 
   @typedoc "Module documentation record as defined by EEP-48"
   @type docs_v1 :: tuple()
@@ -99,12 +101,12 @@ defmodule Lexical.RemoteControl.Modules do
   """
   @spec fetch_specs(beam :: binary()) :: {:ok, [definition()]} | :error
   def fetch_specs(beam) when is_binary(beam) do
-    case Code.Typespec.fetch_specs(beam) do
+    case Typespec.fetch_specs(beam) do
       {:ok, specs} ->
         defs =
           for {{name, arity}, defs} <- specs,
               def <- defs do
-            quoted = Code.Typespec.spec_to_quoted(name, def)
+            quoted = Typespec.spec_to_quoted(name, def)
             formatted = format_definition(quoted)
 
             {name, arity, formatted, quoted}
@@ -122,12 +124,12 @@ defmodule Lexical.RemoteControl.Modules do
   """
   @spec fetch_types(beam :: binary()) :: {:ok, [definition()]} | :error
   def fetch_types(beam) when is_binary(beam) do
-    case Code.Typespec.fetch_types(beam) do
+    case Typespec.fetch_types(beam) do
       {:ok, types} ->
         defs =
           for {kind, {name, _body, args} = type} <- types do
             arity = length(args)
-            quoted_type = Code.Typespec.type_to_quoted(type)
+            quoted_type = Typespec.type_to_quoted(type)
             quoted = {:@, [], [{kind, [], [quoted_type]}]}
             formatted = format_definition(quoted)
 
@@ -146,12 +148,12 @@ defmodule Lexical.RemoteControl.Modules do
   """
   @spec fetch_callbacks(beam :: binary()) :: {:ok, [definition()]} | :error
   def fetch_callbacks(beam) when is_binary(beam) do
-    case Code.Typespec.fetch_callbacks(beam) do
+    case Typespec.fetch_callbacks(beam) do
       {:ok, callbacks} ->
         defs =
           for {{name, arity}, defs} <- callbacks,
               def <- defs do
-            quoted = Code.Typespec.spec_to_quoted(name, def)
+            quoted = Typespec.spec_to_quoted(name, def)
             formatted = format_definition(quoted)
 
             {name, arity, formatted, quoted}

--- a/apps/remote_control/lib/lexical/remote_control/modules.ex
+++ b/apps/remote_control/lib/lexical/remote_control/modules.ex
@@ -151,7 +151,7 @@ defmodule Lexical.RemoteControl.Modules do
         defs =
           for {{name, arity}, defs} <- callbacks,
               def <- defs do
-            quoted = Code.Typespec.type_to_quoted(def)
+            quoted = Code.Typespec.spec_to_quoted(name, def)
             formatted = format_definition(quoted)
 
             {name, arity, formatted, quoted}

--- a/apps/remote_control/mix.exs
+++ b/apps/remote_control/mix.exs
@@ -41,7 +41,7 @@ defmodule Lexical.RemoteControl.MixProject do
       {:lexical_test, path: "../../projects/lexical_test", only: :test},
       {:patch, "~> 0.12", only: [:dev, :test], optional: true, runtime: false},
       {:path_glob, "~> 0.2", optional: true},
-      {:sourceror, github: "doorgan/sourceror", ref: "eaf0cc6"}
+      {:sourceror, github: "doorgan/sourceror", ref: "b0ec3cc"}
     ]
   end
 

--- a/apps/remote_control/mix.exs
+++ b/apps/remote_control/mix.exs
@@ -41,7 +41,7 @@ defmodule Lexical.RemoteControl.MixProject do
       {:lexical_test, path: "../../projects/lexical_test", only: :test},
       {:patch, "~> 0.12", only: [:dev, :test], optional: true, runtime: false},
       {:path_glob, "~> 0.2", optional: true},
-      {:sourceror, github: "doorgan/sourceror", ref: "b0ec3cc"}
+      {:sourceror, "~> 0.14.0"}
     ]
   end
 

--- a/apps/remote_control/mix.exs
+++ b/apps/remote_control/mix.exs
@@ -41,7 +41,7 @@ defmodule Lexical.RemoteControl.MixProject do
       {:lexical_test, path: "../../projects/lexical_test", only: :test},
       {:patch, "~> 0.12", only: [:dev, :test], optional: true, runtime: false},
       {:path_glob, "~> 0.2", optional: true},
-      {:sourceror, "~> 0.12"}
+      {:sourceror, github: "zachallaun/sourceror", ref: "nil-get-range"}
     ]
   end
 

--- a/apps/remote_control/mix.exs
+++ b/apps/remote_control/mix.exs
@@ -41,7 +41,7 @@ defmodule Lexical.RemoteControl.MixProject do
       {:lexical_test, path: "../../projects/lexical_test", only: :test},
       {:patch, "~> 0.12", only: [:dev, :test], optional: true, runtime: false},
       {:path_glob, "~> 0.2", optional: true},
-      {:sourceror, github: "zachallaun/sourceror", ref: "nil-get-range"}
+      {:sourceror, github: "doorgan/sourceror", ref: "eaf0cc6"}
     ]
   end
 

--- a/apps/remote_control/test/lexical/remote_control/completion_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/completion_test.exs
@@ -4,7 +4,6 @@ defmodule Lexical.RemoteControl.CompletionTest do
 
   import Lexical.Test.CursorSupport
   import Lexical.Test.CodeSigil
-  import Lexical.Test.PositionSupport
 
   use ExUnit.Case, async: true
 
@@ -86,23 +85,9 @@ defmodule Lexical.RemoteControl.CompletionTest do
     end
   end
 
-  defp document(source) do
-    text = strip_cursor(source)
-    Document.new(file_uri(), text, 1)
-  end
-
-  defp file_uri do
-    "file:///elixir.ex"
-  end
-
-  defp position(source) do
-    {line, column} = cursor_position(source)
-    position(line, column)
-  end
-
   defp struct_fields(source) do
-    document = document(source)
-    position = position(source)
+    {position, document} = pop_cursor(source, as: :document)
+
     text = Document.to_string(document)
     Code.compile_string(text)
 

--- a/apps/server/lib/lexical/server/code_intelligence/entity.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/entity.ex
@@ -9,7 +9,7 @@ defmodule Lexical.Server.CodeIntelligence.Entity do
   alias Lexical.RemoteControl
   alias Lexical.Text
 
-  import Ast, only: [is_call: 2]
+  import Ast, only: [is_call: 1]
 
   require Logger
 
@@ -155,15 +155,14 @@ defmodule Lexical.Server.CodeIntelligence.Entity do
 
   # Calls inside of a pipe:
   # |> MyModule.some_function(1, 2)
-  defp arity_at_position([{call, _, args}, {:|>, _, _} | _], _position)
-       when is_call(call, args) do
+  defp arity_at_position([{_, _, args} = call, {:|>, _, _} | _], _position) when is_call(call) do
     length(args) + 1
   end
 
   # Calls not inside of a pipe:
   # MyModule.some_function(1, 2)
   # some_function.(1, 2)
-  defp arity_at_position([{call, _, args} | _], _position) when is_call(call, args) do
+  defp arity_at_position([{_, _, args} = call | _], _position) when is_call(call) do
     length(args)
   end
 

--- a/apps/server/lib/lexical/server/code_intelligence/entity.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/entity.ex
@@ -9,6 +9,8 @@ defmodule Lexical.Server.CodeIntelligence.Entity do
   alias Lexical.RemoteControl
   alias Lexical.Text
 
+  import Ast, only: [is_call: 2]
+
   require Logger
 
   @type resolved ::
@@ -162,7 +164,7 @@ defmodule Lexical.Server.CodeIntelligence.Entity do
 
   # Local calls:
   # fun(1, 2, 3)
-  defp arity_at_position({atom, _, args}, _position) when is_atom(atom) and is_list(args) do
+  defp arity_at_position({call, _, args}, _position) when is_call(call, args) do
     length(args)
   end
 

--- a/apps/server/lib/lexical/server/code_intelligence/entity.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/entity.ex
@@ -9,15 +9,16 @@ defmodule Lexical.Server.CodeIntelligence.Entity do
   alias Lexical.RemoteControl
   alias Lexical.Text
 
-  import Ast, only: [is_call: 1]
-
   require Logger
+  require Sourceror.Identifier
 
   @type resolved ::
           {:module, module()}
           | {:struct, module()}
           | {:call, module(), fun_name :: atom(), arity :: non_neg_integer()}
           | {:type, module(), type_name :: atom(), arity :: non_neg_integer()}
+
+  defguardp is_call(form) when Sourceror.Identifier.is_call(form) and elem(form, 0) != :.
 
   @doc """
   Attempts to resolve the entity at the given position in the document.

--- a/apps/server/lib/lexical/server/code_intelligence/entity.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/entity.ex
@@ -148,8 +148,11 @@ defmodule Lexical.Server.CodeIntelligence.Entity do
     {_call, _, args} =
       pipe
       |> Macro.unpipe()
-      |> Stream.map(fn {ast, _arg_position} -> ast end)
-      |> Enum.find(&Ast.contains_position?(&1, position))
+      |> Enum.find_value(fn {ast, _arg_position} ->
+        if Ast.contains_position?(ast, position) do
+          ast
+        end
+      end)
 
     length(args) + 1
   end

--- a/apps/server/lib/lexical/server/provider/handlers/hover.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/hover.ex
@@ -5,6 +5,7 @@ defmodule Lexical.Server.Provider.Handlers.Hover do
   alias Lexical.Protocol.Types.Hover
   alias Lexical.Protocol.Types.Markup
   alias Lexical.RemoteControl
+  alias Lexical.RemoteControl.CodeIntelligence.Docs
   alias Lexical.Server.CodeIntelligence.Entity
   alias Lexical.Server.Provider.Env
 
@@ -13,7 +14,8 @@ defmodule Lexical.Server.Provider.Handlers.Hover do
   def handle(%Requests.Hover{} = request, %Env{} = env) do
     maybe_hover =
       with {:ok, entity, _elixir_range} <- Entity.resolve(request.document, request.position),
-           {:ok, content} <- hover_content(entity, env) do
+           {:ok, sections} <- hover_content(entity, env) do
+        content = Enum.join(sections, "\n---\n\n")
         %Hover{contents: %Markup.Content{kind: :markdown, value: content}}
       else
         error ->
@@ -24,21 +26,59 @@ defmodule Lexical.Server.Provider.Handlers.Hover do
     {:reply, Responses.Hover.new(request.id, maybe_hover)}
   end
 
-  defp hover_content({:module, module}, env) do
+  defp hover_content({kind, module}, env) when kind in [:module, :struct] do
     with {:ok, module_docs} <- RemoteControl.Api.docs(env.project, module) do
       doc_content = module_doc_content(module_docs.doc)
+      defs_content = module_defs_content(kind, module_docs)
+      header_content = format_header(kind, module_docs)
 
-      content = """
-      ### #{Ast.Module.name(module)}
+      sections =
+        [
+          """
+          ```elixir
+          #{header_content}
+          ```
+          """,
+          defs_content,
+          doc_content
+        ]
+        |> Enum.filter(&Function.identity/1)
 
-      #{doc_content}\
-      """
-
-      {:ok, content}
+      {:ok, sections}
     end
+  end
+
+  defp format_header(:module, %Docs{module: module}) do
+    Ast.Module.name(module)
+  end
+
+  defp format_header(:struct, %Docs{module: module}) do
+    "%#{Ast.Module.name(module)}{}"
   end
 
   defp module_doc_content(s) when is_binary(s), do: s
   defp module_doc_content(:none), do: "*This module is undocumented.*\n"
   defp module_doc_content(:hidden), do: "*This module is private.*\n"
+
+  defp module_defs_content(:module, _), do: nil
+
+  defp module_defs_content(:struct, docs) do
+    defs =
+      for entry <- Map.get(docs.types, :t, []),
+          def <- entry.defs do
+        {entry.arity, def}
+      end
+      |> Enum.sort_by(&elem(&1, 0))
+      |> Enum.map(&elem(&1, 1))
+
+    if defs != [] do
+      """
+      #### Struct
+
+      ```elixir
+      #{Enum.join(defs, "\n")}
+      ```
+      """
+    end
+  end
 end

--- a/apps/server/lib/lexical/server/provider/handlers/hover.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/hover.ex
@@ -13,14 +13,14 @@ defmodule Lexical.Server.Provider.Handlers.Hover do
 
   def handle(%Requests.Hover{} = request, %Env{} = env) do
     maybe_hover =
-      with {:ok, entity, _elixir_range} <- Entity.resolve(request.document, request.position),
+      with {:ok, entity, range} <- Entity.resolve(request.document, request.position),
            {:ok, sections} <- hover_content(entity, env) do
         content =
           sections
           |> Markdown.join_sections()
           |> Markdown.to_content()
 
-        %Hover{contents: content}
+        %Hover{contents: content, range: range}
       else
         error ->
           Logger.warning("Could not resolve hover request, got: #{inspect(error)}")

--- a/apps/server/lib/lexical/server/provider/handlers/hover.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/hover.ex
@@ -27,13 +27,13 @@ defmodule Lexical.Server.Provider.Handlers.Hover do
   end
 
   defp hover_content({kind, module}, env) when kind in [:module, :struct] do
-    case RemoteControl.Api.docs(env.project, module) do
-      {:ok, %Docs{doc: doc} = module_docs} when doc != :hidden ->
+    case RemoteControl.Api.docs(env.project, module, exclude_hidden: false) do
+      {:ok, %Docs{} = module_docs} ->
         header = module_header(kind, module_docs)
         types = module_header_types(kind, module_docs)
 
         additional_sections = [
-          module_doc(doc),
+          module_doc(module_docs.doc),
           module_footer(kind, module_docs)
         ]
 
@@ -58,7 +58,7 @@ defmodule Lexical.Server.Provider.Handlers.Hover do
         |> Enum.filter(&(&1.arity >= arity))
         |> Enum.map(&entry_content/1)
 
-      {:ok, Markdown.join_sections(sections, "\n\n---\n\n")}
+      {:ok, Markdown.join_sections(sections, Markdown.separator())}
     end
   end
 

--- a/apps/server/lib/lexical/server/provider/markdown.ex
+++ b/apps/server/lib/lexical/server/provider/markdown.ex
@@ -44,7 +44,7 @@ defmodule Lexical.Server.Provider.Markdown do
     * `:header_level` - Defaults to `4`.
 
   """
-  @spec section([markdown], [opt]) :: markdown
+  @spec section(markdown, [opt]) :: markdown
         when opt: {:header, markdown} | {:header_level, pos_integer()}
   def section(content, opts) do
     header = Keyword.fetch!(opts, :header)

--- a/apps/server/lib/lexical/server/provider/markdown.ex
+++ b/apps/server/lib/lexical/server/provider/markdown.ex
@@ -1,0 +1,73 @@
+defmodule Lexical.Server.Provider.Markdown do
+  @moduledoc """
+  Utilities for formatting Markdown content.
+  """
+
+  alias Lexical.Protocol.Types.Markup
+
+  @type markdown :: String.t()
+
+  @doc """
+  Converts a string of Markdown into LSP markup content.
+  """
+  @spec to_content(markdown) :: Markup.Content.t()
+  def to_content(markdown) when is_binary(markdown) do
+    %Markup.Content{kind: :markdown, value: markdown}
+  end
+
+  @doc """
+  Wraps the content inside a Markdown code block.
+
+  ## Options
+
+    * `:lang` - The language for the block. Defaults to `"elixir"`.
+
+  """
+  @spec code_block(String.t(), [opt]) :: markdown
+        when opt: {:lang, String.t()}
+  def code_block(content, opts \\ []) do
+    lang = Keyword.get(opts, :lang, "elixir")
+
+    """
+    ```#{lang}
+    #{content}
+    ```
+    """
+  end
+
+  @doc """
+  Creates a Markdown section with a header.
+
+  ## Options
+
+    * `:header` (required) - The section title.
+    * `:header_level` - Defaults to `4`.
+
+  """
+  @spec section([markdown], [opt]) :: markdown
+        when opt: {:header, markdown} | {:header_level, pos_integer()}
+  def section(content, opts) do
+    header = Keyword.fetch!(opts, :header)
+    header_level = Keyword.get(opts, :header_level, 4)
+
+    """
+    #{String.duplicate("#", header_level)} #{header}
+
+    #{content}
+    """
+  end
+
+  @doc """
+  Joins multiple Markdown sections with a horizontal rule.
+  """
+  @spec join_sections([markdown | nil]) :: markdown
+  def join_sections(sections) when is_list(sections) do
+    with_rules =
+      sections
+      |> Stream.filter(&(is_binary(&1) and &1 != ""))
+      |> Stream.map(&String.trim(&1))
+      |> Enum.intersperse("\n\n---\n\n")
+
+    IO.iodata_to_binary([with_rules, "\n"])
+  end
+end

--- a/apps/server/lib/lexical/server/provider/markdown.ex
+++ b/apps/server/lib/lexical/server/provider/markdown.ex
@@ -41,14 +41,14 @@ defmodule Lexical.Server.Provider.Markdown do
   ## Options
 
     * `:header` (required) - The section title.
-    * `:header_level` - Defaults to `4`.
+    * `:header_level` - Defaults to `2`.
 
   """
   @spec section(markdown, [opt]) :: markdown
         when opt: {:header, markdown} | {:header_level, pos_integer()}
   def section(content, opts) do
     header = Keyword.fetch!(opts, :header)
-    header_level = Keyword.get(opts, :header_level, 4)
+    header_level = Keyword.get(opts, :header_level, 2)
 
     """
     #{String.duplicate("#", header_level)} #{header}
@@ -58,18 +58,18 @@ defmodule Lexical.Server.Provider.Markdown do
   end
 
   @doc """
-  Joins multiple Markdown sections with a horizontal rule.
+  Joins multiple Markdown sections.
   """
   @spec join_sections([markdown | nil]) :: markdown
-  def join_sections(sections) when is_list(sections) do
+  def join_sections(sections, joiner \\ "\n\n") when is_list(sections) do
     with_rules =
       sections
       |> Stream.filter(&(is_binary(&1) and &1 != ""))
       |> Stream.map(&String.trim(&1))
-      |> Enum.intersperse("\n\n---\n\n")
+      |> Enum.intersperse(joiner)
 
     case with_rules do
-      [] -> nil
+      [] -> ""
       _ -> IO.iodata_to_binary([with_rules, "\n"])
     end
   end

--- a/apps/server/lib/lexical/server/provider/markdown.ex
+++ b/apps/server/lib/lexical/server/provider/markdown.ex
@@ -73,4 +73,12 @@ defmodule Lexical.Server.Provider.Markdown do
       _ -> IO.iodata_to_binary([with_rules, "\n"])
     end
   end
+
+  @doc """
+  Returns a string that can be used to join sections with a horizontal rule.
+  """
+  @spec separator() :: markdown
+  def separator do
+    "\n\n---\n\n"
+  end
 end

--- a/apps/server/lib/lexical/server/provider/markdown.ex
+++ b/apps/server/lib/lexical/server/provider/markdown.ex
@@ -30,7 +30,7 @@ defmodule Lexical.Server.Provider.Markdown do
 
     """
     ```#{lang}
-    #{content}
+    #{String.trim(content)}
     ```
     """
   end

--- a/apps/server/lib/lexical/server/provider/markdown.ex
+++ b/apps/server/lib/lexical/server/provider/markdown.ex
@@ -30,7 +30,7 @@ defmodule Lexical.Server.Provider.Markdown do
 
     """
     ```#{lang}
-    #{String.trim(content)}
+    #{content}
     ```
     """
   end
@@ -68,6 +68,9 @@ defmodule Lexical.Server.Provider.Markdown do
       |> Stream.map(&String.trim(&1))
       |> Enum.intersperse("\n\n---\n\n")
 
-    IO.iodata_to_binary([with_rules, "\n"])
+    case with_rules do
+      [] -> nil
+      _ -> IO.iodata_to_binary([with_rules, "\n"])
+    end
   end
 end

--- a/apps/server/mix.exs
+++ b/apps/server/mix.exs
@@ -41,7 +41,7 @@ defmodule Lexical.Server.MixProject do
   defp deps do
     [
       {:lexical_shared, path: "../../projects/lexical_shared", override: true},
-      {:lexical_test, path: "../../projects/lexical_test", only: :test},
+      {:lexical_test, path: "../../projects/lexical_test", only: [:dev, :test]},
       {:common, in_umbrella: true},
       {:elixir_sense, github: "elixir-lsp/elixir_sense"},
       {:jason, "~> 1.4"},

--- a/apps/server/mix.exs
+++ b/apps/server/mix.exs
@@ -50,7 +50,7 @@ defmodule Lexical.Server.MixProject do
       {:path_glob, "~> 0.2"},
       {:protocol, in_umbrella: true},
       {:remote_control, in_umbrella: true, runtime: false},
-      {:sourceror, github: "zachallaun/sourceror", ref: "nil-get-range"}
+      {:sourceror, github: "doorgan/sourceror", ref: "eaf0cc6"}
     ]
   end
 end

--- a/apps/server/mix.exs
+++ b/apps/server/mix.exs
@@ -50,7 +50,7 @@ defmodule Lexical.Server.MixProject do
       {:path_glob, "~> 0.2"},
       {:protocol, in_umbrella: true},
       {:remote_control, in_umbrella: true, runtime: false},
-      {:sourceror, github: "doorgan/sourceror", ref: "eaf0cc6"}
+      {:sourceror, github: "doorgan/sourceror", ref: "b0ec3cc"}
     ]
   end
 end

--- a/apps/server/mix.exs
+++ b/apps/server/mix.exs
@@ -50,7 +50,7 @@ defmodule Lexical.Server.MixProject do
       {:path_glob, "~> 0.2"},
       {:protocol, in_umbrella: true},
       {:remote_control, in_umbrella: true, runtime: false},
-      {:sourceror, github: "doorgan/sourceror", ref: "b0ec3cc"}
+      {:sourceror, "~> 0.14.0"}
     ]
   end
 end

--- a/apps/server/mix.exs
+++ b/apps/server/mix.exs
@@ -50,7 +50,7 @@ defmodule Lexical.Server.MixProject do
       {:path_glob, "~> 0.2"},
       {:protocol, in_umbrella: true},
       {:remote_control, in_umbrella: true, runtime: false},
-      {:sourceror, "~> 0.12"}
+      {:sourceror, github: "zachallaun/sourceror", ref: "nil-get-range"}
     ]
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion/builder_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/builder_test.exs
@@ -1,27 +1,17 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.BuilderTest do
   alias Lexical.Ast.Env
-  alias Lexical.Document
   alias Lexical.Protocol.Types.Completion.Item, as: CompletionItem
-  alias Lexical.Server.CodeIntelligence.Completion
-  alias Lexical.Test.CodeSigil
-  alias Lexical.Test.CursorSupport
-  alias Lexical.Test.Fixtures
 
   use ExUnit.Case, async: true
 
-  import CodeSigil
-  import Completion.Builder
-  import CursorSupport
-  import Fixtures
+  import Lexical.Server.CodeIntelligence.Completion.Builder
+  import Lexical.Test.CodeSigil
+  import Lexical.Test.CursorSupport
+  import Lexical.Test.Fixtures
 
   def new_env(text) do
     project = project()
-    {line, column} = cursor_position(text)
-    stripped_text = strip_cursor(text)
-    document = Document.new("file://foo.ex", stripped_text, 0)
-
-    position = Document.Position.new(document, line, column)
-
+    {position, document} = pop_cursor(text, as: :document)
     {:ok, env} = Env.new(project, document, position)
     env
   end

--- a/apps/server/test/lexical/server/code_intelligence/entity_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/entity_test.exs
@@ -71,7 +71,7 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
             MyDefinition.greet|("World")
           end
         end
-        ]
+      ]
 
       assert {:ok, ^referenced_uri, definition_line} = definition(project, subject_module)
       assert definition_line == ~S[  def «greet»(name) do]
@@ -86,7 +86,7 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
             MyDefinition|.greet("World")
           end
         end
-        ]
+      ]
 
       assert {:ok, ^referenced_uri, definition_line} = definition(project, subject_module)
       assert definition_line == ~S[defmodule «MyDefinition» do]
@@ -101,7 +101,7 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
             MyDefinition.print_hello|()
           end
         end
-        ]
+      ]
 
       assert {:ok, ^referenced_uri, definition_line} = definition(project, subject_module)
       assert definition_line == ~S[  defmacro «print_hello» do]
@@ -137,7 +137,7 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
             MultiArity.sum|(1, 2, 3)
           end
         end
-        ]
+      ]
 
       {:ok, referenced_uri, definition_line} = definition(project, subject_module)
 
@@ -158,7 +158,7 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
             greet|("World")
           end
         end
-        ]
+      ]
 
       assert {:ok, ^referenced_uri, definition_line} = definition(project, subject_module)
       assert definition_line == ~S[  def «greet»(name) do]
@@ -174,7 +174,7 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
             print_hello|()
           end
         end
-        ]
+      ]
 
       assert {:ok, ^referenced_uri, definition_line} = definition(project, subject_module)
       assert definition_line == ~S[  defmacro «print_hello» do]
@@ -193,7 +193,8 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
             greet|("World")
           end
         end
-        ]
+      ]
+
       assert {:ok, ^referenced_uri, definition_line} = definition(project, subject_module)
       assert definition_line == ~S[  def «greet»(name) do]
     end
@@ -217,7 +218,8 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
             hello_func_in_using|()
           end
         end
-        ]
+      ]
+
       assert {:ok, ^referenced_uri, definition_line} = definition(project, subject_module)
       assert definition_line == ~S[  def «hello_func_in_using» do]
     end
@@ -251,7 +253,7 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
             @|b
           end
         end
-        ]
+      ]
 
       {:ok, referenced_uri, definition_line} = definition(project, subject_module)
 
@@ -270,7 +272,7 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
             end
           end
         end
-        ]
+      ]
 
       {:ok, referenced_uri, definition_line} = definition(project, subject_module)
 
@@ -288,7 +290,7 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
          %{project: project} do
       subject_module = ~q[
         String.to_integer|("1")
-        ]
+      ]
 
       {:ok, uri, definition_line} = definition(project, subject_module)
 
@@ -299,7 +301,8 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
     test "find the definition when calling a erlang module", %{project: project} do
       subject_module = ~q[
         :erlang.binary_to_atom|("1")
-        ]
+      ]
+
       {:ok, uri, definition_line} = definition(project, subject_module)
 
       assert uri =~ "/src/erlang.erl"
@@ -344,8 +347,8 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
 
     test "resolves module segments at and before the cursor", %{project: project} do
       code = ~q[
-            In.|The.Middle
-          ]
+        In.|The.Middle
+      ]
 
       assert {:ok, {:module, In.The}, resolved_range} = resolve(project, code)
       assert resolved_range =~ ~S[«In.The».Middle]
@@ -353,8 +356,8 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
 
     test "excludes trailing module segments with the cursor is on a period", %{project: project} do
       code = ~q[
-            AAA.BBB.CCC.DDD|.EEE
-          ]
+        AAA.BBB.CCC.DDD|.EEE
+      ]
 
       assert {:ok, {:module, AAA.BBB.CCC.DDD}, resolved_range} = resolve(project, code)
       assert resolved_range =~ ~S[«AAA.BBB.CCC.DDD».EEE]
@@ -362,9 +365,9 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
 
     test "succeeds for modules within a multi-line node", %{project: project} do
       code = ~q[
-            foo =
-              On.Another.Lin|e
-          ]
+        foo =
+          On.Another.Lin|e
+      ]
 
       assert {:ok, {:module, On.Another.Line}, resolved_range} = resolve(project, code)
       assert resolved_range =~ ~S[  «On.Another.Line»]
@@ -372,10 +375,10 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
 
     test "resolves the entire module for multi-line modules", %{project: project} do
       code = ~q[
-            On.
-              |Multiple.
-              Lines
-          ]
+        On.
+          |Multiple.
+          Lines
+      ]
 
       assert {:ok, {:module, On.Multiple.Lines}, resolved_range} = resolve(project, code)
 
@@ -388,8 +391,8 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
 
     test "succeeds in single line calls", %{project: project} do
       code = ~q[
-            |Enum.map(1..10, & &1 + 1)
-          ]
+        |Enum.map(1..10, & &1 + 1)
+      ]
 
       assert {:ok, {:module, Enum}, resolved_range} = resolve(project, code)
       assert resolved_range =~ ~S[«Enum».map(1..10, & &1 + 1)]
@@ -397,10 +400,10 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
 
     test "succeeds in multi-line calls", %{project: project} do
       code = ~q[
-            |Enum.map(1..10, fn i ->
-              i + 1
-            end)
-          ]
+        |Enum.map(1..10, fn i ->
+          i + 1
+        end)
+      ]
 
       assert {:ok, {:module, Enum}, resolved_range} = resolve(project, code)
       assert resolved_range =~ ~S[«Enum».map(1..10, fn i ->]
@@ -408,11 +411,11 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
 
     test "expands top-level aliases", %{project: project} do
       code = ~q[
-            defmodule Example do
-              alias Long.Aliased.Module
-              Modul|e
-            end
-          ]
+        defmodule Example do
+          alias Long.Aliased.Module
+          Modul|e
+        end
+      ]
 
       assert {:ok, {:module, Long.Aliased.Module}, resolved_range} = resolve(project, code)
       assert resolved_range =~ ~S[  «Module»]
@@ -420,11 +423,11 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
 
     test "ignores top-level aliases made after the cursor", %{project: project} do
       code = ~q[
-            defmodule Example do
-              Modul|e
-              alias Long.Aliased.Module
-            end
-          ]
+        defmodule Example do
+          Modul|e
+          alias Long.Aliased.Module
+        end
+      ]
 
       assert {:ok, {:module, Module}, resolved_range} = resolve(project, code)
       assert resolved_range =~ ~S[  «Module»]
@@ -432,13 +435,13 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
 
     test "resolves implicit aliases", %{project: project} do
       code = ~q[
-            defmodule Example do
-              defmodule Inner do
-              end
+        defmodule Example do
+          defmodule Inner do
+          end
 
-              Inne|r
-            end
-          ]
+          Inne|r
+        end
+      ]
 
       assert {:ok, {:module, Example.Inner}, resolved_range} = resolve(project, code)
       assert resolved_range =~ ~S[  «Inner»]
@@ -446,10 +449,10 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
 
     test "expands current module", %{project: project} do
       code = ~q[
-            defmodule Example do
-              |__MODULE__
-            end
-          ]
+        defmodule Example do
+          |__MODULE__
+        end
+      ]
 
       assert {:ok, {:module, Example}, resolved_range} = resolve(project, code)
       assert resolved_range =~ ~S[  «__MODULE__»]
@@ -457,10 +460,10 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
 
     test "expands current module used in alias", %{project: project} do
       code = ~q[
-            defmodule Example do
-              |__MODULE__.Nested
-            end
-          ]
+        defmodule Example do
+          |__MODULE__.Nested
+        end
+      ]
 
       assert {:ok, {:module, Example}, resolved_range} = resolve(project, code)
       assert resolved_range =~ ~S[  «__MODULE__».Nested]
@@ -468,10 +471,10 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
 
     test "expands alias following current module", %{project: project} do
       code = ~q[
-            defmodule Example do
-              __MODULE__.|Nested
-            end
-          ]
+        defmodule Example do
+          __MODULE__.|Nested
+        end
+      ]
 
       assert {:ok, {:module, Example.Nested}, resolved_range} = resolve(project, code)
       assert resolved_range =~ ~S[  «__MODULE__.Nested»]
@@ -529,10 +532,10 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
 
     test "expands current module", %{project: project} do
       code = ~q[
-            defmodule Example do
-              %|__MODULE__{}
-            end
-          ]
+        defmodule Example do
+          %|__MODULE__{}
+        end
+      ]
 
       assert {:ok, {:struct, Example}, resolved_range} = resolve(project, code)
       assert resolved_range =~ ~S[  %«__MODULE__»{}]

--- a/apps/server/test/lexical/server/code_intelligence/entity_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/entity_test.exs
@@ -526,6 +526,17 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
       assert {:ok, {:struct, MyStruct}, resolved_range} = resolve(project, code)
       assert resolved_range =~ ~S[%«MyStruct».Nested{}]
     end
+
+    test "expands current module", %{project: project} do
+      code = ~q[
+            defmodule Example do
+              %|__MODULE__{}
+            end
+          ]
+
+      assert {:ok, {:struct, Example}, resolved_range} = resolve(project, code)
+      assert resolved_range =~ ~S[  %«__MODULE__»{}]
+    end
   end
 
   describe "call resolve/2" do

--- a/apps/server/test/lexical/server/code_intelligence/entity_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/entity_test.exs
@@ -573,15 +573,26 @@ defmodule Lexical.Server.CodeIntelligence.EntityTest do
     end
 
     test "succeeds for explicitly aliased module", %{project: project} do
-      code = ~q<
+      code = ~q[
         defmodule Example do
           alias Something.Example
           %Example.|Inner{}
         end
-      >
+      ]
 
       assert {:ok, {:struct, Something.Example.Inner}, resolved_range} = resolve(project, code)
       assert resolved_range =~ ~S[  %«Example.Inner»{}]
+    end
+
+    test "succeeds for module nested inside current module", %{project: project} do
+      code = ~q[
+        defmodule Example do
+          %__MODULE__.|Inner{}
+        end
+      ]
+
+      assert {:ok, {:struct, Example.Inner}, resolved_range} = resolve(project, code)
+      assert resolved_range =~ ~S[  %«__MODULE__.Inner»{}]
     end
   end
 

--- a/apps/server/test/lexical/server/provider/handlers/hover_test.exs
+++ b/apps/server/test/lexical/server/provider/handlers/hover_test.exs
@@ -14,6 +14,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
 
   import Lexical.Test.CodeSigil
   import Lexical.Test.CursorSupport
+  import Lexical.Test.RangeSupport
 
   require Messages
 
@@ -106,6 +107,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
         assert {:reply, %{result: %Types.Hover{} = result}} = hover(project, hovered)
         assert result.contents.kind == :markdown
         assert result.contents.value == expected
+        assert "«HoverWithDoc»" = hovered |> strip_cursor() |> decorate(result.range)
       end)
     end
 
@@ -173,6 +175,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
         assert {:reply, %{result: %Types.Hover{} = result}} = hover(project, hovered)
         assert result.contents.kind == :markdown
         assert result.contents.value == expected
+        assert "«HoverBehaviour»" = hovered |> strip_cursor() |> decorate(result.range)
       end)
     end
 
@@ -220,6 +223,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
         assert {:reply, %{result: %Types.Hover{} = result}} = hover(project, hovered)
         assert result.contents.kind == :markdown
         assert result.contents.value == expected
+        assert "%«StructWithDoc»{}" = hovered |> strip_cursor() |> decorate(result.range)
       end)
     end
 
@@ -263,6 +267,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
         assert {:reply, %{result: %Types.Hover{} = result}} = hover(project, hovered)
         assert result.contents.kind == :markdown
         assert result.contents.value == expected
+        assert "%«StructWithDoc»{}" = hovered |> strip_cursor() |> decorate(result.range)
       end)
     end
 
@@ -293,6 +298,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
         assert {:reply, %{result: %Types.Hover{} = result}} = hover(project, hovered)
         assert result.contents.kind == :markdown
         assert result.contents.value == expected
+        assert "%«StructWithDoc»{}" = hovered |> strip_cursor() |> decorate(result.range)
       end)
     end
   end
@@ -333,6 +339,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
         assert {:reply, %{result: %Types.Hover{} = result}} = hover(project, hovered)
         assert result.contents.kind == :markdown
         assert result.contents.value == expected
+        assert "«CallHover.my_fun»(1, 2)" = hovered |> strip_cursor() |> decorate(result.range)
       end)
     end
 
@@ -366,6 +373,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
         assert {:reply, %{result: %Types.Hover{} = result}} = hover(project, hovered)
         assert result.contents.kind == :markdown
         assert result.contents.value == expected
+        assert "«CallHover.my_fun»(1, 2)" = hovered |> strip_cursor() |> decorate(result.range)
       end)
     end
 
@@ -417,6 +425,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
         assert {:reply, %{result: %Types.Hover{} = result}} = hover(project, hovered)
         assert result.contents.kind == :markdown
         assert result.contents.value == expected
+        assert "«CallHover.my_fun»(1, 2)" = hovered |> strip_cursor() |> decorate(result.range)
       end)
     end
 
@@ -459,6 +468,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
         assert {:reply, %{result: %Types.Hover{} = result}} = hover(project, hovered)
         assert result.contents.kind == :markdown
         assert result.contents.value == expected
+        assert "«CallHover.my_fun»(1)" = hovered |> strip_cursor() |> decorate(result.range)
       end)
     end
   end

--- a/apps/server/test/lexical/server/provider/handlers/hover_test.exs
+++ b/apps/server/test/lexical/server/provider/handlers/hover_test.exs
@@ -97,8 +97,6 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
       HoverWithDoc
       ```
 
-      ---
-
       This module has a moduledoc.
       """
 
@@ -156,13 +154,9 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
       HoverBehaviour
       ```
 
-      ---
-
       This is a custom behaviour.
 
-      ---
-
-      #### Callbacks
+      ## Callbacks
 
       ```elixir
       @callback bar(term()) :: {:ok, custom_type()}
@@ -209,13 +203,9 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
       HoverBehaviour
       ```
 
-      ---
-
       This is a custom behaviour.
 
-      ---
-
-      #### Callbacks
+      ## Callbacks
 
       ```elixir
       @callback bar(term()) :: {:ok, custom_type()}
@@ -263,21 +253,13 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
       expected = """
       ```elixir
       %StructWithDoc{}
-      ```
 
-      ---
-
-      #### Struct
-
-      ```elixir
       @type t() :: %StructWithDoc{
               bar: integer(),
               baz: {boolean(), reference()},
               foo: String.t()
             }
       ```
-
-      ---
 
       This module has a moduledoc.
       """
@@ -309,21 +291,13 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
       expected = """
       ```elixir
       %StructWithDoc{}
-      ```
 
-      ---
-
-      #### Struct
-
-      ```elixir
       @type t() :: %StructWithDoc{foo: String.t()}
 
       @type t(kind) :: %StructWithDoc{foo: kind}
 
       @type t(kind1, kind2) :: %StructWithDoc{foo: {kind1, kind2}}
       ```
-
-      ---
 
       This module has a moduledoc.
       """
@@ -354,8 +328,6 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
       %StructWithDoc{}
       ```
 
-      ---
-
       This module has a moduledoc.
       """
 
@@ -385,17 +357,9 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
       expected = """
       ```elixir
       CallHover.my_fun(x, y)
-      ```
 
-      ---
-
-      #### Specs
-
-      ```elixir
       @spec my_fun(integer(), integer()) :: integer()
       ```
-
-      ---
 
       This function has docs.
       """
@@ -422,13 +386,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
       expected = """
       ```elixir
       CallHover.my_fun(x, y)
-      ```
 
-      ---
-
-      #### Specs
-
-      ```elixir
       @spec my_fun(integer(), integer()) :: integer()
       @spec my_fun(float(), float()) :: float()
       ```
@@ -461,13 +419,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
       expected = """
       ```elixir
       CallHover.my_fun(x, y)
-      ```
 
-      ---
-
-      #### Specs
-
-      ```elixir
       @spec my_fun(integer(), integer()) :: integer()
       ```
 
@@ -475,13 +427,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
 
       ```elixir
       CallHover.my_fun(x, y, z)
-      ```
 
-      ---
-
-      #### Specs
-
-      ```elixir
       @spec my_fun(integer(), integer(), integer()) :: integer()
       ```
       """
@@ -508,8 +454,6 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
       ```elixir
       CallHover.my_fun(x)
       ```
-
-      ---
 
       Function doc
       """
@@ -582,8 +526,6 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
       (macro) MacroHover.my_macro(expr)
       ```
 
-      ---
-
       This is a macro.
       """
 
@@ -615,8 +557,6 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
 
       @type my_type() :: integer()
       ```
-
-      ---
 
       This type has docs.
       """

--- a/apps/server/test/lexical/server/provider/handlers/hover_test.exs
+++ b/apps/server/test/lexical/server/provider/handlers/hover_test.exs
@@ -19,7 +19,6 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
   require Messages
 
   use ExUnit.Case, async: false
-  use Lexical.Test.PositionSupport
 
   setup_all do
     project = Fixtures.project()
@@ -730,16 +729,11 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
   end
 
   defp hover(project, hovered) do
-    with {position, hovered} <- pop_position(hovered),
+    with {position, hovered} <- pop_cursor(hovered),
          {:ok, document} <- document_with_content(project, hovered),
          {:ok, request} <- hover_request(document.uri, position) do
       Handlers.Hover.handle(request, %Env{project: project})
     end
-  end
-
-  defp pop_position(code) do
-    {line, character} = cursor_position(code)
-    {position(line, character), strip_cursor(code)}
   end
 
   defp document_with_content(project, content) do

--- a/apps/server/test/lexical/server/provider/handlers/hover_test.exs
+++ b/apps/server/test/lexical/server/provider/handlers/hover_test.exs
@@ -113,15 +113,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
           end
         ],
         hovered: "|HoverPrivate",
-        expected: """
-        ```elixir
-        HoverPrivate
-        ```
-
-        ---
-
-        *This module is private.*
-        """
+        expected: nil
       )
     end
 
@@ -133,15 +125,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
           end
         ],
         hovered: "|HoverNoDocs",
-        expected: """
-        ```elixir
-        HoverNoDocs
-        ```
-
-        ---
-
-        *This module is undocumented.*
-        """
+        expected: nil
       )
     end
 
@@ -313,7 +297,7 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
       )
     end
 
-    test "public fun with multiple arities", %{project: project} do
+    test "public fun with multiple arities and @spec", %{project: project} do
       assert_hover(
         project,
         code: ~q[
@@ -363,12 +347,16 @@ defmodule Lexical.Server.Provider.Handlers.HoverTest do
   defp assert_hover(project, opts) do
     code = Keyword.fetch!(opts, :code)
     hovered = Keyword.fetch!(opts, :hovered)
-    expected_markdown = Keyword.fetch!(opts, :expected)
+    expected = Keyword.fetch!(opts, :expected)
 
     with_compiled_in(project, code, fn ->
-      assert {:reply, %{result: %Types.Hover{} = result}} = hover(project, hovered)
-      assert result.contents.kind == :markdown
-      assert result.contents.value == expected_markdown
+      if expected do
+        assert {:reply, %{result: %Types.Hover{} = result}} = hover(project, hovered)
+        assert result.contents.kind == :markdown
+        assert result.contents.value == expected
+      else
+        assert {:reply, %{result: nil}} = hover(project, hovered)
+      end
     end)
   end
 

--- a/apps/server/test/support/lexical/test/completion_case.ex
+++ b/apps/server/test/support/lexical/test/completion_case.ex
@@ -41,10 +41,6 @@ defmodule Lexical.Test.Server.CompletionCase do
 
   def complete(project, text, opts \\ []) do
     trigger_character = Keyword.get(opts, :trigger_character)
-    {line, column} = cursor_position(text)
-
-    text = strip_cursor(text)
-
     root_path = Project.root_path(project)
 
     file_path =
@@ -61,12 +57,7 @@ defmodule Lexical.Test.Server.CompletionCase do
           Path.join([root_path, "lib", "file.ex"])
       end
 
-    document =
-      file_path
-      |> Document.Path.ensure_uri()
-      |> Document.new(text, 0)
-
-    position = %Document.Position{line: line, character: column}
+    {position, document} = pop_cursor(text, document: file_path)
 
     context =
       if is_binary(trigger_character) do

--- a/mix.lock
+++ b/mix.lock
@@ -15,6 +15,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "patch": {:hex, :patch, "0.12.0", "2da8967d382bade20344a3e89d618bfba563b12d4ac93955468e830777f816b0", [:mix], [], "hexpm", "ffd0e9a7f2ad5054f37af84067ee88b1ad337308a1cb227e181e3967127b0235"},
   "path_glob": {:hex, :path_glob, "0.2.0", "b9e34b5045cac5ecb76ef1aa55281a52bf603bf7009002085de40958064ca312", [:mix], [{:nimble_parsec, "~> 1.2.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "be2594cb4553169a1a189f95193d910115f64f15f0d689454bb4e8cfae2e7ebc"},
-  "sourceror": {:git, "https://github.com/doorgan/sourceror.git", "b0ec3cc25b8f3568544e7f196ca6cb74d69d3e26", [ref: "b0ec3cc"]},
+  "sourceror": {:hex, :sourceror, "0.14.0", "b6b8552d0240400d66b6f107c1bab7ac1726e998efc797f178b7b517e928e314", [:mix], [], "hexpm", "809c71270ad48092d40bbe251a133e49ae229433ce103f762a2373b7a10a8d8b"},
   "stream_data": {:hex, :stream_data, "0.6.0", "e87a9a79d7ec23d10ff83eb025141ef4915eeb09d4491f79e52f2562b73e5f47", [:mix], [], "hexpm", "b92b5031b650ca480ced047578f1d57ea6dd563f5b57464ad274718c9c29501c"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -15,6 +15,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "patch": {:hex, :patch, "0.12.0", "2da8967d382bade20344a3e89d618bfba563b12d4ac93955468e830777f816b0", [:mix], [], "hexpm", "ffd0e9a7f2ad5054f37af84067ee88b1ad337308a1cb227e181e3967127b0235"},
   "path_glob": {:hex, :path_glob, "0.2.0", "b9e34b5045cac5ecb76ef1aa55281a52bf603bf7009002085de40958064ca312", [:mix], [{:nimble_parsec, "~> 1.2.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "be2594cb4553169a1a189f95193d910115f64f15f0d689454bb4e8cfae2e7ebc"},
-  "sourceror": {:git, "https://github.com/zachallaun/sourceror.git", "cf45de306b46f5991d445ac57e038cf256018262", [ref: "nil-get-range"]},
+  "sourceror": {:git, "https://github.com/doorgan/sourceror.git", "eaf0cc61bf7ff71a41c902339e3936d1656eae01", [ref: "eaf0cc6"]},
   "stream_data": {:hex, :stream_data, "0.6.0", "e87a9a79d7ec23d10ff83eb025141ef4915eeb09d4491f79e52f2562b73e5f47", [:mix], [], "hexpm", "b92b5031b650ca480ced047578f1d57ea6dd563f5b57464ad274718c9c29501c"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -15,6 +15,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "patch": {:hex, :patch, "0.12.0", "2da8967d382bade20344a3e89d618bfba563b12d4ac93955468e830777f816b0", [:mix], [], "hexpm", "ffd0e9a7f2ad5054f37af84067ee88b1ad337308a1cb227e181e3967127b0235"},
   "path_glob": {:hex, :path_glob, "0.2.0", "b9e34b5045cac5ecb76ef1aa55281a52bf603bf7009002085de40958064ca312", [:mix], [{:nimble_parsec, "~> 1.2.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "be2594cb4553169a1a189f95193d910115f64f15f0d689454bb4e8cfae2e7ebc"},
-  "sourceror": {:git, "https://github.com/doorgan/sourceror.git", "eaf0cc61bf7ff71a41c902339e3936d1656eae01", [ref: "eaf0cc6"]},
+  "sourceror": {:git, "https://github.com/doorgan/sourceror.git", "b0ec3cc25b8f3568544e7f196ca6cb74d69d3e26", [ref: "b0ec3cc"]},
   "stream_data": {:hex, :stream_data, "0.6.0", "e87a9a79d7ec23d10ff83eb025141ef4915eeb09d4491f79e52f2562b73e5f47", [:mix], [], "hexpm", "b92b5031b650ca480ced047578f1d57ea6dd563f5b57464ad274718c9c29501c"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -15,6 +15,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "patch": {:hex, :patch, "0.12.0", "2da8967d382bade20344a3e89d618bfba563b12d4ac93955468e830777f816b0", [:mix], [], "hexpm", "ffd0e9a7f2ad5054f37af84067ee88b1ad337308a1cb227e181e3967127b0235"},
   "path_glob": {:hex, :path_glob, "0.2.0", "b9e34b5045cac5ecb76ef1aa55281a52bf603bf7009002085de40958064ca312", [:mix], [{:nimble_parsec, "~> 1.2.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "be2594cb4553169a1a189f95193d910115f64f15f0d689454bb4e8cfae2e7ebc"},
-  "sourceror": {:hex, :sourceror, "0.12.3", "a2ad3a1a4554b486d8a113ae7adad5646f938cad99bf8bfcef26dc0c88e8fade", [:mix], [], "hexpm", "4d4e78010ca046524e8194ffc4683422f34a96f6b82901abbb45acc79ace0316"},
+  "sourceror": {:git, "https://github.com/zachallaun/sourceror.git", "cf45de306b46f5991d445ac57e038cf256018262", [ref: "nil-get-range"]},
   "stream_data": {:hex, :stream_data, "0.6.0", "e87a9a79d7ec23d10ff83eb025141ef4915eeb09d4491f79e52f2562b73e5f47", [:mix], [], "hexpm", "b92b5031b650ca480ced047578f1d57ea6dd563f5b57464ad274718c9c29501c"},
 }

--- a/projects/lexical_test/lib/lexical/test/cursor_support.ex
+++ b/projects/lexical_test/lib/lexical/test/cursor_support.ex
@@ -1,49 +1,98 @@
 defmodule Lexical.Test.CursorSupport do
-  def cursor_position(text) do
-    text
-    |> String.graphemes()
-    |> Enum.chunk_every(2, 1, [""])
-    |> Enum.reduce_while({starting_line(), starting_column()}, fn
-      ["|", ">"], {line, column} ->
-        {:cont, {line, column + 1}}
+  @moduledoc """
+  Utilities for extracting cursor position in code fragments and documents.
+  """
 
-      ["|", _], position ->
-        {:halt, position}
+  alias Lexical.Document
+  alias Lexical.Document.Position
+  alias Lexical.Test.PositionSupport
 
-      ["\n", _], {line, _column} ->
-        {:cont, {line + 1, starting_column()}}
+  @default_cursor "|"
+  @starting_line 1
+  @starting_column 1
 
-      _, {line, column} ->
-        {:cont, {line, column + 1}}
-    end)
+  @type cursor_position :: {pos_integer(), pos_integer()}
+
+  @doc """
+  Finds a cursor in `text` and returns a tuple of the cursor position and
+  the text with the cursor stripped out.
+
+  ## Options
+
+    * `:cursor` - the cursor string to be found. Defaults to
+      `#{inspect(@default_cursor)}`.
+
+    * `:as` - one of `:text` (default) or `:document`. If `:document`,
+      wraps the text in a `Lexical.Document` using the URI `"file:///file.ex"`.
+
+    * `:document` - the document path or URI. Setting this option implies
+      `as: :document`.
+
+  ## Examples
+
+      iex> code = \"""
+      ...> defmodule MyModule do
+      ...>   alias Foo|
+      ...> end
+      ...> \"""
+
+      iex> pop_cursor(code)
+      {
+        %Position{line: 2, column: 12},
+        \"""
+        defmodule MyModule do
+          alias Foo
+        end
+        \"""
+      }
+
+      iex> pop_cursor(code, as: :document)
+      {
+        %Position{line: 2, column: 12},
+        %Document{uri: "file:///file.ex", ...}
+      }
+
+      iex> pop_cursor(code, document: "my_doc.ex")
+      {
+        %Position{line: 2, column: 12},
+        %Document{uri: "file:///my_doc.ex", ...}
+      }
+
+  """
+  @spec pop_cursor(text :: String.t(), [opt]) :: {Position.t(), String.t() | Document.t()}
+        when opt: {:cursor, String.t()} | {:as, :text | :document} | {:document, String.t()}
+  def pop_cursor(text, opts \\ []) do
+    cursor = Keyword.get(opts, :cursor, @default_cursor)
+    as_document? = opts[:as] == :document or is_binary(opts[:document])
+
+    {line, column} = cursor_position(text, cursor)
+    stripped_text = strip_cursor(text, cursor)
+
+    if as_document? do
+      uri = opts |> Keyword.get(:document, "file:///file.ex") |> Document.Path.ensure_uri()
+      document = Document.new(uri, stripped_text, 0)
+      position = Position.new(document, line, column)
+      {position, document}
+    else
+      position = PositionSupport.position(line, column)
+      {position, stripped_text}
+    end
   end
 
-  def context_before_cursor(text) do
-    text
-    |> String.graphemes()
-    |> Enum.chunk_every(2, 1, [""])
-    |> Enum.reduce_while([], fn
-      ["|", ">"], iodata ->
-        {:cont, [iodata, "|"]}
-
-      ["|", _lookahead], iodata ->
-        {:halt, iodata}
-
-      [c, _], iodata ->
-        {:cont, [iodata, c]}
-    end)
-    |> IO.iodata_to_binary()
-  end
-
-  def strip_cursor(text) do
+  @doc """
+  Strips all instances of `cursor` from `text`.
+  """
+  @spec strip_cursor(text :: String.t(), cursor :: String.t()) :: String.t()
+  def strip_cursor(text, cursor \\ @default_cursor) do
     text
     |> String.graphemes()
     |> Enum.chunk_every(2, 1, [""])
     |> Enum.reduce([], fn
+      # don't strip the pipe in a `|>` operator when using the default cursor
       ["|", ">"], iodata ->
         [iodata, "|"]
 
-      ["|", _lookahead], iodata ->
+      [^cursor, _lookahead], iodata ->
         iodata
 
       [c, _], iodata ->
@@ -52,11 +101,23 @@ defmodule Lexical.Test.CursorSupport do
     |> IO.iodata_to_binary()
   end
 
-  defp starting_line do
-    1
-  end
+  defp cursor_position(text, cursor) do
+    text
+    |> String.graphemes()
+    |> Enum.chunk_every(2, 1, [""])
+    |> Enum.reduce_while({@starting_line, @starting_column}, fn
+      # don't consider the pipe in a `|>` operator when using the default cursor
+      ["|", ">"], {line, column} ->
+        {:cont, {line, column + 1}}
 
-  defp starting_column do
-    1
+      [^cursor, _], position ->
+        {:halt, position}
+
+      ["\n", _], {line, _column} ->
+        {:cont, {line + 1, @starting_column}}
+
+      _, {line, column} ->
+        {:cont, {line, column + 1}}
+    end)
   end
 end

--- a/projects/lexical_test/lib/lexical/test/range_support.ex
+++ b/projects/lexical_test/lib/lexical/test/range_support.ex
@@ -1,10 +1,23 @@
 defmodule Lexical.Test.RangeSupport do
   alias Lexical.Document
   alias Lexical.Document.Range
+  alias Lexical.Test.CursorSupport
+
   import Lexical.Document.Line, only: [line: 1]
 
   @range_start_marker "«"
   @range_end_marker "»"
+
+  @doc """
+  Finds range markers in `text` and returns a tuple containing the range
+  and the text with the markers stripped out.
+  """
+  @spec pop_range(text :: String.t()) :: {Range.t(), String.t()}
+  def pop_range(text) do
+    {start_position, text} = CursorSupport.pop_cursor(text, cursor: @range_start_marker)
+    {end_position, text} = CursorSupport.pop_cursor(text, cursor: @range_end_marker)
+    {Range.new(start_position, end_position), text}
+  end
 
   def decorate(%Document{} = document, %Range{} = range) do
     index_range = (range.start.line - 1)..(range.end.line - 1)


### PR DESCRIPTION
This PR builds on #331, adding hover support for additional entities:

- Structs
- Qualified calls
- Qualified types

Improvements:

- Generally improved formatting for all hover content.
- Respond with range information to support editor highlighting.
- Include callback signatures and docs for modules that are behaviours.

Notes:

- Add vendored `Future.Code.Typespec`, which includes required fixes in `@spec` to make Dialyzer happy.
- Update `:sourceror` dep to the latest commit until a new release is cut. This latest version updates Sourceror's zippers to be a `%Zipper{}` struct and includes fixes/improvements to `Sourceror.get_range/1`.
- `Lexical.Ast` now uses the `unescape: false` option when parsing code. See ba4223df5c4020c3dc6bc104b73c208496837cb7 for more context.