### PR TITLE
Generate correct typespec for LSP messages

### DIFF
--- a/apps/proto/lib/lexical/proto/macros/message.ex
+++ b/apps/proto/lib/lexical/proto/macros/message.ex
@@ -21,7 +21,7 @@ defmodule Lexical.Proto.Macros.Message do
       unquote(parse_fn)
       unquote(Meta.build(types))
 
-      @type t :: unquote(Typespec.typespec())
+      @type t :: unquote(Typespec.typespec(types, env))
 
       def method do
         unquote(method)


### PR DESCRIPTION
@scohen noticed this while testing #356.

Before:
![image](https://github.com/lexical-lsp/lexical/assets/503938/b19886a1-224d-4dfe-b8c3-37c40937f61b)

After:
![image](https://github.com/lexical-lsp/lexical/assets/503938/b74e575e-d669-43bd-a7cb-ce916c0f9aad)
