### PR TITLE
Improve incompatible version errors on boot

### DIFF
--- a/apps/common/lib/lexical/vm/versions.ex
+++ b/apps/common/lib/lexical/vm/versions.ex
@@ -64,7 +64,7 @@ defmodule Lexical.VM.Versions do
         |> Path.dirname()
         |> compatible?()
 
-      :error ->
+      _ ->
         false
     end
   end
@@ -196,20 +196,16 @@ defmodule Lexical.VM.Versions do
     Enum.join(normalized, ".")
   end
 
-  require Logger
-
   defp code_find_file(file_name) when is_binary(file_name) do
     file_name
     |> String.to_charlist()
     |> code_find_file()
   end
 
-  defp code_find_file(file_name) do
-    Logger.info("file name is #{file_name}")
-
+  defp code_find_file(file_name) when is_list(file_name) do
     case :code.where_is_file(file_name) do
       :non_existing ->
-        :error
+        {:error, {:file_missing, file_name}}
 
       path ->
         {:ok, List.to_string(path)}

--- a/apps/common/lib/lexical/vm/versions.ex
+++ b/apps/common/lib/lexical/vm/versions.ex
@@ -33,7 +33,7 @@ defmodule Lexical.VM.Versions do
   This function uses the code server to find `.elixir` and `.erlang` files in the code path.
   Each of these files represent the version of the runtime the artifact was compiled with.
   """
-  @spec compiled() :: {:ok, t} | {:error, atom()}
+  @spec compiled() :: {:ok, t} | {:error, term()}
   def compiled do
     with {:ok, elixir_path} <- code_find_file(version_file(:elixir)),
          {:ok, erlang_path} <- code_find_file(version_file(:erlang)),

--- a/apps/server/lib/lexical/server/boot.ex
+++ b/apps/server/lib/lexical/server/boot.ex
@@ -38,7 +38,7 @@ defmodule Lexical.Server.Boot do
 
   @doc false
   def detect_errors do
-    List.wrap(packaging_errors()) ++ List.wrap(versioning_errors())
+    packaging_errors() ++ versioning_errors()
   end
 
   defp load_config do
@@ -84,27 +84,30 @@ defmodule Lexical.Server.Boot do
   end
 
   defp packaging_errors do
-    unless Versions.compatible?() do
-      {:ok, compiled_versions} = Versions.compiled()
+    maybe_error =
+      unless Versions.compatible?() do
+        {:ok, compiled_versions} = Versions.compiled()
 
-      compiled_versions = Versions.to_versions(compiled_versions)
-      current_versions = Versions.current() |> Versions.to_versions()
+        compiled_versions = Versions.to_versions(compiled_versions)
+        current_versions = Versions.current() |> Versions.to_versions()
 
-      compiled_erlang = compiled_versions.erlang
-      current_erlang = current_versions.erlang
+        compiled_erlang = compiled_versions.erlang
+        current_erlang = current_versions.erlang
 
-      """
-      FATAL: Lexical version check failed
+        """
+        FATAL: Lexical version check failed
 
-      The Lexical release being used must be compiled with a major version
-      of Erlang/OTP that is older or equal to the runtime.
+        The Lexical release being used must be compiled with a major version
+        of Erlang/OTP that is older or equal to the runtime.
 
-        Compiled with: #{compiled_erlang}
-        Started with:  #{current_erlang}
+          Compiled with: #{compiled_erlang}
+          Started with:  #{current_erlang}
 
-      To run Lexical with #{current_erlang}, please recompile using Erlang/OTP <= #{current_erlang.major}.
-      """
-    end
+        To run Lexical with #{current_erlang}, please recompile using Erlang/OTP <= #{current_erlang.major}.
+        """
+      end
+
+    List.wrap(maybe_error)
   end
 
   @allowed_elixir %{

--- a/apps/server/lib/lexical/server/boot.ex
+++ b/apps/server/lib/lexical/server/boot.ex
@@ -38,7 +38,7 @@ defmodule Lexical.Server.Boot do
 
   @doc false
   def detect_errors do
-    packaging_errors() ++ versioning_errors()
+    versioning_errors()
   end
 
   defp load_config do
@@ -81,33 +81,6 @@ defmodule Lexical.Server.Boot do
     with {:ok, modules} <- :application.get_key(app_name, :modules) do
       Enum.each(modules, &Code.ensure_loaded!/1)
     end
-  end
-
-  defp packaging_errors do
-    maybe_error =
-      unless Versions.compatible?() do
-        {:ok, compiled_versions} = Versions.compiled()
-
-        compiled_versions = Versions.to_versions(compiled_versions)
-        current_versions = Versions.current() |> Versions.to_versions()
-
-        compiled_erlang = compiled_versions.erlang
-        current_erlang = current_versions.erlang
-
-        """
-        FATAL: Lexical version check failed
-
-        The Lexical release being used must be compiled with a major version
-        of Erlang/OTP that is older or equal to the runtime.
-
-          Compiled with: #{compiled_erlang}
-          Started with:  #{current_erlang}
-
-        To run Lexical with #{current_erlang}, please recompile using Erlang/OTP <= #{current_erlang.major}.
-        """
-      end
-
-    List.wrap(maybe_error)
   end
 
   @allowed_elixir %{

--- a/apps/server/test/lexical/server/boot_test.exs
+++ b/apps/server/test/lexical/server/boot_test.exs
@@ -1,0 +1,68 @@
+defmodule Lexical.Server.BootTest do
+  alias Lexical.Server.Boot
+  alias Lexical.VM.Versions
+
+  use ExUnit.Case
+  use Patch
+
+  describe "detect_errors/0" do
+    test "returns empty list when all checks succeed" do
+      patch_runtime_versions("1.14.5", "25.0")
+      patch_compiled_versions("1.14.5", "25.0")
+
+      assert [] = Boot.detect_errors()
+    end
+
+    test "includes error when compiled erlang is too new" do
+      patch_runtime_versions("1.14.5", "25.0")
+      patch_compiled_versions("1.14.5", "26.1")
+
+      assert [error] = Boot.detect_errors()
+      assert error =~ "FATAL: Lexical version check failed"
+      assert error =~ "Compiled with: 26.1"
+      assert error =~ "Started with:  25.0"
+    end
+
+    test "includes error when runtime elixir is incompatible" do
+      patch_runtime_versions("1.12.0", "24.3.4")
+      patch_compiled_versions("1.13.4", "24.3.4")
+
+      assert [error] = Boot.detect_errors()
+      assert error =~ "FATAL: Lexical is not compatible with Elixir 1.12.0"
+    end
+
+    test "includes error when runtime erlang is incompatible" do
+      patch_runtime_versions("1.13.4", "23.0")
+      patch_compiled_versions("1.13.4", "23.0")
+
+      assert [error] = Boot.detect_errors()
+      assert error =~ "FATAL: Lexical is not compatible with Erlang/OTP 23.0.0"
+    end
+
+    test "includes multiple errors when runtime elixir and erlang are incompatible" do
+      patch_runtime_versions("1.15.2", "26.0.0")
+      patch_compiled_versions("1.15.6", "26.1")
+
+      assert [elixir_error, erlang_error] = Boot.detect_errors()
+      assert elixir_error =~ "FATAL: Lexical is not compatible with Elixir 1.15.2"
+      assert erlang_error =~ "FATAL: Lexical is not compatible with Erlang/OTP 26.0.0"
+    end
+  end
+
+  defp patch_runtime_versions(elixir, erlang) do
+    patch(Versions, :elixir_version, elixir)
+    patch(Versions, :erlang_version, erlang)
+  end
+
+  defp patch_compiled_versions(elixir, erlang) do
+    patch(Versions, :code_find_file, fn file -> {:ok, file} end)
+
+    patch(Versions, :read_file, fn file ->
+      if String.ends_with?(file, ".elixir") do
+        {:ok, elixir}
+      else
+        {:ok, erlang}
+      end
+    end)
+  end
+end

--- a/apps/server/test/lexical/server/boot_test.exs
+++ b/apps/server/test/lexical/server/boot_test.exs
@@ -13,16 +13,6 @@ defmodule Lexical.Server.BootTest do
       assert [] = Boot.detect_errors()
     end
 
-    test "includes error when compiled erlang is too new" do
-      patch_runtime_versions("1.14.5", "25.0")
-      patch_compiled_versions("1.14.5", "26.1")
-
-      assert [error] = Boot.detect_errors()
-      assert error =~ "FATAL: Lexical version check failed"
-      assert error =~ "Compiled with: 26.1"
-      assert error =~ "Started with:  25.0"
-    end
-
     test "includes error when runtime elixir is incompatible" do
       patch_runtime_versions("1.12.0", "24.3.4")
       patch_compiled_versions("1.13.4", "24.3.4")


### PR DESCRIPTION
This commit makes a few improvements to the errors shown when Lexical boots with incompatible Elixir/Erlang versions:

* Consistent formatting for all errors
* Prevent an exception that would occur if using an incompatible major version (e.g. Elixir 1.12)
* If both Elixir and Erlang are incompatible, show both errors
* Show full range of compatible versions instead of just the range for the current major version

**Example before:**

![image](https://github.com/lexical-lsp/lexical/assets/503938/b53f7b5c-1efa-463e-bfd7-e9c0b3b1e779)

**Example after:**

![image](https://github.com/lexical-lsp/lexical/assets/503938/d6865b05-c004-45c4-a081-496d404ea3da)
