### PR TITLE
(Experiment) Make obvious syntax corrections if formatting fails

### DIFF
--- a/apps/remote_control/test/lexical/remote_control/code_mod/format_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_mod/format_test.exs
@@ -125,6 +125,28 @@ defmodule Lexical.RemoteControl.CodeMod.FormatTest do
     end
   end
 
+  describe "format/2 syntax correction" do
+    test "adds missing space after keyword", %{project: project} do
+      assert {:ok, result} = ~q[
+        %{foo:bar}
+      ] |> modify(project: project)
+
+      assert result == ~q[
+        %{foo: bar}
+      ]t
+    end
+
+    test "adds missing space after multiple keywords", %{project: project} do
+      assert {:ok, result} = ~q[
+        %{foo:bar, baz:buzz}
+      ] |> modify(project: project)
+
+      assert result == ~q[
+        %{foo: bar, baz: buzz}
+      ]t
+    end
+  end
+
   describe "emitting diagnostics" do
     setup [:with_real_project]
 

--- a/apps/server/lib/lexical/server/provider/handlers/formatting.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/formatting.ex
@@ -18,8 +18,7 @@ defmodule Lexical.Server.Provider.Handlers.Formatting do
 
       {:error, reason} ->
         Logger.error("Formatter failed #{inspect(reason)}")
-
-        {:reply, Responses.Formatting.error(request.id, :request_failed, inspect(reason))}
+        {:reply, Responses.Formatting.new(request.id, nil)}
     end
   end
 end


### PR DESCRIPTION
This PR should be considered an experiment for now, but I'd love feedback on it because I think something like this is worthwhile.

The gist of it is: The Elixir formatter requires that the code be able to compile, so in the event of an error formatting, try to fix the code and re-format instead of immediately giving up. Right now I've implemented a single correction for `%{foo:bar}` (a space needs to be added after the colon when using keyword syntax).