### PR TITLE
Integrated indexing into language server

### DIFF
--- a/apps/common/lib/lexical/ast.ex
+++ b/apps/common/lib/lexical/ast.ex
@@ -394,8 +394,8 @@ defmodule Lexical.Ast do
     end
   end
 
-  def expand_aliases(_, _, {line, column}) do
-    Position.new(line, column)
+  def expand_aliases(segments, doc, {line, column}) do
+    expand_aliases(segments, doc, Position.new(line, column))
   end
 
   def expand_aliases(_, _, empty) do

--- a/apps/remote_control/lib/lexical/remote_control.ex
+++ b/apps/remote_control/lib/lexical/remote_control.ex
@@ -34,7 +34,7 @@ defmodule Lexical.RemoteControl do
   end
 
   def get_project do
-    :persistent_term.get({__MODULE__, :project})
+    :persistent_term.get({__MODULE__, :project}, nil)
   end
 
   def set_project(%Project{} = project) do

--- a/apps/remote_control/lib/lexical/remote_control/api/messages.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api/messages.ex
@@ -1,4 +1,6 @@
 defmodule Lexical.RemoteControl.Api.Messages do
+  alias Lexical.Project
+
   import Record
   defrecord :project_compile_requested, project: nil, build_number: 0
 
@@ -9,9 +11,13 @@ defmodule Lexical.RemoteControl.Api.Messages do
     diagnostics: [],
     elapsed_ms: 0
 
+  defrecord :filesystem_event, project: nil, uri: nil, event_type: nil
+
   defrecord :file_changed, uri: nil, from_version: nil, to_version: nil, open?: false
 
   defrecord :file_compile_requested, project: nil, build_number: 0, uri: nil
+
+  defrecord :file_quoted, project: nil, document: nil, quoted_ast: nil
 
   defrecord :file_compiled,
     project: nil,
@@ -20,6 +26,8 @@ defmodule Lexical.RemoteControl.Api.Messages do
     status: :successful,
     diagnostics: [],
     elapsed_ms: 0
+
+  defrecord :file_deleted, project: nil, uri: nil
 
   defrecord :module_updated, file: nil, name: nil, functions: [], macros: [], struct: nil
 
@@ -49,7 +57,14 @@ defmodule Lexical.RemoteControl.Api.Messages do
             elapsed_ms: non_neg_integer
           )
 
-  @type file_updated ::
+  @type filesystem_event ::
+          record(:filesystem_event,
+            project: Project.t(),
+            uri: Lexical.uri(),
+            event_type: :created | :updated | :deleted
+          )
+
+  @type file_changed ::
           record(:file_changed,
             uri: Lexical.uri(),
             from_version: maybe_version,
@@ -61,6 +76,13 @@ defmodule Lexical.RemoteControl.Api.Messages do
             project: Lexical.Project.t(),
             build_number: non_neg_integer(),
             uri: Lexical.uri()
+          )
+
+  @type file_quoted ::
+          record(:file_quoted,
+            project: Lexical.Project.t(),
+            document: Lexical.Document.t(),
+            quoted_ast: Macro.t()
           )
 
   @type file_compiled ::

--- a/apps/remote_control/lib/lexical/remote_control/application.ex
+++ b/apps/remote_control/lib/lexical/remote_control/application.ex
@@ -17,7 +17,12 @@ defmodule Lexical.RemoteControl.Application do
           RemoteControl.Build,
           RemoteControl.Build.CaptureServer,
           RemoteControl.Plugin.Runner.Supervisor,
-          RemoteControl.Plugin.Runner.Coordinator
+          RemoteControl.Plugin.Runner.Coordinator,
+          {RemoteControl.Search.Store,
+           [
+             &RemoteControl.Search.Indexer.create_index/1,
+             &RemoteControl.Search.Indexer.update_index/2
+           ]}
         ]
       else
         []

--- a/apps/remote_control/lib/lexical/remote_control/build/document/compilers/quoted.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document/compilers/quoted.ex
@@ -1,12 +1,25 @@
 defmodule Lexical.RemoteControl.Build.Document.Compilers.Quoted do
   alias Elixir.Features
   alias Lexical.Document
+  alias Lexical.RemoteControl
+  alias Lexical.RemoteControl.Api
   alias Lexical.RemoteControl.Build
+  alias Lexical.RemoteControl.Dispatch
   alias Lexical.RemoteControl.ModuleMappings
 
+  import Api.Messages
   import Lexical.RemoteControl.Build.CaptureIO, only: [capture_io: 2]
 
   def compile(%Document{} = document, quoted_ast, compiler_name) do
+
+    Dispatch.broadcast(
+      file_quoted(
+        project: RemoteControl.get_project(),
+        document: document,
+        quoted_ast: quoted_ast
+      )
+    )
+
     prepare_compile(document.path)
 
     {status, diagnostics} =

--- a/apps/remote_control/lib/lexical/remote_control/dispatch.ex
+++ b/apps/remote_control/lib/lexical/remote_control/dispatch.ex
@@ -6,9 +6,10 @@ defmodule Lexical.RemoteControl.Dispatch do
   itself via a call to `register_listener`, while a process must implement the
   `Lexical.RemoteControl.Dispatch.Handler` behaviour and add the module to the @handlers module attribute.
   """
+  alias Lexical.RemoteControl.Dispatch.Handlers
   alias Lexical.RemoteControl.Dispatch.PubSub
 
-  @handlers [PubSub]
+  @handlers [PubSub, Handlers.Indexing]
 
   # public API
 
@@ -30,6 +31,10 @@ defmodule Lexical.RemoteControl.Dispatch do
 
   def registered?(pid) when is_pid(pid) do
     :gen_event.call(__MODULE__, PubSub, PubSub.registered_message(pid))
+  end
+
+  def registered?(name) when is_atom(name) do
+    name in :gen_event.which_handlers(__MODULE__)
   end
 
   def broadcast(message) do

--- a/apps/remote_control/lib/lexical/remote_control/dispatch/handler.ex
+++ b/apps/remote_control/lib/lexical/remote_control/dispatch/handler.ex
@@ -97,13 +97,7 @@ defmodule Lexical.RemoteControl.Dispatch.Handler do
 
   defp ignore_handler do
     quote do
-      require Logger
-
       def handle_event(event, state) do
-        Logger.error(
-          "Handler in #{inspect(__MODULE__)} got an unexpected event #{inspect(event)}"
-        )
-
         {:ok, state}
       end
     end

--- a/apps/remote_control/lib/lexical/remote_control/dispatch/handlers/indexing.ex
+++ b/apps/remote_control/lib/lexical/remote_control/dispatch/handlers/indexing.ex
@@ -25,7 +25,7 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.Indexing do
   end
 
   def reindex(%Document{} = document, quoted_ast) do
-    with :ok <- up_to_date?(document),
+    with :ok <- ensure_latest_version(document),
          {:ok, entries} <- Indexer.Quoted.index(document, quoted_ast) do
       Search.Store.update(document.path, entries)
     end
@@ -36,7 +36,7 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.Indexing do
     Search.Store.clear(path)
   end
 
-  defp up_to_date?(%Document{version: version, uri: uri}) do
+  defp ensure_latest_version(%Document{version: version, uri: uri}) do
     case Document.Store.fetch(uri) do
       {:ok, %Document{version: ^version}} ->
         :ok

--- a/apps/remote_control/lib/lexical/remote_control/dispatch/handlers/indexing.ex
+++ b/apps/remote_control/lib/lexical/remote_control/dispatch/handlers/indexing.ex
@@ -1,0 +1,51 @@
+defmodule Lexical.RemoteControl.Dispatch.Handlers.Indexing do
+  alias Lexical.Document
+  alias Lexical.RemoteControl.Api.Messages
+  alias Lexical.RemoteControl.Dispatch
+  alias Lexical.RemoteControl.Search
+  alias Lexical.RemoteControl.Search.Indexer
+
+  require Logger
+  import Messages
+
+  use Dispatch.Handler, [file_quoted(), filesystem_event()]
+
+  def on_event(file_quoted(document: document, quoted_ast: quoted_ast), state) do
+    reindex(document, quoted_ast)
+    {:ok, state}
+  end
+
+  def on_event(filesystem_event(uri: uri, event_type: :deleted), state) do
+    delete_path(uri)
+    {:ok, state}
+  end
+
+  def on_event(filesystem_event(), state) do
+    {:ok, state}
+  end
+
+  def reindex(%Document{} = document, quoted_ast) do
+    with :ok <- up_to_date?(document),
+         {:ok, entries} <- Indexer.Quoted.index(document, quoted_ast) do
+      Search.Store.update(document.path, entries)
+    end
+  end
+
+  def delete_path(uri) do
+    path = Document.Path.ensure_path(uri)
+    Search.Store.clear(path)
+  end
+
+  defp up_to_date?(%Document{version: version, uri: uri}) do
+    case Document.Store.fetch(uri) do
+      {:ok, %Document{version: ^version}} ->
+        :ok
+
+      _ ->
+        {:error, :version_mismatch}
+    end
+  end
+end
+
+defmodule NewModule do
+end

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
@@ -68,6 +68,6 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
   end
 
   defp timestamp do
-    :calendar.local_time()
+    :calendar.universal_time()
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/quoted.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/quoted.ex
@@ -1,0 +1,14 @@
+defmodule Lexical.RemoteControl.Search.Indexer.Quoted do
+  alias Lexical.Document
+  alias Lexical.RemoteControl.Search.Indexer.Source.Reducer
+
+  def index(%Document{} = document, quoted_ast) do
+    {_, reducer} =
+      Macro.prewalk(quoted_ast, Reducer.new(document, quoted_ast), fn elem, reducer ->
+        {reducer, elem} = Reducer.reduce(reducer, elem)
+        {elem, reducer}
+      end)
+
+    {:ok, Reducer.entries(reducer)}
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/source.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/source.ex
@@ -1,7 +1,7 @@
 defmodule Lexical.RemoteControl.Search.Indexer.Source do
   alias Lexical.Ast
   alias Lexical.Document
-  alias Lexical.RemoteControl.Search.Indexer.Source.Reducer
+  alias Lexical.RemoteControl.Search.Indexer
 
   require Logger
 
@@ -10,22 +10,11 @@ defmodule Lexical.RemoteControl.Search.Indexer.Source do
 
     case Ast.from(document) do
       {:ok, quoted} ->
-        entries = index_quoted(document, quoted)
-        {:ok, entries}
+        Indexer.Quoted.index(document, quoted)
 
       _ ->
         Logger.error("Could not compile #{path} into AST for indexing")
         :error
     end
-  end
-
-  def index_quoted(%Document{} = document, quoted) do
-    {_, reducer} =
-      Macro.prewalk(quoted, Reducer.new(document, quoted), fn elem, reducer ->
-        {reducer, elem} = Reducer.reduce(reducer, elem)
-        {elem, reducer}
-      end)
-
-    Reducer.entries(reducer)
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/store.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store.ex
@@ -54,6 +54,10 @@ defmodule Lexical.RemoteControl.Search.Store do
     GenServer.call(__MODULE__, {:fuzzy, subject, constraints})
   end
 
+  def clear(path) do
+    GenServer.call(__MODULE__, {:update, path, []})
+  end
+
   def update(path, entries) do
     GenServer.call(__MODULE__, {:update, path, entries})
   end
@@ -69,6 +73,10 @@ defmodule Lexical.RemoteControl.Search.Store do
 
   def start_link([%Project{} = project, create_index, refresh_index]) do
     GenServer.start_link(__MODULE__, [project, create_index, refresh_index], name: __MODULE__)
+  end
+
+  def start_link([create_index, refresh_index]) do
+    start_link(Lexical.RemoteControl.get_project(), create_index, refresh_index)
   end
 
   def init([%Project{} = project, create_index, update_index]) do

--- a/apps/remote_control/test/lexical/remote_control/build/error_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/error_test.exs
@@ -10,6 +10,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
   use Patch
 
   setup do
+    start_supervised!(Lexical.RemoteControl.Dispatch)
     start_supervised!(CaptureServer)
     :ok
   end

--- a/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
@@ -1,0 +1,125 @@
+defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
+  alias Lexical.Ast
+  alias Lexical.Document
+  alias Lexical.RemoteControl.Api
+  alias Lexical.RemoteControl.Dispatch.Handlers.Indexing
+  alias Lexical.RemoteControl.Search
+
+  import Api.Messages
+  import Lexical.Test.CodeSigil
+  import Lexical.Test.Fixtures
+
+  use ExUnit.Case
+  use Patch
+
+  setup do
+    project = project()
+    create_index = &Search.Indexer.create_index/1
+    update_index = &Search.Indexer.update_index/2
+
+    start_supervised!({Search.Store, [project, create_index, update_index]})
+    start_supervised!(Document.Store)
+
+    {:ok, state} = Indexing.init([])
+    {:ok, state: state, project: project}
+  end
+
+  def quoted_document(source) do
+    doc = Document.new("file:///file.ex", source, 1)
+    Document.Store.open("file:///file.ex", source, 1)
+    {:ok, quoted} = Ast.from(doc)
+
+    {doc, quoted}
+  end
+
+  def file_quoted_event(document, quoted_ast) do
+    file_quoted(document: document, quoted_ast: quoted_ast)
+  end
+
+  describe "handling file_quoted events" do
+    test "should add new entries to the store", %{state: state} do
+      {doc, quoted} =
+        ~q[
+        defmodule NewModule do
+        end
+      ]
+        |> quoted_document()
+
+      assert {:ok, _} = Indexing.on_event(file_quoted_event(doc, quoted), state)
+
+      assert {:ok, [entry]} = Search.Store.exact("NewModule", [])
+
+      assert entry.subject == NewModule
+    end
+
+    test "should update entries in the store", %{state: state} do
+      {old_doc, old_quoted} = quoted_document("defmodule OldModule do\nend")
+
+      {:ok, _} = Search.Indexer.Quoted.index(old_doc, old_quoted)
+
+      {doc, quoted} =
+        ~q[
+        defmodule UpdatedModule do
+        end
+      ]
+        |> quoted_document()
+
+      assert {:ok, _} = Indexing.on_event(file_quoted_event(doc, quoted), state)
+
+      assert {:ok, [entry]} = Search.Store.exact("UpdatedModule", [])
+      assert entry.subject == UpdatedModule
+      assert {:ok, []} = Search.Store.exact("OldModule", [])
+    end
+
+    test "only updates entries if the version of the document is the same as the version in the document store",
+         %{state: state} do
+      Document.Store.open("file:///file.ex", "defmodule Newer do \nend", 3)
+
+      {doc, quoted} =
+        ~q[
+        defmodule Stale do
+        end
+      ]
+        |> quoted_document()
+
+      assert {:ok, _} = Indexing.on_event(file_quoted_event(doc, quoted), state)
+      assert {:ok, []} = Search.Store.exact("Stale", [])
+    end
+  end
+
+  describe "a file is deleted" do
+    test "its entries should be deleted", %{project: project, state: state} do
+      {doc, quoted} =
+        ~q[
+        defmodule ToDelete do
+        end
+      ]
+        |> quoted_document()
+
+      {:ok, entries} = Search.Indexer.Quoted.index(doc, quoted)
+      Search.Store.update(doc.path, entries)
+      assert {:ok, [_]} = Search.Store.exact("ToDelete", [])
+
+      Indexing.on_event(
+        filesystem_event(project: project, uri: doc.uri, event_type: :deleted),
+        state
+      )
+
+      assert {:ok, []} = Search.Store.exact("ToDelete", [])
+    end
+  end
+
+  describe "a file is created" do
+    test "is a no op", %{project: project, state: state} do
+      spy(Search.Store)
+      spy(Search.Indexer)
+
+      event = filesystem_event(project: project, uri: "file:///another.ex", event_type: :created)
+
+      assert {:ok, _} = Indexing.on_event(event, state)
+
+      assert history(Search.Store) == []
+      assert history(Search.Indexer) == []
+    end
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexing_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexing_test.exs
@@ -1,0 +1,2 @@
+defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexerTest do
+end

--- a/apps/remote_control/test/lexical/remote_control/search/indexer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer_test.exs
@@ -90,7 +90,7 @@ defmodule Lexical.RemoteControl.Search.IndexerTest do
 
       patch(Indexer, :stat, fn path ->
         {ymd, {hour, minute, second}} =
-          Map.get_lazy(path_to_mtime, file_path, &:calendar.local_time/0)
+          Map.get_lazy(path_to_mtime, file_path, &:calendar.universal_time/0)
 
         hms =
           if path == file_path do

--- a/apps/remote_control/test/lexical/remote_control/search/indexer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer_test.exs
@@ -87,19 +87,19 @@ defmodule Lexical.RemoteControl.Search.IndexerTest do
       file_path: file_path
     } do
       path_to_mtime = Map.new(entries, & &1.updated_at)
+      [entry | _] = entries
+      old_mtime = entry.updated_at
 
       patch(Indexer, :stat, fn path ->
         {ymd, {hour, minute, second}} =
           Map.get_lazy(path_to_mtime, file_path, &:calendar.universal_time/0)
 
-        hms =
+        mtime =
           if path == file_path do
-            {hour, minute, second + 1}
+            {ymd, {hour, minute, second + 1}}
           else
-            {hour, minute, second}
+            old_mtime
           end
-
-        mtime = {ymd, hms}
 
         {:ok, %File.Stat{mtime: mtime}}
       end)

--- a/apps/remote_control/test/lexical/remote_control/search/indexer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer_test.exs
@@ -88,7 +88,8 @@ defmodule Lexical.RemoteControl.Search.IndexerTest do
     } do
       path_to_mtime = Map.new(entries, & &1.updated_at)
       [entry | _] = entries
-      old_mtime = entry.updated_at
+      {{year, month, day}, hms} = entry.updated_at
+      old_mtime = {{year - 1, month, day}, hms}
 
       patch(Indexer, :stat, fn path ->
         {ymd, {hour, minute, second}} =

--- a/apps/server/lib/lexical/server.ex
+++ b/apps/server/lib/lexical/server.ex
@@ -12,6 +12,7 @@ defmodule Lexical.Server do
   @server_specific_messages [
     Notifications.DidChange,
     Notifications.DidChangeConfiguration,
+    Notifications.DidChangeWatchedFiles,
     Notifications.DidClose,
     Notifications.DidOpen,
     Notifications.DidSave,


### PR DESCRIPTION
This commit has the following changes:

  1. RemoteControl now emits an event when a document has been quoted.
  2. Added a handler to listen for the above event, and update the index when a newly quoted document is emitted
  3. Wired up workspace file changes so that when a file is created or deleted, it emits an event to RemoteControl
  4. When a filesystem create or delete is detcted by the indexing handler, it is either indexed or its information is removed from the index.

I also had to make Document.Store global. This required moving `fetch` back into the GenServer

After the above changes, I can now edit documents and find module definitions and references via the console.