### PR TITLE
Made aliases better handle the __aliases__ special form

### DIFF
--- a/apps/common/lib/lexical/ast/aliases.ex
+++ b/apps/common/lib/lexical/ast/aliases.ex
@@ -71,6 +71,7 @@ defmodule Lexical.Ast.Aliases do
   end
 
   defmodule Reducer do
+    alias Lexical.Ast
     defstruct scopes: []
 
     def new do
@@ -95,22 +96,6 @@ defmodule Lexical.Ast.Aliases do
       |> Map.put(:__MODULE__, current_module(reducer))
     end
 
-    # Expands aliases given the rules in the special form
-    # https://hexdocs.pm/elixir/1.13.4/Kernel.SpecialForms.html#__aliases__/1
-    defp expand_alias(current_module, [:"Elixir" | _] = expanded) do
-      [current_module | expanded]
-    end
-
-    defp expand_alias(current_module, [atom | _rest] = expanded) when is_atom(atom) do
-      [current_module | expanded]
-    end
-
-    defp expand_alias(current_module, [unexpanded | rest]) do
-      expanded = Macro.expand(unexpanded, %{module: current_module})
-
-      [expanded | rest]
-    end
-
     # defmodule MyModule do
     defp apply_ast(
            %__MODULE__{} = reducer,
@@ -122,7 +107,7 @@ defmodule Lexical.Ast.Aliases do
             module_name
 
           current_module ->
-            expand_alias(current_module, module_name)
+            Ast.reify_alias(current_module, module_name)
         end
 
       current_module_alias =

--- a/apps/common/lib/lexical/ast/module.ex
+++ b/apps/common/lib/lexical/ast/module.ex
@@ -6,8 +6,26 @@ defmodule Lexical.Ast.Module do
   @doc """
   Formats a module name as a string.
   """
-  @spec name(module()) :: String.t()
-  def name(module) when is_atom(module) do
-    module |> to_string() |> String.replace_prefix("Elixir.", "")
+  @spec name(module() | Macro.t() | String.t()) :: String.t()
+  def name([{:__MODULE__, _, _} | rest]) do
+    [__MODULE__ | rest]
+    |> Module.concat()
+    |> name()
+  end
+
+  def name(module_name) when is_list(module_name) do
+    module_name
+    |> Module.concat()
+    |> name()
+  end
+
+  def name(module_name) when is_binary(module_name) do
+    module_name
+  end
+
+  def name(module_name) when is_atom(module_name) do
+    module_name
+    |> inspect()
+    |> name()
   end
 end

--- a/apps/common/test/lexical/ast/aliases_test.exs
+++ b/apps/common/test/lexical/ast/aliases_test.exs
@@ -205,6 +205,20 @@ defmodule Lexical.Ast.AliasesTest do
       assert aliases[:Child] == Grandparent.Parent.Child
       assert aliases[:__MODULE__] == Grandparent.Parent.Child
     end
+
+    test "with a child that has an explicit parent" do
+      {:ok, aliases} =
+        ~q[
+          defmodule Parent do
+            defmodule __MODULE__.Child do
+              |
+            end
+          end
+        ]
+        |> aliases_at_cursor()
+
+      assert aliases[:__MODULE__] == Parent.Child
+    end
   end
 
   describe "alias scopes" do

--- a/apps/common/test/lexical/ast_test.exs
+++ b/apps/common/test/lexical/ast_test.exs
@@ -259,12 +259,12 @@ defmodule Lexical.AstTest do
     test "works with __MODULE__ aliases" do
       {position, document} =
         ~q[
-        defmodule Parent do
-          defmodule __MODULE__.Child do
-            |
+          defmodule Parent do
+            defmodule __MODULE__.Child do
+              |
+            end
           end
-        end
-      ]
+        ]
         |> pop_cursor(as: :document)
 
       assert {:ok, Parent.Child} =

--- a/apps/common/test/lexical/ast_test.exs
+++ b/apps/common/test/lexical/ast_test.exs
@@ -255,6 +255,23 @@ defmodule Lexical.AstTest do
     end
   end
 
+  describe "expand_aliases/4" do
+    test "works with __MODULE__ aliases" do
+      {position, document} =
+        ~q[
+        defmodule Parent do
+          defmodule __MODULE__.Child do
+            |
+          end
+        end
+      ]
+        |> pop_cursor(as: :document)
+
+      assert {:ok, Parent.Child} =
+               Ast.expand_aliases([quote(do: __MODULE__), nil], document, position)
+    end
+  end
+
   defp ast(s) do
     case Ast.from(s) do
       {:ok, {:__block__, _, [node]}} -> node

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module.ex
@@ -152,28 +152,12 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Module do
   defp to_range(%Document{} = document, module_name, {line, column}) do
     module_length =
       module_name
-      |> module_name()
+      |> Ast.Module.name()
       |> String.length()
 
     Range.new(
       Position.new(document, line, column),
       Position.new(document, line, column + module_length)
     )
-  end
-
-  defp module_name(module_name) when is_list(module_name) do
-    module_name
-    |> Module.concat()
-    |> module_name()
-  end
-
-  defp module_name(module_name) when is_binary(module_name) do
-    module_name
-  end
-
-  defp module_name(module_name) when is_atom(module_name) do
-    module_name
-    |> inspect()
-    |> module_name()
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/source_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/source_test.exs
@@ -387,5 +387,24 @@ defmodule Lexical.RemoteControl.Search.Indexer.SourceTest do
       assert child_alias.subtype == :reference
       assert child_alias.subject == Something.Else.Other
     end
+
+    test "works with __MODULE__" do
+      {:ok, [parent, child], _} =
+        ~q[
+          defmodule Parent do
+            defmodule __MODULE__.Child do
+            end
+          end
+        ]
+        |> index()
+
+      assert parent.parent == :root
+      assert parent.type == :module
+      assert parent.subtype == :definition
+
+      assert child.parent == parent.ref
+      assert child.type == :module
+      assert child.subtype == :definition
+    end
   end
 end


### PR DESCRIPTION
The __aliases__ special form defines three types of aliases, and we were not handling one of them properly. This was made apparent to us in issue #378, where the module defined via `defmodule __MODULE__.Child` was not handled properly. This change fixes that issue, and should handle other aliases as well.

Fixes #378