### PR TITLE
Add Support for `Renaming module`

### DIFF
--- a/apps/common/lib/lexical/ast/module.ex
+++ b/apps/common/lib/lexical/ast/module.ex
@@ -3,9 +3,12 @@ defmodule Lexical.Ast.Module do
   Module utilities
   """
 
+  # alias Lexical.Document.Range
+
   @doc """
   Formats a module name as a string.
   """
+
   @spec name(module() | Macro.t() | String.t()) :: String.t()
   def name([{:__MODULE__, _, _} | rest]) do
     [__MODULE__ | rest]
@@ -27,5 +30,17 @@ defmodule Lexical.Ast.Module do
     module_name
     |> inspect()
     |> name()
+  end
+
+  def local_module_name(entity) when is_atom(entity) do
+    entity
+    |> inspect()
+    |> local_module_name()
+  end
+
+  def local_module_name(entity) when is_binary(entity) do
+    entity
+    |> String.split(".")
+    |> List.last()
   end
 end

--- a/apps/protocol/lib/generated/lexical/protocol/types/prepare_rename/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/prepare_rename/params.ex
@@ -1,0 +1,10 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.PrepareRename.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+
+  deftype position: Types.Position,
+          text_document: Types.TextDocument.Identifier,
+          work_done_token: optional(Types.Progress.Token)
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/prepare_rename_result.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/prepare_rename_result.ex
@@ -1,0 +1,23 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.PrepareRenameResult do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+
+  defmodule PrepareRenameResult do
+    use Proto
+    deftype placeholder: string(), range: Types.Range
+  end
+
+  defmodule PrepareRenameResult1 do
+    use Proto
+    deftype default_behavior: boolean()
+  end
+
+  use Proto
+
+  defalias one_of([
+             Types.Range,
+             Lexical.Protocol.Types.PrepareRenameResult.PrepareRenameResult,
+             Lexical.Protocol.Types.PrepareRenameResult.PrepareRenameResult1
+           ])
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/rename/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/rename/params.ex
@@ -1,0 +1,11 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.Rename.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+
+  deftype new_name: string(),
+          position: Types.Position,
+          text_document: Types.TextDocument.Identifier,
+          work_done_token: optional(Types.Progress.Token)
+end

--- a/apps/protocol/lib/lexical/protocol/requests.ex
+++ b/apps/protocol/lib/lexical/protocol/requests.ex
@@ -76,6 +76,12 @@ defmodule Lexical.Protocol.Requests do
     defrequest "workspace/executeCommand", Types.ExecuteCommand.Params
   end
 
+  defmodule Rename do
+    use Proto
+
+    defrequest "textDocument/rename", Types.Rename.Params
+  end
+
   # Server -> Client requests
 
   defmodule RegisterCapability do

--- a/apps/protocol/lib/lexical/protocol/requests.ex
+++ b/apps/protocol/lib/lexical/protocol/requests.ex
@@ -76,6 +76,12 @@ defmodule Lexical.Protocol.Requests do
     defrequest "workspace/executeCommand", Types.ExecuteCommand.Params
   end
 
+  defmodule PrepareRename do
+    use Proto
+
+    defrequest "textDocument/prepareRename", Types.PrepareRename.Params
+  end
+
   defmodule Rename do
     use Proto
 

--- a/apps/protocol/lib/lexical/protocol/responses.ex
+++ b/apps/protocol/lib/lexical/protocol/responses.ex
@@ -75,5 +75,11 @@ defmodule Lexical.Protocol.Responses do
     defresponse optional(Types.Message.ActionItem)
   end
 
+  defmodule Rename do
+    use Proto
+
+    defresponse optional(Types.Workspace.Edit)
+  end
+
   use Typespecs, for: :responses
 end

--- a/apps/protocol/lib/lexical/protocol/responses.ex
+++ b/apps/protocol/lib/lexical/protocol/responses.ex
@@ -75,6 +75,12 @@ defmodule Lexical.Protocol.Responses do
     defresponse optional(Types.Message.ActionItem)
   end
 
+  defmodule PrepareRename do
+    use Proto
+
+    defresponse Types.PrepareRenameResult
+  end
+
   defmodule Rename do
     use Proto
 

--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -47,12 +47,12 @@ defmodule Lexical.RemoteControl.Api do
     RemoteControl.call(project, CodeAction, :for_range, [document, range, diagnostics, kinds])
   end
 
-  def rename_supported?(
+  def prepare_rename(
         %Project{} = project,
         %Analysis{} = analysis,
         %Position{} = position
       ) do
-    RemoteControl.call(project, CodeIntelligence.Rename, :supported?, [analysis, position])
+    RemoteControl.call(project, CodeIntelligence.Rename, :prepare, [analysis, position])
   end
 
   def rename(%Project{} = project, %Analysis{} = analysis, %Position{} = position, new_name) do

--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -52,11 +52,11 @@ defmodule Lexical.RemoteControl.Api do
         %Analysis{} = analysis,
         %Position{} = position
       ) do
-    RemoteControl.call(project, CodeIntelligence.Rename, :prepare, [analysis, position])
+    RemoteControl.call(project, CodeIntelligence.Rename.Module, :prepare, [analysis, position])
   end
 
   def rename(%Project{} = project, %Analysis{} = analysis, %Position{} = position, new_name) do
-    RemoteControl.call(project, CodeIntelligence.Rename, :rename, [
+    RemoteControl.call(project, CodeIntelligence.Rename.Module, :rename, [
       analysis,
       position,
       new_name

--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -47,6 +47,14 @@ defmodule Lexical.RemoteControl.Api do
     RemoteControl.call(project, CodeAction, :for_range, [document, range, diagnostics, kinds])
   end
 
+  def rename(%Project{} = project, %Analysis{} = analysis, %Position{} = position, new_name) do
+    RemoteControl.call(project, CodeIntelligence.Rename, :rename, [
+      analysis,
+      position,
+      new_name
+    ])
+  end
+
   def complete(%Project{} = project, %Document{} = document, %Position{} = position) do
     document_string = Document.to_string(document)
     complete(project, document_string, position)

--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -47,6 +47,14 @@ defmodule Lexical.RemoteControl.Api do
     RemoteControl.call(project, CodeAction, :for_range, [document, range, diagnostics, kinds])
   end
 
+  def rename_supported?(
+        %Project{} = project,
+        %Analysis{} = analysis,
+        %Position{} = position
+      ) do
+    RemoteControl.call(project, CodeIntelligence.Rename, :supported?, [analysis, position])
+  end
+
   def rename(%Project{} = project, %Analysis{} = analysis, %Position{} = position, new_name) do
     RemoteControl.call(project, CodeIntelligence.Rename, :rename, [
       analysis,

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/references.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/references.ex
@@ -34,21 +34,18 @@ defmodule Lexical.RemoteControl.CodeIntelligence.References do
   end
 
   defp module_references(module, include_definitions?) do
-    with {:ok, references} <- Store.exact(module, type: :module, subtype: :reference) do
-      entities = maybe_fetch_module_definitions(module, include_definitions?) ++ references
-      locations = Enum.map(entities, &to_location/1)
-      {:ok, locations}
-    end
+    references = Store.exact(module, type: :module, subtype: :reference)
+    entities = maybe_fetch_module_definitions(module, include_definitions?) ++ references
+    locations = Enum.map(entities, &to_location/1)
+    {:ok, locations}
   end
 
   defp function_references(module, function_name, arity, include_definitions) do
     subject = Formats.mfa(module, function_name, arity)
-
-    with {:ok, references} <- Store.exact(subject, type: :function, subtype: :reference) do
-      entities = maybe_fetch_function_definitions(subject, include_definitions) ++ references
-      locations = Enum.map(entities, &to_location/1)
-      {:ok, locations}
-    end
+    references = Store.exact(subject, type: :function, subtype: :reference)
+    entities = maybe_fetch_function_definitions(subject, include_definitions) ++ references
+    locations = Enum.map(entities, &to_location/1)
+    {:ok, locations}
   end
 
   defp to_location(%Entry{} = entry) do
@@ -57,19 +54,13 @@ defmodule Lexical.RemoteControl.CodeIntelligence.References do
   end
 
   defp maybe_fetch_function_definitions(subject, true) do
-    case Store.exact(subject, type: :function, subtype: :definition) do
-      {:ok, definitions} -> definitions
-      _ -> []
-    end
+    Store.exact(subject, type: :function, subtype: :definition)
   end
 
   defp maybe_fetch_function_definitions(_, false), do: []
 
   defp maybe_fetch_module_definitions(module, true) do
-    case Store.exact(module, type: :module, subtype: :definition) do
-      {:ok, definitions} -> definitions
-      _ -> []
-    end
+    Store.exact(module, type: :module, subtype: :definition)
   end
 
   defp maybe_fetch_module_definitions(_module, false) do

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/rename.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/rename.ex
@@ -1,0 +1,178 @@
+defmodule Lexical.RemoteControl.CodeIntelligence.Rename do
+  alias Lexical.Ast
+  alias Lexical.Ast.Analysis
+  alias Lexical.Document
+  alias Lexical.Document.Edit
+  alias Lexical.Document.Line
+  alias Lexical.Document.Position
+  alias Lexical.RemoteControl.CodeIntelligence.Entity
+  alias Lexical.RemoteControl.Search.Store
+  require Logger
+
+  import Line
+
+  @spec rename(Analysis.t(), Position.t(), String.t()) ::
+          {:ok, %{Lexical.uri() => [Edit.t()]}} | {:error, term()}
+  def rename(%Analysis{} = analysis, %Position{} = position, new_name) do
+    with {:ok, entity, range} <- resolve_module(analysis, position) do
+      edits =
+        analysis.document
+        |> search_related_candidates(position, entity, range)
+        |> to_uri_with_changes(new_name)
+
+      {:ok, edits}
+    end
+  end
+
+  defp resolve_module(analysis, position) do
+    case Entity.resolve(analysis, position) do
+      {:ok, {module_or_struct, module}, range} when module_or_struct in [:struct, :module] ->
+        {:ok, module, range}
+
+      {:ok, other, _} ->
+        {:error, {:unsupported_entity, other}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp search_related_candidates(document, position, entity, range) do
+    cursor_entity_string = cursor_entity_string(range)
+
+    entities =
+      exacts(entity, cursor_entity_string)
+
+    # Users won't always want to rename descendants of a module.
+    # For instance, when there are no more submodules after the cursor.
+    # like: `defmodule TopLevel.Mo|dule do`
+    # in most cases, users only want to rename the module itself.
+    #
+    # However, there's an exception when the cursor is in the middle,
+    # such as `Top.Mo|dule.ChildModule`. If we rename it to `Top.Renamed.Child`,
+    # it would be natural to also rename `Module.ChildModule` to `Renamed.Child`.
+    if at_the_middle_of_module?(document, position, range) do
+      entities ++ descendants(entity, cursor_entity_string)
+    else
+      entities
+    end
+  end
+
+  defp at_the_middle_of_module?(document, position, range) do
+    range_text = range_text(range)
+
+    case Ast.surround_context(document, position) do
+      {:ok, %{context: {:alias, alias}}} ->
+        String.length(range_text) < length(alias)
+
+      _ ->
+        false
+    end
+  end
+
+  defp cursor_entity_string(range) do
+    # Parent.|Module -> Module
+    range
+    |> range_text()
+    |> String.split(".")
+    |> List.last()
+  end
+
+  defp descendants(entity, cursor_entity_string) do
+    entity_string = inspect(entity)
+    prefix = "#{entity_string}."
+
+    case Store.prefix(prefix, subject: [:definition, :reference]) do
+      {:ok, results} ->
+        filtered =
+          results
+          |> Enum.filter(fn result ->
+            range_text = range_text(result.range)
+            String.contains?(range_text, cursor_entity_string)
+          end)
+          |> adjust_range(entity)
+
+        filtered
+
+      _ ->
+        []
+    end
+  end
+
+  defp exacts(entity, cursor_entity_string) do
+    entity_string = inspect(entity)
+
+    case Store.exact(entity_string, subject: [:definition, :reference]) do
+      {:ok, results} ->
+        filtered =
+          Enum.filter(results, fn result ->
+            range_text = range_text(result.range)
+            String.contains?(range_text, cursor_entity_string)
+          end)
+
+        filtered
+
+      _ ->
+        []
+    end
+  end
+
+  defp adjust_range(entries, entity) do
+    for entry <- entries do
+      location = {entry.range.start.line, entry.range.start.character}
+      uri = Document.Path.ensure_uri(entry.path)
+
+      case resolve_entity_range(uri, location, entity) do
+        {:ok, range} ->
+          %{entry | range: range}
+
+        :error ->
+          :error
+      end
+    end
+    |> Enum.reject(&(&1 == :error))
+  end
+
+  defp resolve_entity_range(uri, location, entity) do
+    {line, character} = location
+
+    with {:ok, document} <- Document.Store.open_temporary(uri),
+         position = Position.new(document, line, character),
+         analysis = Ast.analyze(document),
+         {:ok, result, range} <- resolve_module(analysis, position) do
+      if result == entity do
+        {:ok, range}
+      else
+        result_length = result |> inspect() |> String.length()
+        # Move the cursor the next part:
+        # `|Parent.Next.Target.Child` -> 'Parent.|Next.Target.Child' -> 'Parent.Next.|Target.Child'
+        resolve_entity_range(uri, {line, character + result_length + 1}, entity)
+      end
+    else
+      _ ->
+        Logger.error("Failed to find entity range for #{inspect(uri)} at #{inspect(location)}")
+        :error
+    end
+  end
+
+  defp to_uri_with_changes(results, new_name) do
+    Enum.group_by(
+      results,
+      fn result -> Document.Path.ensure_uri(result.path) end,
+      fn result ->
+        cursor_entity_length = result.range |> cursor_entity_string() |> String.length()
+        # e.g: `Parent.|ToBeRenameModule`, we need the start position of `ToBeRenameModule`
+        start_character = result.range.end.character - cursor_entity_length
+        start_position = %{result.range.start | character: start_character}
+
+        new_range = %{result.range | start: start_position}
+        Edit.new(new_name, new_range)
+      end
+    )
+  end
+
+  defp range_text(range) do
+    line(text: text) = range.end.context_line
+    String.slice(text, range.start.character - 1, range.end.character - range.start.character)
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/rename.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/rename.ex
@@ -24,14 +24,15 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Rename do
     end
   end
 
-  @spec supported?(Analysis.t(), Position.t()) :: boolean()
-  def supported?(%Analysis{} = analysis, %Position{} = position) do
+  @spec prepare(Analysis.t(), Position.t()) :: {:ok, String.t(), Range.t()} | {:error, term()}
+  def prepare(%Analysis{} = analysis, %Position{} = position) do
     case resolve_module(analysis, position) do
-      {:ok, _, _} ->
-        true
+      {:ok, _, range} ->
+        cursor_entity = cursor_entity_string(range)
+        {:ok, cursor_entity, range}
 
       {:error, _} ->
-        false
+        {:error, :unsupported_entity}
     end
   end
 

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/rename.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/rename.ex
@@ -94,7 +94,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Rename do
     prefix = "#{entity_string}."
 
     prefix
-    |> Store.prefix(subject: [:definition, :reference])
+    |> Store.prefix([])
     |> Enum.filter(&(entry_matching?(&1, cursor_entity_string) and has_dots_in_range?(&1)))
     |> adjust_range(entity)
   end
@@ -103,7 +103,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Rename do
     entity_string = inspect(entity)
 
     entity_string
-    |> Store.exact(subject: [:definition, :reference])
+    |> Store.exact([])
     |> Enum.filter(&entry_matching?(&1, cursor_entity_string))
   end
 
@@ -156,7 +156,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Rename do
   defp to_edits_by_uri(results, new_name) do
     Enum.group_by(
       results,
-      fn result -> Document.Path.ensure_uri(result.path) end,
+      &Document.Path.ensure_uri(&1.path),
       fn result ->
         cursor_entity_length = result.range |> cursor_entity_string() |> String.length()
         # e.g: `Parent.|ToBeRenameModule`, we need the start position of `ToBeRenameModule`

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/rename.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/rename.ex
@@ -110,8 +110,8 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Rename do
   end
 
   defp resolve_entity_range(uri, position, entity) do
-    with {:ok, document} <- Document.Store.open_temporary(uri),
-         analysis = Ast.analyze(document),
+    with {:ok, _} <- Document.Store.open_temporary(uri),
+         {:ok, document, analysis} <- Document.Store.fetch(uri, :analysis),
          {:ok, result, range} <- resolve_module(analysis, position) do
       if result == entity do
         {:ok, range}

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/rename.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/rename.ex
@@ -24,6 +24,17 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Rename do
     end
   end
 
+  @spec supported?(Analysis.t(), Position.t()) :: boolean()
+  def supported?(%Analysis{} = analysis, %Position{} = position) do
+    case resolve_module(analysis, position) do
+      {:ok, _, _} ->
+        true
+
+      {:error, _} ->
+        false
+    end
+  end
+
   defp resolve_module(analysis, position) do
     case Entity.resolve(analysis, position) do
       {:ok, {module_or_struct, module}, range} when module_or_struct in [:struct, :module] ->

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/rename/module.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/rename/module.ex
@@ -1,4 +1,4 @@
-defmodule Lexical.RemoteControl.CodeIntelligence.Rename do
+defmodule Lexical.RemoteControl.CodeIntelligence.Rename.Module do
   alias Lexical.Ast
   alias Lexical.Ast.Analysis
   alias Lexical.Document

--- a/apps/remote_control/lib/lexical/remote_control/search/store.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store.ex
@@ -60,6 +60,10 @@ defmodule Lexical.RemoteControl.Search.Store do
     GenServer.call(__MODULE__, {:exact, subject, constraints})
   end
 
+  def prefix(prefix, constraints) do
+    GenServer.call(__MODULE__, {:prefix, prefix, constraints})
+  end
+
   def fuzzy(subject, constraints) do
     GenServer.call(__MODULE__, {:fuzzy, subject, constraints})
   end
@@ -170,6 +174,10 @@ defmodule Lexical.RemoteControl.Search.Store do
 
   def handle_call({:exact, subject, constraints}, _from, {ref, %State{} = state}) do
     {:reply, State.exact(state, subject, constraints), {ref, state}}
+  end
+
+  def handle_call({:prefix, prefix, constraints}, _from, {ref, %State{} = state}) do
+    {:reply, State.prefix(state, prefix, constraints), {ref, state}}
   end
 
   def handle_call({:fuzzy, subject, constraints}, _from, {ref, %State{} = state}) do

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backend.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backend.ex
@@ -18,6 +18,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backend do
 
   @type wildcard :: :_
   @type subject_query :: Entry.subject() | wildcard()
+  @type prefix_query :: Entry.subject() | wildcard()
   @type type_query :: Entry.entry_type() | wildcard()
   @type subtype_query :: Entry.entry_subtype() | wildcard()
 
@@ -73,6 +74,11 @@ defmodule Lexical.RemoteControl.Search.Store.Backend do
   Finds all entries
   """
   @callback find_by_subject(subject_query(), type_query(), subtype_query()) :: [Entry.t()]
+
+  @doc """
+  Finds all entries whose subject starts with the given prefix
+  """
+  @callback find_by_prefix(prefix_query(), type_query(), subtype_query()) :: [Entry.t()]
 
   @doc """
   Finds entries whose ref attribute is in the given list

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
@@ -69,6 +69,11 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
   end
 
   @impl Backend
+  def find_by_prefix(prefix, type, subtype) do
+    GenServer.call(genserver_name(), {:find_by_prefix, [prefix, type, subtype]})
+  end
+
+  @impl Backend
   def find_by_refs(references, type, subtype) do
     GenServer.call(genserver_name(), {:find_by_references, [references, type, subtype]})
   end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v1.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v1.ex
@@ -25,6 +25,14 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1 do
     :path
   ]
 
+  defkey :by_prefix, [
+    :prefix,
+    :type,
+    :subtype,
+    :elixir_version,
+    :erlang_version
+  ]
+
   defkey :by_path, [:path]
 
   def migrate(entries) do
@@ -70,9 +78,18 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1 do
         erlang_version: entry.erlang_version
       )
 
+    prefix_key =
+      by_prefix(
+        prefix: to_prefix(entry.subject),
+        type: entry.type,
+        subtype: entry.subtype,
+        elixir_version: entry.elixir_version,
+        erlang_version: entry.erlang_version
+      )
+
     path_key = by_path(path: entry.path)
 
-    [{subject_key, entry}, {id_key, entry}, {path_key, id_key}]
+    [{subject_key, entry}, {prefix_key, entry}, {id_key, entry}, {path_key, id_key}]
   end
 
   # This case will handle any namespaced entries
@@ -92,4 +109,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1 do
   defp to_subject(:_), do: :_
   defp to_subject(atom) when is_atom(atom), do: inspect(atom)
   defp to_subject(other), do: to_string(other)
+
+  defp to_prefix(atom) when is_atom(atom), do: atom |> inspect() |> to_charlist()
+  defp to_prefix(other), do: to_charlist(other)
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v1.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v1.ex
@@ -8,8 +8,6 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1 do
   Finally, entries are stored by their reference, which powers direct lookups, which are used in fuzzy matching.
 
   """
-
-  alias Lexical.RemoteControl.Search.Indexer.Entry
   alias Lexical.RemoteControl.Search.Store.Backends.Ets.Schema
 
   use Schema, version: 1
@@ -28,68 +26,6 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1 do
   defkey :by_path, [:path]
 
   def migrate(entries) do
-    migrated =
-      entries
-      |> Stream.filter(fn
-        {_, %_{elixir_version: _, erlang_version: _, type: _, subtype: _, ref: _}} -> true
-        _ -> false
-      end)
-      |> Stream.map(fn {_, entry} -> entry end)
-      |> entries_to_rows()
-
-    {:ok, migrated}
+    {:ok, entries}
   end
-
-  @spec entries_to_rows(Enumerable.t(Entry.t())) :: [tuple()]
-  def entries_to_rows(entries) do
-    entries
-    |> Stream.flat_map(&to_rows(&1))
-    |> Enum.reduce(%{}, fn {key, value}, acc ->
-      Map.update(acc, key, [value], fn old_values -> [value | old_values] end)
-    end)
-    |> Enum.to_list()
-  end
-
-  def to_rows(%Entry{} = entry) do
-    subject_key =
-      by_subject(
-        elixir_version: entry.elixir_version,
-        erlang_version: entry.erlang_version,
-        subject: to_subject(entry.subject),
-        type: entry.type,
-        subtype: entry.subtype,
-        path: entry.path
-      )
-
-    id_key =
-      by_id(
-        id: entry.ref,
-        type: entry.type,
-        subtype: entry.subtype,
-        elixir_version: entry.elixir_version,
-        erlang_version: entry.erlang_version
-      )
-
-    path_key = by_path(path: entry.path)
-
-    [{subject_key, entry}, {id_key, entry}, {path_key, id_key}]
-  end
-
-  # This case will handle any namespaced entries
-  def to_rows(%{elixir_version: _, erlang_version: _, type: _, subtype: _, ref: _} = entry) do
-    map = Map.delete(entry, :__struct__)
-
-    Entry
-    |> struct(map)
-    |> to_rows()
-  end
-
-  def table_options do
-    [:named_table, :ordered_set]
-  end
-
-  defp to_subject(binary) when is_binary(binary), do: binary
-  defp to_subject(:_), do: :_
-  defp to_subject(atom) when is_atom(atom), do: inspect(atom)
-  defp to_subject(other), do: to_string(other)
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v1.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v1.ex
@@ -25,14 +25,6 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1 do
     :path
   ]
 
-  defkey :by_prefix, [
-    :prefix,
-    :type,
-    :subtype,
-    :elixir_version,
-    :erlang_version
-  ]
-
   defkey :by_path, [:path]
 
   def migrate(entries) do
@@ -78,18 +70,9 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1 do
         erlang_version: entry.erlang_version
       )
 
-    prefix_key =
-      by_prefix(
-        prefix: to_prefix(entry.subject),
-        type: entry.type,
-        subtype: entry.subtype,
-        elixir_version: entry.elixir_version,
-        erlang_version: entry.erlang_version
-      )
-
     path_key = by_path(path: entry.path)
 
-    [{subject_key, entry}, {prefix_key, entry}, {id_key, entry}, {path_key, id_key}]
+    [{subject_key, entry}, {id_key, entry}, {path_key, id_key}]
   end
 
   # This case will handle any namespaced entries
@@ -109,7 +92,4 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1 do
   defp to_subject(:_), do: :_
   defp to_subject(atom) when is_atom(atom), do: inspect(atom)
   defp to_subject(other), do: to_string(other)
-
-  defp to_prefix(atom) when is_atom(atom), do: atom |> inspect() |> to_charlist()
-  defp to_prefix(other), do: to_charlist(other)
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v2.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v2.ex
@@ -1,8 +1,9 @@
 defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V2 do
+  alias Lexical.RemoteControl.Search.Indexer.Entry
   alias Lexical.RemoteControl.Search.Store.Backends.Ets.Schema
   alias Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1
 
-  import V1, only: [query_by_subject: 1]
+  import V1, only: [query_by_subject: 1, by_id: 1, by_path: 1]
 
   use Schema, version: 2
 
@@ -18,32 +19,98 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V2 do
   def migrate(entries) do
     migrated =
       entries
-      |> Stream.map(fn
-        {query_by_subject(
-           subject: subject,
+      |> migrate_v0_to_v2()
+      |> migrate_v1_to_v2()
+
+    {:ok, migrated}
+  end
+
+  defp migrate_v1_to_v2(entries) do
+    entries
+    |> Stream.map(fn
+      {query_by_subject(
+         subject: subject,
+         type: type,
+         subtype: subtype,
+         elixir_version: elixir_version,
+         erlang_version: erlang_version,
+         path: path
+       ), v} ->
+        {query_by_subject_prefix(
+           subject: subject_to_charlist(subject),
            type: type,
            subtype: subtype,
            elixir_version: elixir_version,
            erlang_version: erlang_version,
            path: path
-         ), v} ->
-          {query_by_subject_prefix(
-             subject: subject_to_charlist(subject),
-             type: type,
-             subtype: subtype,
-             elixir_version: elixir_version,
-             erlang_version: erlang_version,
-             path: path
-           ), v}
+         ), v}
 
-        other ->
-          other
-      end)
-      |> Enum.to_list()
-
-    {:ok, migrated}
+      other ->
+        other
+    end)
+    |> Enum.to_list()
   end
 
+  defp migrate_v0_to_v2(entries) do
+    entries
+    |> Stream.filter(fn
+      {_, %_{elixir_version: _, erlang_version: _, type: _, subtype: _, ref: _}} -> true
+      _ -> false
+    end)
+    |> Stream.map(fn {_, entry} -> entry end)
+    |> entries_to_rows()
+  end
+
+  @spec entries_to_rows(Enumerable.t(Entry.t())) :: [tuple()]
+  def entries_to_rows(entries) do
+    entries
+    |> Stream.flat_map(&to_rows(&1))
+    |> Enum.reduce(%{}, fn {key, value}, acc ->
+      Map.update(acc, key, [value], fn old_values -> [value | old_values] end)
+    end)
+    |> Enum.to_list()
+  end
+
+  def to_rows(%Entry{} = entry) do
+    subject_prefix_key =
+      by_subject_prefix(
+        elixir_version: entry.elixir_version,
+        erlang_version: entry.erlang_version,
+        subject: subject_to_charlist(entry.subject),
+        type: entry.type,
+        subtype: entry.subtype,
+        path: entry.path
+      )
+
+    id_key =
+      by_id(
+        id: entry.ref,
+        type: entry.type,
+        subtype: entry.subtype,
+        elixir_version: entry.elixir_version,
+        erlang_version: entry.erlang_version
+      )
+
+    path_key = by_path(path: entry.path)
+
+    [{subject_prefix_key, entry}, {id_key, entry}, {path_key, id_key}]
+  end
+
+  # This case will handle any namespaced entries
+  def to_rows(%{elixir_version: _, erlang_version: _, type: _, subtype: _, ref: _} = entry) do
+    map = Map.delete(entry, :__struct__)
+
+    Entry
+    |> struct(map)
+    |> to_rows()
+  end
+
+  def table_options do
+    [:named_table, :ordered_set]
+  end
+
+  def subject_to_charlist(charlist) when is_list(charlist), do: charlist
+  def subject_to_charlist(:_), do: :_
   def subject_to_charlist(atom) when is_atom(atom), do: atom |> inspect() |> to_charlist()
   def subject_to_charlist(other), do: to_charlist(other)
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v2.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v2.ex
@@ -1,0 +1,49 @@
+defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V2 do
+  alias Lexical.RemoteControl.Search.Store.Backends.Ets.Schema
+  alias Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1
+
+  import V1, only: [query_by_subject: 1]
+
+  use Schema, version: 2
+
+  defkey :by_subject_prefix, [
+    :subject,
+    :type,
+    :subtype,
+    :elixir_version,
+    :erlang_version,
+    :path
+  ]
+
+  def migrate(entries) do
+    migrated =
+      entries
+      |> Stream.map(fn
+        {query_by_subject(
+           subject: subject,
+           type: type,
+           subtype: subtype,
+           elixir_version: elixir_version,
+           erlang_version: erlang_version,
+           path: path
+         ), v} ->
+          {query_by_subject_prefix(
+             subject: subject_to_charlist(subject),
+             type: type,
+             subtype: subtype,
+             elixir_version: elixir_version,
+             erlang_version: erlang_version,
+             path: path
+           ), v}
+
+        other ->
+          other
+      end)
+      |> Enum.to_list()
+
+    {:ok, migrated}
+  end
+
+  def subject_to_charlist(atom) when is_atom(atom), do: atom |> inspect() |> to_charlist()
+  def subject_to_charlist(other), do: to_charlist(other)
+end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
@@ -53,7 +53,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
   end
 
   def insert(%__MODULE__{leader?: true} = state, entries) do
-    rows = Schemas.V1.entries_to_rows(entries)
+    rows = Schemas.V2.entries_to_rows(entries)
     true = :ets.insert(state.table_name, rows)
     :ok
   end
@@ -111,7 +111,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
   end
 
   def replace_all(%__MODULE__{leader?: true} = state, entries) do
-    rows = Schemas.V1.entries_to_rows(entries)
+    rows = Schemas.V2.entries_to_rows(entries)
 
     with true <- :ets.delete_all_objects(state.table_name),
          true <- :ets.insert(state.table_name, rows) do

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
@@ -166,6 +166,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
   defp to_subject(atom) when is_atom(atom), do: inspect(atom)
   defp to_subject(other), do: to_string(other)
 
+  @dialyzer {:nowarn_function, to_prefix: 1}
+
   defp to_prefix(prefix) when is_binary(prefix) do
     [last_char | others] = prefix |> String.to_charlist() |> Enum.reverse()
     others |> Enum.reverse() |> Enum.concat([last_char | :_])

--- a/apps/remote_control/lib/lexical/remote_control/search/store/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/state.ex
@@ -82,6 +82,13 @@ defmodule Lexical.RemoteControl.Search.Store.State do
     {:ok, results}
   end
 
+  def prefix(%__MODULE__{} = state, prefix, constraints) do
+    type = Keyword.get(constraints, :type, :_)
+    subtype = Keyword.get(constraints, :subtype, :_)
+    results = state.backend.find_by_prefix(prefix, type, subtype)
+    {:ok, results}
+  end
+
   def fuzzy(%__MODULE__{} = state, subject, constraints) do
     case Fuzzy.match(state.fuzzy, subject) do
       [] ->

--- a/apps/remote_control/lib/lexical/remote_control/search/store/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/state.ex
@@ -78,26 +78,24 @@ defmodule Lexical.RemoteControl.Search.Store.State do
   def exact(%__MODULE__{} = state, subject, constraints) do
     type = Keyword.get(constraints, :type, :_)
     subtype = Keyword.get(constraints, :subtype, :_)
-    results = state.backend.find_by_subject(subject, type, subtype)
-    {:ok, results}
+    state.backend.find_by_subject(subject, type, subtype)
   end
 
   def prefix(%__MODULE__{} = state, prefix, constraints) do
     type = Keyword.get(constraints, :type, :_)
     subtype = Keyword.get(constraints, :subtype, :_)
-    results = state.backend.find_by_prefix(prefix, type, subtype)
-    {:ok, results}
+    state.backend.find_by_prefix(prefix, type, subtype)
   end
 
   def fuzzy(%__MODULE__{} = state, subject, constraints) do
     case Fuzzy.match(state.fuzzy, subject) do
       [] ->
-        {:ok, []}
+        []
 
       refs ->
         type = Keyword.get(constraints, :type, :_)
         subtype = Keyword.get(constraints, :subtype, :_)
-        {:ok, state.backend.find_by_refs(refs, type, subtype)}
+        state.backend.find_by_refs(refs, type, subtype)
     end
   end
 

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/rename/module_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/rename/module_test.exs
@@ -1,4 +1,4 @@
-defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
+defmodule Lexical.RemoteControl.CodeIntelligence.Rename.ModuleTest do
   alias Lexical.Document
   alias Lexical.Project
   alias Lexical.RemoteControl
@@ -314,7 +314,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
          {:ok, entries} <- Search.Indexer.Source.index(document.path, text),
          :ok <- Search.Store.replace(entries),
          analysis = Lexical.Ast.analyze(document),
-         {:ok, uri_with_changes} <- Rename.rename(analysis, position, new_name) do
+         {:ok, uri_with_changes} <- Rename.Module.rename(analysis, position, new_name) do
       changes = uri_with_changes |> Map.values() |> List.flatten()
       {:ok, apply_edits(document, changes)}
     end

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/rename_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/rename_test.exs
@@ -205,13 +205,13 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
     test "in the middle of reference" do
       {:ok, result} =
         ~q[
-          defmodule TopLevel.Middle.Module do
-            alias TopLevel.|Middle.Module
+          defmodule TopLevel.Second.Middle.Module do
+            alias TopLevel.Second.|Middle.Module
           end
         ] |> rename("Renamed")
 
-      assert result =~ ~S[defmodule TopLevel.Renamed.Module]
-      assert result =~ ~S[alias TopLevel.Renamed.Module]
+      assert result =~ ~S[defmodule TopLevel.Second.Renamed.Module]
+      assert result =~ ~S[alias TopLevel.Second.Renamed.Module]
     end
 
     test "succeeds when there are same module name in the cursor neighborhood" do

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/rename_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/rename_test.exs
@@ -19,7 +19,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
   setup_all do
     project = project()
     RemoteControl.set_project(project)
-    start_supervised!(Document.Store)
+    start_supervised!({Document.Store, derive: [analysis: &Lexical.Ast.analyze/1]})
 
     start_supervised!(
       {Search.Store,

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/rename_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/rename_test.exs
@@ -20,6 +20,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
     project = project()
     RemoteControl.set_project(project)
     start_supervised!({Document.Store, derive: [analysis: &Lexical.Ast.analyze/1]})
+    start_supervised!(RemoteControl.Dispatch)
 
     start_supervised!(
       {Search.Store,
@@ -31,6 +32,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
        ]}
     )
 
+    Search.Store.enable()
     assert_eventually Search.Store.loaded?()
 
     {:ok, project: project}

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/rename_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/rename_test.exs
@@ -47,7 +47,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
   end
 
   describe "rename exact module" do
-    test "succeeds when the cursor on the definition" do
+    test "succeeds when the cursor is at the definition" do
       {:ok, result} =
         ~q[
         defmodule |Foo do
@@ -57,7 +57,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
       assert result =~ ~S[defmodule Renamed do]
     end
 
-    test "succeeds when the cursor on the alias" do
+    test "succeeds when the cursor is at the alias" do
       {:ok, result} =
         ~q[
         defmodule Baz do
@@ -68,7 +68,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
       assert result =~ ~S[alias Renamed]
     end
 
-    test "succeeds when the definition in a nested module" do
+    test "succeeds when the definition is in a nested module" do
       {:ok, result} =
         ~q[
         defmodule TopLevel do
@@ -93,7 +93,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
       ]
     end
 
-    test "succeeds when the cursor in the multiple aliases off of single alias" do
+    test "succeeds when the cursor is in the multiple aliases off of single alias" do
       {:ok, result} =
         ~q[
         defmodule TopLevel do
@@ -108,7 +108,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
       assert result =~ ~S[  First, Renamed,]
     end
 
-    test "only rename the aliased when the cursor at the aliased" do
+    test "only rename the aliased when the cursor is at the aliased" do
       {:ok, result} =
         ~q[
         defmodule TopLevel do
@@ -122,7 +122,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
       assert result =~ ~S[  Renamed]
     end
 
-    test "succeeds when the cursor at the alias_ased child" do
+    test "succeeds when the cursor is at the aliased child" do
       {:ok, result} =
         ~q[
           defmodule TopLevel.Foo.Bar do
@@ -140,7 +140,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
       assert result =~ ~S[  Parent.Renamed]
     end
 
-    test "only rename aliased when the cursor at the alias_ased" do
+    test "only rename aliased when the cursor is at the aliased" do
       {:ok, result} =
         ~q[
           defmodule TopLevel.Foo.Bar do
@@ -172,7 +172,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
       assert result =~ ~S[defmodule FooTest do]
     end
 
-    test "shouldn't rename the descendants when the cursor at the end of the module" do
+    test "shouldn't rename the descendants when the cursor is at the end of the module" do
       {:ok, result} = ~q[
         defmodule TopLevel.Module do # ✓
         end
@@ -190,7 +190,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
   end
 
   describe "rename descendants" do
-    test "in the middle of definition" do
+    test "succeeds when the cursor is in the middle of definition" do
       {:ok, result} =
         ~q[
           defmodule TopLevel.|Middle.Module do
@@ -202,7 +202,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
       assert result =~ ~S[alias TopLevel.Renamed.Module]
     end
 
-    test "in the middle of reference" do
+    test "succeeds when the cursor is in the middle of reference" do
       {:ok, result} =
         ~q[
           defmodule TopLevel.Second.Middle.Module do
@@ -214,7 +214,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
       assert result =~ ~S[alias TopLevel.Second.Renamed.Module]
     end
 
-    test "succeeds when there are same module name in the cursor neighborhood" do
+    test "succeeds when there are same module name is in the cursor neighborhood" do
       {:ok, result} =
         ~q[
           defmodule TopLevel.Foo do
@@ -254,7 +254,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
   end
 
   describe "rename struct" do
-    test "succeeds when the cursor on the definition" do
+    test "succeeds when the cursor is at the definition" do
       {:ok, result} =
         ~q[
         defmodule |Foo do
@@ -272,7 +272,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
       assert result =~ ~S[%Renamed{}]
     end
 
-    test "succeeds when the cursor on the reference" do
+    test "succeeds when the cursor is at the reference" do
       {:ok, result} =
         ~q[
         defmodule Foo do

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/rename_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/rename_test.exs
@@ -232,6 +232,25 @@ defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
       assert result =~ ~S[defmodule TopLevel.Foo.Renamed do]
       assert result =~ ~S[alias TopLevel.Foo.Renamed]
     end
+
+    test "succeeds even if there are descendants with the same name" do
+      {:ok, result} =
+        ~q[
+        defmodule TopLevel.Foo do
+          defmodule Foo do # skip this
+          end
+        end
+
+        defmodule TopLevel.Bar do
+          alias TopLevel.|Foo.Foo
+        end
+      ]
+        |> rename("Renamed")
+
+      assert result =~ ~S[defmodule TopLevel.Renamed do]
+      assert result =~ ~S[defmodule Foo do # skip this]
+      assert result =~ ~S[alias TopLevel.Renamed.Foo]
+    end
   end
 
   describe "rename struct" do

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/rename_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/rename_test.exs
@@ -1,0 +1,319 @@
+defmodule Lexical.RemoteControl.CodeIntelligence.RenameTest do
+  alias Lexical.Document
+  alias Lexical.Project
+  alias Lexical.RemoteControl
+  alias Lexical.RemoteControl.CodeIntelligence.Rename
+  alias Lexical.RemoteControl.Search
+
+  alias Lexical.Test.CodeSigil
+  alias Lexical.Test.CursorSupport
+  alias Lexical.Test.Fixtures
+
+  import CodeSigil
+  import CursorSupport
+  import Lexical.Test.EventualAssertions
+  import Fixtures
+
+  use ExUnit.Case
+
+  setup_all do
+    project = project()
+    RemoteControl.set_project(project)
+    start_supervised!(Document.Store)
+
+    start_supervised!(
+      {Search.Store,
+       [
+         project,
+         fn _ -> {:ok, []} end,
+         fn _, _ -> {:ok, [], []} end,
+         Search.Store.Backends.Ets
+       ]}
+    )
+
+    assert_eventually Search.Store.loaded?()
+
+    {:ok, project: project}
+  end
+
+  setup %{project: project} do
+    uri = subject_uri(project)
+
+    on_exit(fn ->
+      Document.Store.close(uri)
+    end)
+
+    %{uri: uri}
+  end
+
+  describe "rename exact module" do
+    test "succeeds when the cursor on the definition" do
+      {:ok, result} =
+        ~q[
+        defmodule |Foo do
+        end
+      ] |> rename("Renamed")
+
+      assert result =~ ~S[defmodule Renamed do]
+    end
+
+    test "succeeds when the cursor on the alias" do
+      {:ok, result} =
+        ~q[
+        defmodule Baz do
+          alias |Foo
+        end
+      ] |> rename("Renamed")
+
+      assert result =~ ~S[alias Renamed]
+    end
+
+    test "succeeds when the definition in a nested module" do
+      {:ok, result} =
+        ~q[
+        defmodule TopLevel do
+          defmodule Foo do
+          end
+        end
+
+        defmodule TopLevelTest do
+          alias TopLevel.|Foo
+        end
+      ] |> rename("Renamed")
+
+      assert result == ~q[
+        defmodule TopLevel do
+          defmodule Renamed do
+          end
+        end
+
+        defmodule TopLevelTest do
+          alias TopLevel.Renamed
+        end
+      ]
+    end
+
+    test "succeeds when the cursor in the multiple aliases off of single alias" do
+      {:ok, result} =
+        ~q[
+        defmodule TopLevel do
+          alias Foo.{
+            First, Second,
+            Third.Fourth
+          }
+          |Second
+        end
+      ] |> rename("Renamed")
+
+      assert result =~ ~S[  First, Renamed,]
+    end
+
+    test "only rename the aliased when the cursor at the aliased" do
+      {:ok, result} =
+        ~q[
+        defmodule TopLevel do
+          alias Foo.Bar, as: FooBar
+          |FooBar
+        end
+        ]
+        |> rename("Renamed")
+
+      assert result =~ ~S[alias Foo.Bar, as: Renamed]
+      assert result =~ ~S[  Renamed]
+    end
+
+    test "succeeds when the cursor at the alias_ased child" do
+      {:ok, result} =
+        ~q[
+          defmodule TopLevel.Foo.Bar do
+          end
+
+          defmodule TopLevel.Another do
+            alias TopLevel.Foo, as: Parent
+            Parent.|Bar
+          end
+        ]
+        |> rename("Renamed")
+
+      assert result =~ ~S[defmodule TopLevel.Foo.Renamed]
+
+      assert result =~ ~S[  Parent.Renamed]
+    end
+
+    test "only rename aliased when the cursor at the alias_ased" do
+      {:ok, result} =
+        ~q[
+          defmodule TopLevel.Foo.Bar do
+          end
+
+          defmodule TopLevel.Another do
+            alias TopLevel.Foo, as: Parent
+            |Parent.Bar
+          end
+        ]
+        |> rename("Renamed")
+
+      assert result =~ ~S[defmodule TopLevel.Foo.Bar do]
+
+      assert result =~ ~S[alias TopLevel.Foo, as: Renamed]
+      assert result =~ ~S[  Renamed.Bar]
+    end
+
+    test "shouldn't rename the relative module" do
+      {:ok, result} =
+        ~q[
+        defmodule |Foo do
+        end
+
+        defmodule FooTest do
+        end
+        ] |> rename("Renamed")
+
+      assert result =~ ~S[defmodule FooTest do]
+    end
+
+    test "shouldn't rename the descendants when the cursor at the end of the module" do
+      {:ok, result} = ~q[
+        defmodule TopLevel.Module do # ✓
+        end
+
+        defmodule TopLevel.Module.Another do # x
+          alias TopLevel.|Module
+        end
+      ] |> rename("Renamed")
+
+      refute result =~ ~S[defmodule TopLevel.Renamed.Another]
+
+      assert result =~ ~S[defmodule TopLevel.Renamed do]
+      assert result =~ ~S[alias TopLevel.Renamed]
+    end
+  end
+
+  describe "rename descendants" do
+    test "in the middle of definition" do
+      {:ok, result} =
+        ~q[
+          defmodule TopLevel.|Middle.Module do
+            alias TopLevel.Middle.Module
+          end
+        ] |> rename("Renamed")
+
+      assert result =~ ~S[defmodule TopLevel.Renamed.Module]
+      assert result =~ ~S[alias TopLevel.Renamed.Module]
+    end
+
+    test "in the middle of reference" do
+      {:ok, result} =
+        ~q[
+          defmodule TopLevel.Middle.Module do
+            alias TopLevel.|Middle.Module
+          end
+        ] |> rename("Renamed")
+
+      assert result =~ ~S[defmodule TopLevel.Renamed.Module]
+      assert result =~ ~S[alias TopLevel.Renamed.Module]
+    end
+
+    test "succeeds when there are same module name in the cursor neighborhood" do
+      {:ok, result} =
+        ~q[
+          defmodule TopLevel.Foo do
+          end
+
+          defmodule TopLevel.Foo.Foo do
+          end
+
+          defmodule TopLevel.Another do
+            alias TopLevel.Foo.|Foo
+          end
+        ] |> rename("Renamed")
+
+      assert result =~ ~S[defmodule TopLevel.Foo do]
+      assert result =~ ~S[defmodule TopLevel.Foo.Renamed do]
+      assert result =~ ~S[alias TopLevel.Foo.Renamed]
+    end
+  end
+
+  describe "rename struct" do
+    test "succeeds when the cursor on the definition" do
+      {:ok, result} =
+        ~q[
+        defmodule |Foo do
+          defstruct bar: 1
+        end
+
+        defmodule Bar do
+          def foo do
+            %Foo{}
+          end
+        end
+      ] |> rename("Renamed")
+
+      assert result =~ ~S[defmodule Renamed do]
+      assert result =~ ~S[%Renamed{}]
+    end
+
+    test "succeeds when the cursor on the reference" do
+      {:ok, result} =
+        ~q[
+        defmodule Foo do
+          defstruct bar: 1
+        end
+
+        defmodule Bar do
+          def foo do
+            %Fo|o{}
+          end
+        end
+      ] |> rename("Renamed")
+
+      assert result =~ ~S[defmodule Renamed do]
+      assert result =~ ~S[defmodule Bar do]
+      assert result =~ ~S[%Renamed{}]
+    end
+  end
+
+  describe "unsupported" do
+    test "rename a function" do
+      assert {:error, {:unsupported, {:local_or_var, ~c"bar"}}} ==
+               ~q[
+        defmodule Foo do
+          def |bar do
+          end
+        end
+      ] |> rename("baz")
+    end
+  end
+
+  defp rename(%Project{} = project \\ project(), source, new_name) do
+    uri = subject_uri(project)
+
+    with {position, text} <- pop_cursor(source),
+         {:ok, document} <- open_document(uri, text),
+         {:ok, entries} <- Search.Indexer.Source.index(document.path, text),
+         :ok <- Search.Store.replace(entries),
+         analysis = Lexical.Ast.analyze(document),
+         {:ok, uri_with_changes} <- Rename.rename(analysis, position, new_name) do
+      changes = uri_with_changes |> Map.values() |> List.flatten()
+      {:ok, apply_edits(document, changes)}
+    end
+  end
+
+  defp subject_uri(project) do
+    project
+    |> file_path(Path.join("lib", "project.ex"))
+    |> Document.Path.ensure_uri()
+  end
+
+  defp open_document(uri, content) do
+    with :ok <- Document.Store.open(uri, content, 0) do
+      Document.Store.fetch(uri)
+    end
+  end
+
+  def apply_edits(document, text_edits) do
+    {:ok, edited_document} = Document.apply_content_changes(document, 1, text_edits)
+    edited_document = Document.to_string(edited_document)
+    edited_document
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
@@ -61,7 +61,7 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
 
       assert {:ok, _} = Indexing.on_event(file_compile_requested(uri: uri), state)
 
-      assert_eventually {:ok, [entry]} = Search.Store.exact("NewModule", [])
+      assert_eventually [entry] = Search.Store.exact("NewModule", [])
 
       assert entry.subject == NewModule
     end
@@ -85,9 +85,9 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
 
       assert {:ok, _} = Indexing.on_event(file_compile_requested(uri: uri), state)
 
-      assert_eventually {:ok, [entry]} = Search.Store.exact("UpdatedModule", [])
+      assert_eventually [entry] = Search.Store.exact("UpdatedModule", [])
       assert entry.subject == UpdatedModule
-      assert {:ok, []} = Search.Store.exact("OldModule", [])
+      assert Search.Store.exact("OldModule", []) == []
     end
 
     test "only updates entries if the version of the document is the same as the version in the document store",
@@ -102,7 +102,7 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
         |> set_document!()
 
       assert {:ok, _} = Indexing.on_event(file_compile_requested(uri: uri), state)
-      assert {:ok, []} = Search.Store.exact("Stale", [])
+      assert Search.Store.exact("Stale", []) == []
     end
   end
 
@@ -118,14 +118,14 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
       {:ok, entries} = Search.Indexer.Source.index(uri, source)
       Search.Store.update(uri, entries)
 
-      assert_eventually {:ok, [_]} = Search.Store.exact("ToDelete", [])
+      assert_eventually [_] = Search.Store.exact("ToDelete", [])
 
       Indexing.on_event(
         filesystem_event(project: project, uri: uri, event_type: :deleted),
         state
       )
 
-      assert_eventually {:ok, []} = Search.Store.exact("ToDelete", [])
+      assert_eventually Search.Store.exact("ToDelete", []) == []
     end
   end
 

--- a/apps/remote_control/test/lexical/remote_control/search/store_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store_test.exs
@@ -58,7 +58,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           reference(ref: 3)
         ])
 
-        assert {:ok, [ref]} = Store.exact(subtype: :reference)
+        assert [ref] = Store.exact(subtype: :reference)
         assert ref.subtype == :reference
       end
 
@@ -68,7 +68,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           reference(subject: Enum)
         ])
 
-        assert {:ok, [ref]} = Store.exact("Enum", subtype: :reference)
+        assert [ref] = Store.exact("Enum", subtype: :reference)
         assert ref.subject == Enum
         refute ref.elixir_version == "1.0.0"
       end
@@ -79,7 +79,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           reference(subject: Enum)
         ])
 
-        assert {:ok, [ref]} = Store.exact("Enum", subtype: :reference)
+        assert [ref] = Store.exact("Enum", subtype: :reference)
 
         assert ref.subject == Enum
         refute ref.erlang_version == "1.0.0"
@@ -92,7 +92,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           definition(subject: Foo.Bar.Baz)
         ])
 
-        assert {:ok, [ref]} = Store.exact("Foo.Bar.Baz", subtype: :reference)
+        assert [ref] = Store.exact("Foo.Bar.Baz", subtype: :reference)
 
         assert ref.subject == Foo.Bar.Baz
         assert ref.type == :module
@@ -105,7 +105,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           definition(ref: 2, subject: Foo.Bar.Bak)
         ])
 
-        assert {:ok, [entry]} = Store.exact("Foo.Bar.Baz", type: :module, subtype: :definition)
+        assert [entry] = Store.exact("Foo.Bar.Baz", type: :module, subtype: :definition)
 
         assert entry.subject == Foo.Bar.Baz
         assert entry.ref == 1
@@ -118,7 +118,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           definition(ref: 3, subject: Foo.Bar.Baz)
         ])
 
-        assert {:ok, [entry1, entry3]} =
+        assert [entry1, entry3] =
                  Store.prefix("Foo.Bar", type: :module, subtype: :definition)
 
         assert entry1.subject == Foo.Bar
@@ -135,7 +135,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           definition(ref: 3, subject: Bad.Times.Now)
         ])
 
-        assert {:ok, [entry_1, entry_2]} =
+        assert [entry_1, entry_2] =
                  Store.fuzzy("Foo.Bar.B", type: :module, subtype: :definition)
 
         assert entry_1.subject in [Foo.Bar.Baz, Foo.Bar.Bak]
@@ -148,7 +148,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           definition(ref: 2, subject: Foo.Bar.Baz)
         ])
 
-        assert {:ok, [entry]} = Store.fuzzy("Foo.Bar.", type: :module, subtype: :definition)
+        assert [entry] = Store.fuzzy("Foo.Bar.", type: :module, subtype: :definition)
         assert entry.ref == 2
       end
 
@@ -158,7 +158,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           definition(ref: 2, subject: Foo.Bar.Baz)
         ])
 
-        assert {:ok, [entry]} = Store.fuzzy("Foo.Bar.", type: :module, subtype: :definition)
+        assert [entry] = Store.fuzzy("Foo.Bar.", type: :module, subtype: :definition)
         assert entry.ref == 2
       end
     end
@@ -218,7 +218,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           reference(ref: 2, subject: Present, path: path)
         ])
 
-        assert_eventually {:ok, [found]} = Store.fuzzy("Pres", type: :module, subtype: :reference)
+        assert_eventually [found] = Store.fuzzy("Pres", type: :module, subtype: :reference)
         assert found.ref == 2
         assert found.subject == Present
       end

--- a/apps/remote_control/test/lexical/remote_control/search/store_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store_test.exs
@@ -111,6 +111,23 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
         assert entry.ref == 1
       end
 
+      test "matching prefix tokens should work" do
+        Store.replace([
+          definition(ref: 1, subject: Foo.Bar),
+          definition(ref: 2, subject: Foo.Baa.Baa),
+          definition(ref: 3, subject: Foo.Bar.Baz)
+        ])
+
+        assert {:ok, [entry1, entry3]} =
+                 Store.prefix("Foo.Bar", type: :module, subtype: :definition)
+
+        assert entry1.subject == Foo.Bar
+        assert entry3.subject == Foo.Bar.Baz
+
+        assert entry1.ref == 1
+        assert entry3.ref == 3
+      end
+
       test "matching fuzzy tokens works" do
         Store.replace([
           definition(ref: 1, subject: Foo.Bar.Baz),

--- a/apps/server/lib/lexical/server/provider/handlers.ex
+++ b/apps/server/lib/lexical/server/provider/handlers.ex
@@ -28,6 +28,9 @@ defmodule Lexical.Server.Provider.Handlers do
       %Requests.ExecuteCommand{} ->
         {:ok, Handlers.Commands}
 
+      %Requests.PrepareRename{} ->
+        {:ok, Handlers.PrepareRename}
+
       %Requests.Rename{} ->
         {:ok, Handlers.Rename}
 

--- a/apps/server/lib/lexical/server/provider/handlers.ex
+++ b/apps/server/lib/lexical/server/provider/handlers.ex
@@ -28,6 +28,9 @@ defmodule Lexical.Server.Provider.Handlers do
       %Requests.ExecuteCommand{} ->
         {:ok, Handlers.Commands}
 
+      %Requests.Rename{} ->
+        {:ok, Handlers.Rename}
+
       %request_module{} ->
         {:error, {:unhandled, request_module}}
     end

--- a/apps/server/lib/lexical/server/provider/handlers.ex
+++ b/apps/server/lib/lexical/server/provider/handlers.ex
@@ -2,6 +2,7 @@ defmodule Lexical.Server.Provider.Handlers do
   alias Lexical.Protocol.Requests
   alias Lexical.Server.Provider.Handlers
 
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def for_request(%_{} = request) do
     case request do
       %Requests.FindReferences{} ->

--- a/apps/server/lib/lexical/server/provider/handlers/prepare_rename.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/prepare_rename.ex
@@ -1,0 +1,37 @@
+defmodule Lexical.Server.Provider.Handlers.PrepareRename do
+  alias Lexical.Ast
+  alias Lexical.Document
+  alias Lexical.Protocol.Requests.PrepareRename
+  alias Lexical.Protocol.Responses
+  alias Lexical.Protocol.Types
+  alias Lexical.RemoteControl.Api
+  alias Lexical.Server.Provider.Env
+
+  def handle(%PrepareRename{} = request, %Env{} = env) do
+    case Document.Store.fetch(request.document.uri, :analysis) do
+      {:ok, _document, %Ast.Analysis{valid?: true} = analysis} ->
+        prepare_rename(env.project, analysis, request.position, request.id)
+
+      _ ->
+        {:reply,
+         Responses.PrepareRename.error(
+           request.id,
+           :request_failed,
+           "document can not be analyzed"
+         )}
+    end
+  end
+
+  defp prepare_rename(project, analysis, position, id) do
+    case Api.rename_supported?(project, analysis, position) do
+      true ->
+        default_behavior =
+          Types.PrepareRenameResult.PrepareRenameResult1.new(default_behavior: true)
+
+        {:reply, Responses.PrepareRename.new(id, default_behavior)}
+
+      false ->
+        {:reply, Responses.PrepareRename.new(id, nil)}
+    end
+  end
+end

--- a/apps/server/lib/lexical/server/provider/handlers/prepare_rename.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/prepare_rename.ex
@@ -23,14 +23,17 @@ defmodule Lexical.Server.Provider.Handlers.PrepareRename do
   end
 
   defp prepare_rename(project, analysis, position, id) do
-    case Api.rename_supported?(project, analysis, position) do
-      true ->
-        default_behavior =
-          Types.PrepareRenameResult.PrepareRenameResult1.new(default_behavior: true)
+    case Api.prepare_rename(project, analysis, position) do
+      {:ok, cursor_entity, range} ->
+        result =
+          Types.PrepareRenameResult.PrepareRenameResult.new(
+            placeholder: cursor_entity,
+            range: range
+          )
 
-        {:reply, Responses.PrepareRename.new(id, default_behavior)}
+        {:reply, Responses.PrepareRename.new(id, result)}
 
-      false ->
+      _ ->
         {:reply, Responses.PrepareRename.new(id, nil)}
     end
   end

--- a/apps/server/lib/lexical/server/provider/handlers/rename.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/rename.ex
@@ -10,7 +10,7 @@ defmodule Lexical.Server.Provider.Handlers.Rename do
 
   def handle(%Rename{} = request, %Env{} = env) do
     case Document.Store.fetch(request.document.uri, :analysis) do
-      {:ok, _document, %Ast.Analysis{} = analysis} ->
+      {:ok, _document, %Ast.Analysis{valid?: true} = analysis} ->
         rename(env.project, analysis, request.position, request.new_name, request.id)
 
       _ ->

--- a/apps/server/lib/lexical/server/provider/handlers/rename.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/rename.ex
@@ -1,0 +1,39 @@
+defmodule Lexical.Server.Provider.Handlers.Rename do
+  alias Lexical.Ast
+  alias Lexical.Document
+  alias Lexical.Protocol.Requests.Rename
+  alias Lexical.Protocol.Responses
+  alias Lexical.Protocol.Types.Workspace.Edit
+  alias Lexical.RemoteControl.Api
+  alias Lexical.Server.Provider.Env
+  require Logger
+
+  def handle(%Rename{} = request, %Env{} = env) do
+    case Document.Store.fetch(request.document.uri, :analysis) do
+      {:ok, _document, %Ast.Analysis{} = analysis} ->
+        rename(env.project, analysis, request.position, request.new_name, request.id)
+
+      _ ->
+        {:reply,
+         Responses.Rename.error(request.id, :request_failed, "document can not be analyzed")}
+    end
+  end
+
+  defp rename(project, analysis, position, new_name, id) do
+    case Api.rename(project, analysis, position, new_name) do
+      {:ok, results} when results == %{} ->
+        {:reply, nil}
+
+      {:ok, results} ->
+        edit = Edit.new(changes: results)
+        {:reply, Responses.Rename.new(id, edit)}
+
+      {:error, {:unsupported_entity, entity}} ->
+        Logger.info("Unrenameable entity: #{inspect(entity)}")
+        {:reply, nil}
+
+      {:error, reason} ->
+        {:reply, Responses.Rename.error(id, :request_failed, inspect(reason))}
+    end
+  end
+end

--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -286,6 +286,7 @@ defmodule Lexical.Server.State do
         execute_command_provider: command_options,
         hover_provider: true,
         references_provider: Features.indexing_enabled?(),
+        rename_provider: Features.indexing_enabled?(),
         text_document_sync: sync_options
       )
 

--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -286,7 +286,8 @@ defmodule Lexical.Server.State do
         execute_command_provider: command_options,
         hover_provider: true,
         references_provider: Features.indexing_enabled?(),
-        rename_provider: Features.indexing_enabled?(),
+        rename_provider:
+          Features.indexing_enabled?() && Types.Rename.Options.new(prepare_provider: true),
         text_document_sync: sync_options
       )
 


### PR DESCRIPTION
We need to consider two typical scenarios: 

1. One is renaming an exact entry, 
2. And the other is renaming both the entry and its descendants.

I differentiate between these two scenarios based on the cursor's position. If there are no more child modules after the cursor, for example, in the case of `defmodule TopLevel.|Entry`, then rename the `Entry` module. 

However, if there are child modules after the cursor, then rename both the Entry module and its descendants. 
For example, if the cursor is at `defmodule TopLevel.|Entry.Child`, and we want to rename it to `defmodule TopLevel.Renamed.Child`, then `TopLevel.Entry.AnotherChild` will also be renamed to `TopLevel.Renamed.AnotherChild`


### TODO

* [ ] Add some tests for `handlers/rename.ex`

