### PR TITLE
Fixed index store test failure

### DIFF
--- a/apps/remote_control/test/lexical/remote_control/search/store_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store_test.exs
@@ -12,14 +12,25 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
 
   setup do
     project = project()
+    # These test cases require an clean slate going into them
+    # so we should remove the indexes once when the tests start,
+    # and again when tests end, so the next test has a clean slate.
+    # Removing the index at the end will also let other test cases
+    # start with a clean slate.
+    delete_indexes(project)
 
     on_exit(fn ->
-      project
-      |> Store.State.index_path()
-      |> File.rm()
+      delete_indexes(project)
     end)
 
     {:ok, project: project}
+  end
+
+  def delete_indexes(project) do
+    project
+    |> Store.State.index_path()
+    |> Path.dirname()
+    |> File.rm_rf()
   end
 
   def default_create(_project) do


### PR DESCRIPTION
Depending on what was run prior, the store test suite might encounter a previously built index, which would make the create index tests fail. The change here deletes the index in a setup_all block, so the test suite starts with an empty index, and keeps the on_exit handler that deletes the index at the end of each test.