### PR TITLE
Detect version manager the same way in all scripts

### DIFF
--- a/apps/remote_control/priv/port_wrapper.sh
+++ b/apps/remote_control/priv/port_wrapper.sh
@@ -1,24 +1,22 @@
 #!/usr/bin/env bash
 
-set_up_version_manager() {
-    if [ -e $HOME/.asdf ] && asdf which erl -eq 0 ; then
-        VERSION_MANAGER="asdf"
-    elif [ -e $HOME/.rtx ] && rtx which erl -eq 0 ; then
-        VERSION_MANAGER="rtx"
+detect_version_manager() {
+    if command -v asdf > /dev/null && asdf which elixir > /dev/null 2>&1 ; then
+        echo "asdf"
+    elif command -v rtx > /dev/null &&  rtx which elixir > /dev/null 2>&1 ; then
+        echo "rtx"
     else
-        VERSION_MANAGER="none"
+        echo "not_detected"
     fi
 }
 
-set_up_version_manager
-
 # Start the program in the background
-case "$VERSION_MANAGER" in
+case "$(detect_version_manager)" in
     asdf)
         asdf env erl exec "$@" &
         ;;
     rtx)
-        rtx env -s bash erl exec "$@" &
+        eval "$(rtx env -s bash)"
         ;;
     *)
         exec "$@" &

--- a/bin/start_lexical.sh
+++ b/bin/start_lexical.sh
@@ -1,19 +1,17 @@
 #!/usr/bin/env bash
 
-set_up_version_manager() {
+detect_version_manager() {
     if command -v asdf > /dev/null && asdf which elixir > /dev/null 2>&1 ; then
-        VERSION_MANAGER="asdf"
+        echo "asdf"
     elif command -v rtx > /dev/null &&  rtx which elixir > /dev/null 2>&1 ; then
-        VERSION_MANAGER="rtx"
+        echo "rtx"
     else
-        VERSION_MANAGER="none"
+        echo "not_detected"
     fi
 }
 
-set_up_version_manager
-
 # Start the program in the background
-case "$VERSION_MANAGER" in
+case "$(detect_version_manager)" in
     asdf)
         asdf env erl exec "$@" &
         ;;


### PR DESCRIPTION
`start_lexical.sh` and `port_wrapper.sh` were using different methods to detect the version manager. `start_lexical.sh` was updated more recently, so I standardized on that.

I also refactored the detection function slightly to echo the result instead of setting a global variable, since it was only used in one place and can be easily captured. This should also make it easier to extract this function into a shared utility if we desire.

Finally, `start_lexical.sh` wasn't doing anything to start the program in the background in non-detected version manager case. I don't fully understand why this is necessary in the first place, but I added it for consistency.