### PR TITLE
Refactor shell scripts and add Docker-based integration tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,8 @@ insert_final_newline = true
 
 [*.{md, markdown, eex}]
 trim_trailing_whitespace = false
+
+[*.sh]
+indent_style = space
+indent_size = 4
+switch_case_indent = true

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -221,5 +221,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Build integration runner
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./integration/Dockerfile
+          tags: lx
+          # GitHub Actions cache
+          # https://docs.docker.com/build/ci/github-actions/cache/
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Required to make the image available through docker
+          load: true
+
       - name: Run integration tests
-        run: ./integration/test.sh
+        run: NO_BUILD=1 ./integration/test.sh

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Step: Check out the code.
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set Variables
         id: set_mix_lock_hash
@@ -100,7 +100,7 @@ jobs:
 
       # Step: Check out the code.
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set Variables
         id: set_mix_lock_hash
@@ -172,7 +172,7 @@ jobs:
     steps:
       # Step: Check out the code.
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Step: Setup Elixir + Erlang image as the base.
       - name: Set up Elixir
@@ -210,3 +210,16 @@ jobs:
       # Step: Execute the tests.
       - name: Run tests
         run: make test.all
+
+  integration_test:
+    runs-on: ubuntu-latest
+    name: Integration tests
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run integration tests
+        run: ./integration/test.sh

--- a/apps/remote_control/priv/port_wrapper.sh
+++ b/apps/remote_control/priv/port_wrapper.sh
@@ -1,27 +1,10 @@
 #!/usr/bin/env bash
 
-detect_version_manager() {
-    if command -v asdf > /dev/null && asdf which elixir > /dev/null 2>&1 ; then
-        echo "asdf"
-    elif command -v rtx > /dev/null &&  rtx which elixir > /dev/null 2>&1 ; then
-        echo "rtx"
-    else
-        echo "not_detected"
-    fi
-}
+# Prevents zombie operating system processes
+# https://hexdocs.pm/elixir/Port.html#module-zombie-operating-system-processes
 
 # Start the program in the background
-case "$(detect_version_manager)" in
-    asdf)
-        asdf env erl exec "$@" &
-        ;;
-    rtx)
-        eval "$(rtx env -s bash)"
-        ;;
-    *)
-        exec "$@" &
-        ;;
-esac
+exec "$@" &
 pid1=$!
 
 # Silence warnings from here on
@@ -30,8 +13,8 @@ exec >/dev/null 2>&1
 # Read from stdin in the background and
 # kill running program when stdin closes
 exec 0<&0 $(
-  while read; do :; done
-  kill -KILL $pid1
+    while read; do :; done
+    kill -KILL $pid1
 ) &
 pid2=$!
 

--- a/bin/activate_version_manager.sh
+++ b/bin/activate_version_manager.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# The purpose of these functions is to detect and activate the correct
+# installed version manager in the current shell session. Currently, we
+# try to detect asdf and rtx.
+#
+# The general approach involves the following steps:
+#
+#   1. Try to detect an already activated version manager that provides
+#      Elixir. If one is present, there's nothing more to do.
+#   2. Try to find and activate an asdf installation. If it provides
+#      Elixir, we're all set.
+#   3. Try to find and activate an rtx installation. If it provides
+#      Elixir, we're all set.
+#
+
+activate_version_manager() {
+    _detect_version_manager ||
+        (_try_activating_asdf && _detect_asdf) ||
+        (_try_activating_rtx && _detect_rtx)
+    return $?
+}
+
+_detect_version_manager() {
+    if ! (_detect_asdf || _detect_rtx); then
+        echo >&2 "No version manager detected"
+        return 1
+    fi
+}
+
+_detect_asdf() {
+    if command -v asdf >/dev/null && asdf which elixir >/dev/null 2>&1; then
+        echo >&2 "Detected Elixir through asdf: $(asdf which elixir)"
+        return 0
+    else
+        return 1
+    fi
+}
+
+_detect_rtx() {
+    if command -v rtx >/dev/null && rtx which elixir >/dev/null 2>&1; then
+        echo >&2 "Detected Elixir through rtx: $(rtx which elixir)"
+        return 0
+    else
+        return 1
+    fi
+}
+
+_try_activating_asdf() {
+    local asdf_dir="${ASDF_DIR:-"$HOME/.asdf"}"
+    local asdf_vm="$asdf_dir/asdf.sh"
+
+    if test -f "$asdf_vm"; then
+        echo >&2 "Found asdf. Activating..."
+        # shellcheck disable=SC1090
+        . "$asdf_vm"
+        return $?
+    else
+        return 1
+    fi
+}
+
+_try_activating_rtx() {
+    if which rtx >/dev/null; then
+        echo >&2 "Found rtx. Activating..."
+        eval "$($(which rtx) activate bash)"
+        return $?
+    else
+        return 1
+    fi
+}
+
+# Run activate_version_manager if we're being run directly. If we're being
+# sourced, let the caller run the function.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    activate_version_manager
+fi

--- a/bin/boot.exs
+++ b/bin/boot.exs
@@ -21,3 +21,9 @@ end)
 end)
 
 LXical.Server.Boot.start()
+
+if System.get_env("LX_HALT_AFTER_BOOT") do
+  require Logger
+  Logger.warning("Shutting down (LX_HALT_AFTER_BOOT)")
+  System.halt()
+end

--- a/bin/debug_shell.sh
+++ b/bin/debug_shell.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 project_name=$1
-node_name=$(epmd -names | grep manager-$project_name | awk '{print $2}')
+node_name=$(epmd -names | grep manager-"$project_name" | awk '{print $2}')
 
 iex --name "shell@127.0.0.1" \
     --remsh "${node_name}" \

--- a/bin/start_lexical.sh
+++ b/bin/start_lexical.sh
@@ -1,39 +1,22 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
-detect_version_manager() {
-    if command -v asdf > /dev/null && asdf which elixir > /dev/null 2>&1 ; then
-        echo "asdf"
-    elif command -v rtx > /dev/null &&  rtx which elixir > /dev/null 2>&1 ; then
-        echo "rtx"
-    else
-        echo "not_detected"
-    fi
-}
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-# Start the program in the background
-case "$(detect_version_manager)" in
-    asdf)
-        asdf env erl exec "$@" &
-        ;;
-    rtx)
-        eval "$(rtx env -s bash)"
-        ;;
-    *)
-        ;;
-esac
+if ! "$script_dir"/activate_version_manager.sh; then
+    echo "Could not activate a version manager."
+fi
 
 case $1 in
     iex)
-        ELIXIR_COMMAND=iex
+        elixir_command=iex
         ;;
     *)
-        ELIXIR_COMMAND=elixir
+        elixir_command=elixir
         ;;
 esac
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
-"${ELIXIR_COMMAND}" \
+$elixir_command \
     --cookie "lexical" \
     --no-halt \
-    "${SCRIPT_DIR}/../bin/boot.exs"
+    "$script_dir/boot.exs"

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -30,7 +30,6 @@ RUN integration/boot/set_up_asdf.sh
 COPY apps apps
 COPY bin bin
 COPY config config
-COPY priv priv
 COPY projects projects
 COPY mix* .
 

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,0 +1,40 @@
+# Used to build a clean container for testing the Lexical boot sequence.
+#
+# Build: docker build -t lx -f integration/Dockerfile .
+# Run:   docker run -it lx
+
+ARG ELIXIR_VERSION=1.15.6
+ARG ERLANG_VERSION=26.1.1
+
+FROM hexpm/elixir:${ELIXIR_VERSION}-erlang-${ERLANG_VERSION}-ubuntu-jammy-20230126
+
+RUN apt-get update
+RUN apt-get install -y \
+  git \
+  curl \
+  unzip \
+  # used to compile erlang
+  build-essential \
+  autoconf \
+  openssl \
+  libssl-dev
+
+WORKDIR /lexical
+
+COPY integration/boot/set_up_rtx.sh integration/boot/set_up_rtx.sh
+RUN integration/boot/set_up_rtx.sh
+
+COPY integration/boot/set_up_asdf.sh integration/boot/set_up_asdf.sh
+RUN integration/boot/set_up_asdf.sh
+
+COPY apps apps
+COPY bin bin
+COPY config config
+COPY priv priv
+COPY projects projects
+COPY mix* .
+
+COPY integration/boot/set_up_lexical.sh integration/boot/set_up_lexical.sh
+RUN integration/boot/set_up_lexical.sh
+
+CMD bash

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,0 +1,38 @@
+# Integration tests
+
+These integration tests confirm that Lexical can start using the correct version manager (asdf/rtx) and Elixir/Erlang versions in a variety of environments.
+They work using a Docker image with both asdf and rtx installed, but with neither activated.
+An individual test will then run some setup and manipulate the environment, then ensure that Lexical can properly start.
+
+## Running the tests
+
+Tests are run using `test.sh`:
+
+```sh
+$ ./integration/test.sh
+```
+
+By default, this will first build the Docker image and then run the tests.
+The first run will take quite some time to build the image, but subsequent runs will be much faster, as most setup will be cached and only Lexical will need to be rebuilt.
+
+If needed, you can separate building and running using `build.sh` and the `NO_BUILD=1` flag:
+
+```sh
+$ ./integration/build.sh
+$ NO_BUILD=1 ./integration/test.sh
+```
+
+### Debugging
+
+Run the tests with `LX_DEBUG=1` to see the output from the underlying commands:
+
+```sh
+$ LX_DEBUG=1 ./integration/test.sh
+...
+test_find_asdf_directory...
+> No version manager detected
+> Found asdf. Activating...
+> Detected Elixir through asdf: /root/.asdf/installs/elixir/1.15.6-otp-26/bin/elixir
+Pass
+...
+```

--- a/integration/boot/set_up_asdf.sh
+++ b/integration/boot/set_up_asdf.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+asdf_dir=/version_managers/asdf_vm
+mkdir -p $asdf_dir && cd $asdf_dir
+
+git clone https://github.com/asdf-vm/asdf.git .
+
+# shellcheck disable=SC1091
+ASDF_DIR=$asdf_dir . asdf.sh
+
+asdf update
+
+export KERL_CONFIGURE_OPTIONS="--disable-debug --without-javac --without-termcap --without-wx"
+asdf plugin add erlang https://github.com/asdf-vm/asdf-erlang.git
+asdf install erlang latest
+asdf global erlang latest
+
+asdf plugin add elixir https://github.com/asdf-vm/asdf-elixir.git
+asdf install elixir latest
+asdf global elixir latest

--- a/integration/boot/set_up_lexical.sh
+++ b/integration/boot/set_up_lexical.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+cd /lexical
+
+mix local.hex --force
+mix deps.get
+mix package

--- a/integration/boot/set_up_rtx.sh
+++ b/integration/boot/set_up_rtx.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+rtx_dir=/version_managers/rtx_vm
+mkdir -p $rtx_dir && cd $rtx_dir
+
+# Download the rtx binary for the correct architecture
+arch=$(uname -m)
+architecture=""
+
+case $arch in
+    "x86_64")
+        architecture="x64"
+        ;;
+    "aarch64")
+        architecture="arm64"
+        ;;
+    *)
+        echo "Unsupported architecture: $arch"
+        exit 1
+        ;;
+esac
+
+curl "https://rtx.pub/rtx-latest-linux-$architecture" >"$(pwd)/rtx"
+chmod +x ./rtx
+
+eval "$(./rtx activate bash)"
+
+export KERL_CONFIGURE_OPTIONS="--disable-debug --without-javac --without-termcap --without-wx"
+./rtx plugins install erlang
+./rtx use --global erlang@latest
+
+./rtx plugins install elixir
+./rtx use --global elixir@latest

--- a/integration/build.sh
+++ b/integration/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+docker build -t lx -f integration/Dockerfile .

--- a/integration/test.sh
+++ b/integration/test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# shellcheck disable=SC1091
+. "$script_dir/test_utils.sh"
+
+# Ensure the Docker image is up-to-date unless NO_BUILD=1
+if [ -z "$NO_BUILD" ]; then
+    "$script_dir"/build.sh
+fi
+
+start_lexical() {
+    local command='LX_HALT_AFTER_BOOT=1 _build/dev/package/lexical/bin/start_lexical.sh; exit $?'
+
+    if [[ $1 != "" ]]; then
+        command="$1 && $command"
+    fi
+
+    docker run -i lx bash -c "$command" 2>&1
+    return $?
+}
+
+run_test() {
+    local setup=$1
+    local expected=("${@:2}")
+
+    # $FUNCNAME is a special array containing the stack of function calls,
+    # with the current function at the head.
+    local test="${FUNCNAME[1]}"
+    log "$test... "
+
+    local output
+    output=$(start_lexical "$setup")
+    local exit_code=$?
+
+    if [[ -n $LX_DEBUG ]]; then
+        log_info "\n$(prefix_lines "> " "$output")"
+    fi
+
+    assert_contains "$output" "${expected[@]}"
+    local assert_exit_code=$?
+
+    if [ $exit_code -ne 0 ]; then
+        log_error "Fail (exit_code=$exit_code)"
+        return 1
+    elif [ $assert_exit_code -ne 0 ]; then
+        return 1
+    else
+        log_success "Pass"
+    fi
+}
+
+# Tests:
+
+test_using_system_installation() {
+    local expect=(
+        "Could not activate a version manager"
+    )
+
+    run_test "" "${expect[@]}"
+    return $?
+}
+
+test_find_asdf_directory() {
+    local expect=(
+        "No version manager detected"
+        "Found asdf"
+        "Detected Elixir through asdf"
+    )
+    local setup="export ASDF_DIR=/version_managers/asdf_vm"
+
+    run_test "$setup" "${expect[@]}"
+    return $?
+}
+
+test_activated_asdf() {
+    local expect=(
+        "Detected Elixir through asdf"
+    )
+    local setup="ASDF_DIR=/version_managers/asdf_vm . /version_managers/asdf_vm/asdf.sh"
+
+    run_test "$setup" "${expect[@]}"
+    return $?
+}
+
+test_activated_rtx() {
+    local expect=(
+        "Detected Elixir through rtx"
+    )
+    # shellcheck disable=2016
+    local setup='eval "$(/version_managers/rtx_vm/rtx activate bash)"'
+
+    run_test "$setup" "${expect[@]}"
+    return $?
+}
+
+# Run all tests
+
+run_tests_and_exit

--- a/integration/test_utils.sh
+++ b/integration/test_utils.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+reset="\033[0m"
+faint="$reset\033[0;2m"
+red="$reset\033[0;31m"
+green="$reset\033[0;32m"
+cyan="$reset\033[0;36m"
+
+# Asserts that the given string contains all given substrings.
+#
+#   assert_contains STRING SUBSTRING*
+#
+# Example:
+#
+#   assert_contains "foobar" "foo" "bar"
+#
+assert_contains() {
+    local output=$1
+    local expectations=("${@:2}")
+    local not_found=()
+
+    for expected in "${expectations[@]}"; do
+        if [[ $output != *"$expected"* ]]; then
+            not_found+=("$expected")
+        fi
+    done
+
+    if [ ${#not_found[@]} -ne 0 ]; then
+        log_error "Assertion failed!"
+
+        log "\n  ${cyan}Expected:${reset}\n\n"
+
+        for expected in "${not_found[@]}"; do
+            prefix_lines "    " "$expected"
+        done
+
+        log "\n  ${cyan}To be in:${reset}\n\n"
+
+        prefix_lines "    " "$output"
+
+        log "\n\n"
+
+        return 1
+    fi
+}
+
+# Runs every function that starts with "test_" in the current script,
+# exits 1 if any tests exit non-zero
+#
+# Example:
+#
+#   test_foo() { ... }
+#   test_bar() { ... }
+#
+#   # automatically runs test_foo and test_bar
+#   run_tests_and_exit
+#
+run_tests_and_exit() {
+    local tests
+    tests=$(declare -F | awk '/test_/ {print $3}')
+
+    local exit_code=0
+
+    for test in $tests; do
+        if ! "$test"; then
+            exit_code=1
+        fi
+    done
+
+    exit $exit_code
+}
+
+log() {
+    echo -ne "$1"
+}
+
+log_error() {
+    log "${red}$1${reset}\n"
+}
+
+log_success() {
+    log "${green}$1${reset}\n"
+}
+
+log_info() {
+    log "${faint}$1${reset}\n"
+}
+
+prefix_lines() {
+    local prefix_with=$1
+    echo "$2" | sed "s/^/$prefix_with/" | cat
+}


### PR DESCRIPTION
* Add `bin/activate_version_manager.sh`

This script encapsulates detecting, finding, and activating a version manager. Currently asdf and rtx are supported, though more work likely needs to be done to make sure that they can be found/activated in more cases.

* Refactor `bin/start_lexical.sh`

This script now uses `activate_version_manager.sh` to activate the version manager. It additionally ensures that it exits with an error code if any commands run exit non-zero.

* `bin/boot.exs` halts after booting Lexical if `LX_HALT_AFTER_BOOT` is set

* Begin using `shellcheck` and `shfmt` for script linting and formatting

Both of these tools can be installed using asdf/rtx and have editor support through plugins. CI is not currently enforcing that these be used; we can decide on that later.

* Add `integration/` dir and integration tests for booting Lexical

Currently, these test system installations of elixir, asdf, and rtx, all using bash and running in a Docker container. I'd like to add tests using different shells (zsh/fish/etc.) at some point as well.

These tests are not currently running in CI. That will be added in a later commit.