### PR TITLE
Moved dispatch to :gen_event

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/dispatch.ex
+++ b/apps/remote_control/lib/lexical/remote_control/dispatch.ex
@@ -15,12 +15,13 @@ defmodule Lexical.RemoteControl.Dispatch do
   @doc """
   Registers a process that will receive messages sent directly to its pid.
   """
-  def register_listener(listener_pid, :all) do
-    register_listener(listener_pid, [:all])
-  end
 
   def register_listener(listener_pid, message_types) when is_list(message_types) do
     :gen_event.call(__MODULE__, PubSub, PubSub.register_message(listener_pid, message_types))
+  end
+
+  def register_listener(listener_pid, event_or_all) do
+    register_listener(listener_pid, List.wrap(event_or_all))
   end
 
   def add_handler(handler_module, init_args \\ []) do

--- a/apps/remote_control/lib/lexical/remote_control/dispatch.ex
+++ b/apps/remote_control/lib/lexical/remote_control/dispatch.ex
@@ -1,137 +1,61 @@
 defmodule Lexical.RemoteControl.Dispatch do
-  defmodule State do
-    alias Lexical.Project
+  @moduledoc """
+  A global event dispatcher for lexical.
 
-    defstruct [:registrations]
+  Dispatch allows two recipients of its messages, processes and modules. A process must register
+  itself via a call to `register_listener`, while a process must implement the
+  `Lexical.RemoteControl.Dispatch.Handler` behaviour and add the module to the @handlers module attribute.
+  """
+  alias Lexical.RemoteControl.Dispatch.PubSub
 
-    def new do
-      %__MODULE__{registrations: %{}}
-    end
-
-    def add(%__MODULE__{} = state, message_type, pid) do
-      registrations =
-        Map.update(state.registrations, message_type, [pid], fn registrations ->
-          [pid | registrations]
-        end)
-
-      %__MODULE__{state | registrations: registrations}
-    end
-
-    def registrations(%__MODULE__{} = state, message_type) do
-      all = Map.get(state.registrations, :all, [])
-      specific = Map.get(state.registrations, message_type, [])
-      all ++ specific
-    end
-
-    def registered?(%__MODULE__{} = state, pid) do
-      state.registrations
-      |> Map.values()
-      |> List.flatten()
-      |> Enum.member?(pid)
-    end
-
-    def registered?(%__MODULE__{} = state, message_type, pid) do
-      pid in registrations(state, message_type)
-    end
-
-    def remove(%__MODULE__{} = state, message_type, pid) do
-      registrations =
-        Map.update(state.registrations, message_type, [], &Enum.reject(&1, fn e -> e == pid end))
-
-      %__MODULE__{state | registrations: registrations}
-    end
-
-    def remove_all(%__MODULE__{} = state, pid) do
-      registrations =
-        Map.new(state.registrations, fn {message, pids} ->
-          pids = Enum.reject(pids, &(&1 == pid))
-          {message, pids}
-        end)
-
-      %__MODULE__{state | registrations: registrations}
-    end
-  end
-
-  alias Lexical.Project
-  use GenServer
+  @handlers [PubSub]
 
   # public API
 
+  @doc """
+  Registers a process that will receive messages sent directly to its pid.
+  """
+  def register_listener(listener_pid, :all) do
+    register_listener(listener_pid, [:all])
+  end
+
   def register_listener(listener_pid, message_types) when is_list(message_types) do
-    GenServer.call(__MODULE__, {:register, listener_pid, message_types})
+    :gen_event.call(__MODULE__, PubSub, PubSub.register_message(listener_pid, message_types))
+  end
+
+  def add_handler(handler_module, init_args \\ []) do
+    :gen_event.add_handler(__MODULE__, handler_module, init_args)
   end
 
   def registered?(pid) when is_pid(pid) do
-    GenServer.call(__MODULE__, {:registered?, pid})
+    :gen_event.call(__MODULE__, PubSub, PubSub.registered_message(pid))
   end
 
   def broadcast(message) do
-    __MODULE__
-    |> Process.whereis()
-    |> send(message)
+    :gen_event.notify(__MODULE__, message)
   end
 
   # GenServer callbacks
 
   def start_link(_) do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+    case :gen_event.start_link(name()) do
+      {:ok, pid} = success ->
+        Enum.each(@handlers, &:gen_event.add_handler(pid, &1, []))
+        success
+
+      error ->
+        error
+    end
   end
 
-  def child_spec do
+  def child_spec(_) do
     %{
       id: {__MODULE__, :dispatch},
-      start: {__MODULE__, :start_link, []}
+      start: {__MODULE__, :start_link, [[]]}
     }
   end
 
-  @impl GenServer
-  def init([]) do
-    {:ok, State.new()}
+  defp name do
+    {:local, __MODULE__}
   end
-
-  @impl GenServer
-  def handle_call({:register, listener_pid, message_types}, _from, %State{} = state) do
-    Process.monitor(listener_pid)
-
-    new_state =
-      Enum.reduce(message_types, state, fn
-        message_type_or_message, %State{} = state ->
-          message_type = extract_message_type(message_type_or_message)
-          State.add(state, message_type, listener_pid)
-      end)
-
-    {:reply, :ok, new_state}
-  end
-
-  @impl GenServer
-  def handle_call({:registered?, pid}, _from, %State{} = state) do
-    registered? = State.registered?(state, pid)
-    {:reply, registered?, state}
-  end
-
-  @impl GenServer
-  def handle_info({:DOWN, _ref, _, pid, _}, %State{} = state) do
-    new_state = State.remove_all(state, pid)
-    {:noreply, new_state}
-  end
-
-  @impl GenServer
-  def handle_info(message, %State{} = state) do
-    message_type = extract_message_type(message)
-
-    state
-    |> State.registrations(message_type)
-    |> Enum.each(&send(&1, message))
-
-    {:noreply, state}
-  end
-
-  def name(%Project{} = project) do
-    :"#{Project.name(project)}::dispatch"
-  end
-
-  # Private api
-
-  defp extract_message_type(message_type) when is_atom(message_type), do: message_type
-  defp extract_message_type(message_type) when is_tuple(message_type), do: elem(message_type, 0)
 end

--- a/apps/remote_control/lib/lexical/remote_control/dispatch/handler.ex
+++ b/apps/remote_control/lib/lexical/remote_control/dispatch/handler.ex
@@ -1,0 +1,49 @@
+defmodule Lexical.RemoteControl.Dispatch.Handler do
+  defmacro __using__(event_types) do
+    quote do
+      @behaviour :gen_event
+      @event_names unquote(event_types)
+                   |> List.wrap()
+                   |> MapSet.new(fn
+                     :all -> :all
+                     event when is_tuple(event) -> elem(event, 0)
+                   end)
+
+      def init(arg) do
+        {:ok, arg}
+      end
+
+      def on(event, state) do
+        {:ok, event, state}
+      end
+
+      def handle_call(_, state) do
+        {:ok, state}
+      end
+
+      def handle_info(_, state) do
+        {:ok, state}
+      end
+
+      def handle_event(event, state) when is_tuple(event) do
+        cond do
+          MapSet.member?(@event_names, elem(event, 0)) ->
+            on(event, state)
+
+          MapSet.member?(@event_names, :all) ->
+            on(event, state)
+
+          true ->
+            {:ok, state}
+        end
+      end
+
+      def handle_event(_event, state) do
+        {:ok, state}
+      end
+
+      # handlers only respond to on or info, not calls.
+      defoverridable init: 1, handle_info: 2, on: 2
+    end
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/dispatch/handler.ex
+++ b/apps/remote_control/lib/lexical/remote_control/dispatch/handler.ex
@@ -1,13 +1,50 @@
 defmodule Lexical.RemoteControl.Dispatch.Handler do
+  @moduledoc """
+  Defines a handler that selectively receives events emitted from a remote control node.
+
+  ## Usage
+
+  Define a handler, specifying the events to be handled and implementing `on_event/2`:
+
+      defmodule MyHandler do
+        alias Lexical.RemoteControl.Api.Messages
+        alias Lexical.RemoteControl.Dispatch.Handler
+
+        import Messages
+
+        use Handler, [project_compiled()]
+
+        def on_event(project_compiled(), state) do
+          ...do something with the message
+          {:ok, state}
+        end
+      end
+
+    Register the handler with dispatch:
+
+    # The second argument here will be passed to the `init/1` callback
+    Lexical.RemoteControl.Dispatch.add_handler(MyHandler, init_arg)
+
+  """
+  @type event :: tuple()
+  @type handler_state :: term()
+
+  @callback on_event(event(), handler_state) :: {:ok, handler_state} | {:error, any()}
+  @callback init(term()) :: {:ok, handler_state()}
+  @optional_callbacks init: 1
+
   defmacro __using__(event_types) do
+    event_types = List.wrap(event_types)
+
+    handler_bodies =
+      if Enum.member?(event_types, :all) do
+        [all_handler()]
+      else
+        handler_bodies(event_types)
+      end
+
     quote do
-      @behaviour :gen_event
-      @event_names unquote(event_types)
-                   |> List.wrap()
-                   |> MapSet.new(fn
-                     :all -> :all
-                     event when is_tuple(event) -> elem(event, 0)
-                   end)
+      @behaviour unquote(__MODULE__)
 
       def init(arg) do
         {:ok, arg}
@@ -25,25 +62,50 @@ defmodule Lexical.RemoteControl.Dispatch.Handler do
         {:ok, state}
       end
 
-      def handle_event(event, state) when is_tuple(event) do
-        cond do
-          MapSet.member?(@event_names, elem(event, 0)) ->
-            on(event, state)
-
-          MapSet.member?(@event_names, :all) ->
-            on(event, state)
-
-          true ->
-            {:ok, state}
-        end
-      end
-
-      def handle_event(_event, state) do
-        {:ok, state}
-      end
+      unquote_splicing(handler_bodies)
 
       # handlers only respond to on or info, not calls.
       defoverridable init: 1, handle_info: 2, on: 2
+    end
+  end
+
+  def handler_bodies(event_types) do
+    results =
+      Enum.map(event_types, fn {event_name, _, _} ->
+        event_handler(event_name)
+      end)
+
+    results ++ [ignore_handler()]
+  end
+
+  defp event_handler(event_name) do
+    quote do
+      def handle_event(event, state)
+          when is_tuple(event) and elem(event, 0) == unquote(event_name) do
+        on_event(event, state)
+      end
+    end
+  end
+
+  defp all_handler do
+    quote do
+      def handle_event(event, state) do
+        on_event(event, state)
+      end
+    end
+  end
+
+  defp ignore_handler do
+    quote do
+      require Logger
+
+      def handle_event(event, state) do
+        Logger.error(
+          "Handler in #{inspect(__MODULE__)} got an unexpected event #{inspect(event)}"
+        )
+
+        {:ok, state}
+      end
     end
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/dispatch/pub_sub.ex
+++ b/apps/remote_control/lib/lexical/remote_control/dispatch/pub_sub.ex
@@ -1,8 +1,6 @@
 defmodule Lexical.RemoteControl.Dispatch.PubSub do
   @moduledoc """
   A pubsub event handler for a gen_event controller.
-
-
   """
   defmodule State do
     alias Lexical.Project

--- a/apps/remote_control/lib/lexical/remote_control/dispatch/pub_sub.ex
+++ b/apps/remote_control/lib/lexical/remote_control/dispatch/pub_sub.ex
@@ -1,0 +1,122 @@
+defmodule Lexical.RemoteControl.Dispatch.PubSub do
+  @moduledoc """
+  A pubsub event handler for a gen_event controller.
+
+
+  """
+  defmodule State do
+    alias Lexical.Project
+
+    defstruct [:registrations]
+
+    def new do
+      %__MODULE__{registrations: %{}}
+    end
+
+    def add(%__MODULE__{} = state, message_type, pid) do
+      registrations =
+        Map.update(state.registrations, message_type, [pid], fn registrations ->
+          [pid | registrations]
+        end)
+
+      %__MODULE__{state | registrations: registrations}
+    end
+
+    def registrations(%__MODULE__{} = state, message_type) do
+      all = Map.get(state.registrations, :all, [])
+      specific = Map.get(state.registrations, message_type, [])
+      all ++ specific
+    end
+
+    def registered?(%__MODULE__{} = state, pid) do
+      state.registrations
+      |> Map.values()
+      |> List.flatten()
+      |> Enum.member?(pid)
+    end
+
+    def registered?(%__MODULE__{} = state, message_type, pid) do
+      pid in registrations(state, message_type)
+    end
+
+    def remove(%__MODULE__{} = state, message_type, pid) do
+      registrations =
+        Map.update(state.registrations, message_type, [], &Enum.reject(&1, fn e -> e == pid end))
+
+      %__MODULE__{state | registrations: registrations}
+    end
+
+    def remove_all(%__MODULE__{} = state, pid) do
+      registrations =
+        Map.new(state.registrations, fn {message, pids} ->
+          pids = Enum.reject(pids, &(&1 == pid))
+          {message, pids}
+        end)
+
+      %__MODULE__{state | registrations: registrations}
+    end
+  end
+
+  alias Lexical.Project
+
+  @behaviour :gen_event
+
+  def register_message(listener_pid, message_types) do
+    {:register, listener_pid, message_types}
+  end
+
+  def registered_message(pid) do
+    {:registered?, pid}
+  end
+
+  @impl :gen_event
+  def init(_) do
+    {:ok, State.new()}
+  end
+
+  @impl :gen_event
+  def handle_call({:register, listener_pid, message_types}, %State{} = state) do
+    Process.monitor(listener_pid)
+
+    new_state =
+      Enum.reduce(message_types, state, fn
+        message_type_or_message, %State{} = state ->
+          message_type = extract_message_type(message_type_or_message)
+          State.add(state, message_type, listener_pid)
+      end)
+
+    {:ok, :ok, new_state}
+  end
+
+  @impl :gen_event
+  def handle_call({:registered?, pid}, %State{} = state) do
+    registered? = State.registered?(state, pid)
+    {:ok, registered?, state}
+  end
+
+  @impl :gen_event
+  def handle_info({:DOWN, _ref, _, pid, _}, %State{} = state) do
+    new_state = State.remove_all(state, pid)
+    {:ok, new_state}
+  end
+
+  @impl :gen_event
+  def handle_event(message, %State{} = state) do
+    message_type = extract_message_type(message)
+
+    state
+    |> State.registrations(message_type)
+    |> Enum.each(&send(&1, message))
+
+    {:ok, state}
+  end
+
+  def name(%Project{} = project) do
+    :"#{Project.name(project)}::dispatch"
+  end
+
+  # Private api
+
+  defp extract_message_type(message_type) when is_atom(message_type), do: message_type
+  defp extract_message_type(message_type) when is_tuple(message_type), do: elem(message_type, 0)
+end

--- a/apps/remote_control/test/lexical/remote_control/dispatch/handler_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/dispatch/handler_test.exs
@@ -13,7 +13,7 @@ defmodule Lexical.RemoteControl.Dispatch.HandlerTest do
   defmodule AllForwarder do
     use Dispatch.Handler, :all
 
-    def on(event, caller_pid) do
+    def on_event(event, caller_pid) do
       send(caller_pid, {__MODULE__, event})
       {:ok, caller_pid}
     end
@@ -43,7 +43,7 @@ defmodule Lexical.RemoteControl.Dispatch.HandlerTest do
         file_compiled()
       ]
 
-      def on(event, test_pid) do
+      def on_event(event, test_pid) do
         send(test_pid, {__MODULE__, event})
         {:ok, test_pid}
       end
@@ -81,12 +81,12 @@ defmodule Lexical.RemoteControl.Dispatch.HandlerTest do
         project_compiled()
       ]
 
-      def on(project_compiled(status: :failure) = project_compiled, caller_pid) do
+      def on_event(project_compiled(status: :failure) = project_compiled, caller_pid) do
         send(caller_pid, {__MODULE__, project_compiled})
         {:error, :died}
       end
 
-      def on(event, caller_pid) do
+      def on_event(event, caller_pid) do
         send(caller_pid, {__MODULE__, event})
       end
     end

--- a/apps/remote_control/test/lexical/remote_control/dispatch/handler_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/dispatch/handler_test.exs
@@ -1,0 +1,129 @@
+defmodule Lexical.RemoteControl.Dispatch.HandlerTest do
+  alias Lexical.RemoteControl.Api.Messages
+  alias Lexical.RemoteControl.Dispatch
+
+  import Messages
+  use ExUnit.Case
+
+  setup do
+    start_supervised!(Dispatch)
+    :ok
+  end
+
+  defmodule AllForwarder do
+    use Dispatch.Handler, :all
+
+    def on(event, caller_pid) do
+      send(caller_pid, {__MODULE__, event})
+      {:ok, caller_pid}
+    end
+  end
+
+  describe "All forwarder" do
+    setup do
+      Dispatch.add_handler(AllForwarder, self())
+      :ok
+    end
+
+    test "sends all messages here" do
+      file_changed = file_changed(uri: "file:////foo/bar.ex")
+      Dispatch.broadcast(file_changed)
+      assert_receive {AllForwarder, ^file_changed}
+
+      project_compiled = project_compiled(project: make_ref())
+      Dispatch.broadcast(project_compiled)
+      assert_receive {AllForwarder, ^project_compiled}
+    end
+  end
+
+  describe "selective handler" do
+    defmodule SelectiveForwarder do
+      use Dispatch.Handler, [
+        project_compile_requested(),
+        file_compiled()
+      ]
+
+      def on(event, test_pid) do
+        send(test_pid, {__MODULE__, event})
+        {:ok, test_pid}
+      end
+    end
+
+    setup do
+      Dispatch.add_handler(SelectiveForwarder, self())
+    end
+
+    test "forwards messages it cares about" do
+      project_compile = project_compile_requested(project: make_ref())
+      Dispatch.broadcast(project_compile)
+
+      assert_receive {SelectiveForwarder, ^project_compile}
+
+      file_compile = file_compiled(uri: "file:///foo.ex")
+      Dispatch.broadcast(file_compile)
+
+      assert_receive {SelectiveForwarder, ^file_compile}
+    end
+
+    test "ignores messages it doesn't subscribe to" do
+      Dispatch.broadcast(file_changed())
+      refute_receive {SelectiveForwarder, _}
+
+      Dispatch.broadcast(project_progress())
+      refute_receive {SelectiveForwarder, _}
+    end
+  end
+
+  describe "error handler" do
+    defmodule ErrorForwarder do
+      use Dispatch.Handler, [
+        file_compiled(),
+        project_compiled()
+      ]
+
+      def on(project_compiled(status: :failure) = project_compiled, caller_pid) do
+        send(caller_pid, {__MODULE__, project_compiled})
+        {:error, :died}
+      end
+
+      def on(event, caller_pid) do
+        send(caller_pid, {__MODULE__, event})
+      end
+    end
+
+    setup do
+      Dispatch.add_handler(AllForwarder, self())
+      Dispatch.add_handler(ErrorForwarder, self())
+    end
+
+    test "works for file compiled" do
+      file_compiled = file_compiled(uri: "file:///something.ex")
+      Dispatch.broadcast(file_compiled)
+
+      assert_receive {AllForwarder, ^file_compiled}
+      assert_receive {ErrorForwarder, ^file_compiled}
+    end
+
+    test "works for project compiled" do
+      project_compiled = project_compiled(project: make_ref())
+      Dispatch.broadcast(project_compiled)
+
+      assert_receive {AllForwarder, ^project_compiled}
+      assert_receive {ErrorForwarder, ^project_compiled}
+    end
+
+    test "removes a handler if it errors" do
+      failure = project_compiled(status: :failure)
+      Dispatch.broadcast(failure)
+
+      assert_receive {AllForwarder, ^failure}
+      assert_receive {ErrorForwarder, ^failure}
+
+      # The error forwarder should now be removed
+
+      Dispatch.broadcast(file_compiled())
+      assert_receive {AllForwarder, _}
+      refute_receive {ErrorForwarder, _}
+    end
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/dispatch/pub_sub_state_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/dispatch/pub_sub_state_test.exs
@@ -1,7 +1,7 @@
-defmodule Lexical.RemoteControl.Dispatch.StateTest do
+defmodule Lexical.RemoteControl.Dispatch.PubSubStateTest do
   use ExUnit.Case
 
-  alias Lexical.RemoteControl.Dispatch.State
+  alias Lexical.RemoteControl.Dispatch.PubSub.State
 
   setup do
     state = State.new()


### PR DESCRIPTION
As I was integrating indexing into lexical, I kept having to implement genservers that had no other point than to receive messages and take some action when one was received. :gen_event already does this, so I thought it would be nice to have a simple way to implement handler modules in addition to proceses that receive events.