### PR TITLE
Add `current_project/1` helper function

### DIFF
--- a/apps/server/lib/lexical/server/iex/helpers.ex
+++ b/apps/server/lib/lexical/server/iex/helpers.ex
@@ -113,6 +113,12 @@ defmodule Lexical.Server.IEx.Helpers do
     end)
   end
 
+  def current_project do
+    [prefix, _] = Node.self() |> to_string() |> String.split("@")
+    [_, project_name, entropy] = String.split(prefix, "-")
+    %{ensure_project(project_name) | entropy: entropy}
+  end
+
   def stop_project(project) do
     project
     |> ensure_project()


### PR DESCRIPTION
I found the `bin/debug_shell.sh` is pretty cool, and I want to debug the current editor's project node. with this function, the debug flow would be:

```elixir
~/Code/lexical add-current-project ❯ _build/dev/package/lexical/bin/debug_shell.sh                  
Erlang/OTP 25 [erts-13.2.2.2] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:1] [jit:ns]

Interactive Elixir (1.15.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(manager-lexical-37683@127.0.0.1)1> project = current_project()
%LXical.Project{
  root_uri: "file:///Users/scottming/Code/lexical",
  mix_exs_uri: "file:///Users/scottming/Code/lexical/mix.exs",
  mix_project?: true,
  mix_env: nil,
  mix_target: nil,
  env_variables: %{},
  project_module: nil,
  entropy: "37683"
}
iex(manager-lexical-37683@127.0.0.1)2> complete(project, "demod|")

20:04:21.959 [info] Completion for %LXical.Document.Position{line: 1, character: 6}

20:04:26.663 [info] Local completions are [%LXical.RemoteControl.Completion.Candidate.Macro{argument_names: ["alias", "do_block"], arity: 2, name: "defmodule", origin: "Kernel", type: :macro, visibility: :public, spec: "", metadata: %{}}]

20:04:26.672 [warning] Emitting completions: [#Protocol.Types.Completion.Item<[detail: "", insert_text: "defmodule ${1:File} do\n  $0\nend\n", insert_text_format: :snippet, kind: :class, label: "defmodule (Define a module)", sort_text: "092_defmodule (Define a module)"]>]
[
  #Protocol.Types.Completion.Item<[
    detail: "",
    insert_text: "defmodule ${1:File} do\n  $0\nend\n",
    insert_text_format: :snippet,
    kind: :class,
    label: "defmodule (Define a module)",
    sort_text: "092_defmodule (Define a module)"
  ]>
]
```