### PR TITLE
Refactor client capability tracking

### DIFF
--- a/apps/server/lib/lexical/server/configuration/support.ex
+++ b/apps/server/lib/lexical/server/configuration/support.ex
@@ -1,65 +1,71 @@
 defmodule Lexical.Server.Configuration.Support do
+  @moduledoc false
+
   alias Lexical.Protocol.Types.ClientCapabilities
 
-  defstruct code_action_dynamic_registration?: false,
-            hierarchical_document_symbols?: false,
-            snippet?: false,
-            deprecated?: false,
-            tags?: false,
-            signature_help?: false,
-            work_done_progress?: false
+  # To track a new client capability, add a new field and the path to the
+  # capability in the `Lexical.Protocol.Types.ClientCapabilities` struct
+  # to this mapping:
+  @client_capability_mapping [
+    code_action_dynamic_registration: [
+      :text_document,
+      :code_action,
+      :dynamic_registration
+    ],
+    hierarchical_symbols: [
+      :text_document,
+      :document_symbol,
+      :hierarchical_document_symbol_support
+    ],
+    snippet: [
+      :text_document,
+      :completion,
+      :completion_item,
+      :snippet_support
+    ],
+    deprecated: [
+      :text_document,
+      :completion,
+      :completion_item,
+      :deprecated_support
+    ],
+    tags: [
+      :text_document,
+      :completion,
+      :completion_item,
+      :tag_support
+    ],
+    signature_help: [
+      :text_document,
+      :signature_help
+    ],
+    work_done_progress: [
+      :window,
+      :work_done_progress
+    ]
+  ]
+
+  defstruct code_action_dynamic_registration: false,
+            hierarchical_symbols: false,
+            snippet: false,
+            deprecated: false,
+            tags: false,
+            signature_help: false,
+            work_done_progress: false
+
+  @type t :: %__MODULE__{}
 
   def new(%ClientCapabilities{} = client_capabilities) do
-    dynamic_registration? =
-      client_capabilities
-      |> get_in([:text_document, :code_action, :dynamic_registration])
-      |> bool()
+    defaults =
+      for {key, path} <- @client_capability_mapping do
+        value = get_in(client_capabilities, path) || false
+        {key, value}
+      end
 
-    hierarchical_symbols? =
-      client_capabilities
-      |> get_in([:text_document, :document_symbol, :hierarchical_document_symbol_support])
-      |> bool()
-
-    snippet? =
-      client_capabilities
-      |> get_in([:text_document, :completion, :completion_item, :snippet_support])
-      |> bool()
-
-    deprecated? =
-      client_capabilities
-      |> get_in([:text_document, :completion, :completion_item, :deprecated_support])
-      |> bool()
-
-    tags? =
-      client_capabilities
-      |> get_in([:text_document, :completion, :completion_item, :tag_support])
-      |> bool()
-
-    signature_help? =
-      client_capabilities
-      |> get_in([:text_document, :signature_help])
-      |> bool()
-
-    work_done_progress? =
-      client_capabilities
-      |> get_in([:window, :work_done_progress])
-      |> bool()
-
-    %__MODULE__{
-      code_action_dynamic_registration?: dynamic_registration?,
-      hierarchical_document_symbols?: hierarchical_symbols?,
-      snippet?: snippet?,
-      deprecated?: deprecated?,
-      tags?: tags?,
-      signature_help?: signature_help?,
-      work_done_progress?: work_done_progress?
-    }
+    struct(__MODULE__, defaults)
   end
 
-  def new(_) do
+  def new do
     %__MODULE__{}
   end
-
-  defp bool(b) when b in [true, false], do: b
-  defp bool(_), do: false
 end

--- a/apps/server/lib/lexical/server/project/progress/state.ex
+++ b/apps/server/lib/lexical/server/project/progress/state.ex
@@ -44,14 +44,14 @@ defmodule Lexical.Server.Project.Progress.State do
   end
 
   defp write_work_done(token) do
-    if Configuration.supports?(:work_done_progress?) do
+    if Configuration.client_supports?(:work_done_progress) do
       progress = Requests.CreateWorkDoneProgress.new(id: Id.next(), token: token)
       Transport.write(progress)
     end
   end
 
   defp write(%{token: token} = progress) when not is_nil(token) do
-    if Configuration.supports?(:work_done_progress?) do
+    if Configuration.client_supports?(:work_done_progress) do
       progress |> Value.to_protocol() |> Transport.write()
     end
   end

--- a/apps/server/test/lexical/server/project/progress_test.exs
+++ b/apps/server/test/lexical/server/project/progress_test.exs
@@ -43,7 +43,7 @@ defmodule Lexical.Server.Project.ProgressTest do
     setup [:with_patched_tranport]
 
     test "it should be able to send the report progress", %{project: project} do
-      patch(Configuration, :supports?, fn :work_done_progress? -> true end)
+      patch(Configuration, :client_supports?, fn :work_done_progress -> true end)
 
       begin_message = progress(:begin, "mix compile")
       RemoteControl.Api.broadcast(project, begin_message)
@@ -62,7 +62,7 @@ defmodule Lexical.Server.Project.ProgressTest do
     end
 
     test "it should write nothing when the client does not support work done", %{project: project} do
-      patch(Configuration, :supports?, fn :work_done_progress? -> false end)
+      patch(Configuration, :client_supports?, fn :work_done_progress -> false end)
 
       begin_message = progress(:begin, "mix compile")
       RemoteControl.Api.broadcast(project, begin_message)


### PR DESCRIPTION
While walking through how server and client capabilities were managed, I saw some opportunities to refactor the code that manages configuration and client capabilities. The main changes are:

* Rename `Lexical.Server.Configuration.supports?/1` to `client_supports?/1`
* Refactor `client_supports?/1` to not duplicate the set of keys being tracked
* Refactor `Lexical.Server.Configuration.Support` to generate the struct and `new/1` function based on a mapping.
* Change the capability attributes from the format `:thing?` to `:thing`. This is done because the `%Configuration.Support{}` struct is never intended to be accessed directly, but instead through `Configuration.client_supports?/1`, which reads better as `Configuration.client_supports?(:thing)`.