### PR TITLE
Entry LSP conversion improvements

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
@@ -1,4 +1,6 @@
 defmodule Lexical.RemoteControl.Search.Indexer.Entry do
+  alias Lexical.Document
+
   @type entry_type :: :module
   @type subject :: String.t()
   @type entry_subtype :: :reference | :definition
@@ -11,26 +13,30 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
   defstruct [
     :application,
     :elixir_version,
+    :end_line,
     :erlang_version,
-    :range,
-    :updated_at,
-    :subject,
     :parent,
     :path,
+    :range,
     :ref,
+    :start_line,
+    :subject,
     :subtype,
-    :type
+    :type,
+    :updated_at
   ]
 
   @type t :: %__MODULE__{
           application: module(),
           elixir_version: version(),
+          end_line: Document.Line.t(),
           erlang_version: version(),
-          subject: subject(),
           parent: entry_reference(),
           path: Path.t(),
-          range: Lexical.Document.Range.t(),
+          range: Document.Range.t(),
           ref: entry_reference(),
+          start_line: Document.Line.t(),
+          subject: subject(),
           subtype: entry_subtype(),
           type: entry_type(),
           updated_at: :calendar.datetime()
@@ -41,26 +47,30 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
 
   use StructAccess
 
-  def reference(path, ref, parent, subject, type, range, application) do
-    new(path, ref, parent, subject, type, :reference, range, application)
+  def reference(%Document{} = document, ref, parent, subject, type, range, application) do
+    new(document, ref, parent, subject, type, :reference, range, application)
   end
 
-  def definition(path, ref, parent, subject, type, range, application) do
-    new(path, ref, parent, subject, type, :definition, range, application)
+  def definition(%Document{} = document, ref, parent, subject, type, range, application) do
+    new(document, ref, parent, subject, type, :definition, range, application)
   end
 
-  defp new(path, ref, parent, subject, type, subtype, range, application) do
+  defp new(%Document{} = document, ref, parent, subject, type, subtype, range, application) do
     versions = Versions.current()
+    {:ok, start_line} = Document.fetch_line_at(document, range.start.line)
+    {:ok, end_line} = Document.fetch_line_at(document, range.end.line)
 
     %__MODULE__{
       application: application,
       elixir_version: versions.elixir,
+      end_line: end_line,
       erlang_version: versions.erlang,
-      subject: subject,
       parent: parent,
-      path: path,
+      path: document.path,
       range: range,
       ref: ref,
+      start_line: start_line,
+      subject: subject,
       subtype: subtype,
       type: type,
       updated_at: timestamp()

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module.ex
@@ -25,7 +25,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Module do
 
     entry =
       Entry.definition(
-        reducer.document.path,
+        reducer.document,
         block.ref,
         block.parent_ref,
         aliased_module,
@@ -53,7 +53,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Module do
 
         entry =
           Entry.reference(
-            reducer.document.path,
+            reducer.document,
             make_ref(),
             current_block.ref,
             module,
@@ -80,7 +80,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Module do
 
         entry =
           Entry.reference(
-            reducer.document.path,
+            reducer.document,
             make_ref(),
             current_block.ref,
             module,

--- a/projects/lexical_shared/test/lexical/document/lines_test.exs
+++ b/projects/lexical_shared/test/lexical/document/lines_test.exs
@@ -64,4 +64,42 @@ defmodule Lexical.Document.LinesTest do
       assert Lines.size(document) == line_count
     end
   end
+
+  def make_line(text, line_number, ending \\ "\n") do
+    line(text: text, line_number: line_number, ending: ending)
+  end
+
+  describe "sparse" do
+    test "works with size/1" do
+      lines = Lines.sparse([make_line("hello", 20)])
+      assert Lines.size(lines) == 20
+    end
+
+    test "works with to_string/1" do
+      lines =
+        Lines.sparse([
+          line(line_number: 2, text: "hello", ending: "\n"),
+          line(line_number: 5, text: "goodbye", ending: "\n")
+        ])
+
+      expected = """
+
+      hello
+
+
+      goodbye
+      """
+
+      assert Lines.to_string(lines) == expected
+    end
+
+    test "works with fetch_line" do
+      lines = Lines.sparse([make_line("first", 2), make_line("second", 4)])
+      assert {:ok, line(text: "", line_number: 1)} = Lines.fetch_line(lines, 1)
+      assert {:ok, line(text: "first", line_number: 2)} = Lines.fetch_line(lines, 2)
+      assert {:ok, line(text: "", line_number: 3)} = Lines.fetch_line(lines, 3)
+      assert {:ok, line(text: "second", line_number: 4)} = Lines.fetch_line(lines, 4)
+      assert :error = Lines.fetch_line(lines, 5)
+    end
+  end
 end


### PR DESCRIPTION
While integrating indexing into the language server, I encountered a pretty severe performance issue. Find references can return a _lot_ of things, and all of those references include ranges that need to be converted into LSP form before we can emit them. This poses a problem, we will likely need to open up dozens (possibly hundreds) of files in order to do the conversion. This will cause a massive amount of File I/O, and just can't work.

However, if we can store the lines along with the entries, then we can create a sparse Document.Lines document and use _that_ in the conversion step (which is already supported in conversions.ex), then we won't need to do _any_ file I/O at all.

This change introduces a `sparse` constructor for Document.Lines and changes the `Entry` constructors to take documents rather than paths for their first arguments so we can pull out the lines in question.