### PR TITLE
Fix Field parsing error for zed editor

### DIFF
--- a/apps/proto/lib/lexical/proto/field.ex
+++ b/apps/proto/lib/lexical/proto/field.ex
@@ -67,6 +67,10 @@ defmodule Lexical.Proto.Field do
     extract(alias_module.definition(), name, orig_value)
   end
 
+  def extract(nil, _name, orig_value) do
+    {:ok, orig_value}
+  end
+
   def extract(module, _name, orig_value)
       when is_atom(module) and module not in [:integer, :string, :boolean, :float] do
     module.parse(orig_value)

--- a/apps/protocol/test/lexical/protocol/integration/initialize_test.exs
+++ b/apps/protocol/test/lexical/protocol/integration/initialize_test.exs
@@ -26,6 +26,22 @@ defmodule Lexical.Protocol.Integrations.InitializeTest do
     validate_completion(text_doc_capabilities)
   end
 
+  test "initialize parse a request from zed" do
+    assert {:ok, %Requests.Initialize{lsp: %Requests.Initialize.LSP{} = parsed}} =
+             Requests.Initialize.parse(zed_initialize())
+
+    assert parsed.client_info == nil
+
+    assert %Types.ClientCapabilities{} = capabilities = parsed.capabilities
+    validate_workspace(capabilities)
+
+    assert %TextDocument.ClientCapabilities{} = text_doc_capabilities = capabilities.text_document
+    assert %Completion.ClientCapabilities{} = text_doc_capabilities.completion
+
+    validate_code_action(text_doc_capabilities)
+    validate_definition(text_doc_capabilities)
+  end
+
   def validate_completion(%TextDocument.ClientCapabilities{} = text_doc_capabilities) do
     assert %Completion.ClientCapabilities{} =
              completion_capabilities = text_doc_capabilities.completion
@@ -215,6 +231,114 @@ defmodule Lexical.Protocol.Integrations.InitializeTest do
           ]
         }
       }
+    )
+    |> Jason.decode!()
+  end
+
+  def zed_initialize do
+    # Zed Preview 0.106.2
+    ~S(
+    {
+      "jsonrpc":"2.0",
+      "id":0,
+      "method":"initialize",
+      "params":{
+        "processId":null,
+        "rootUri":"file:///Users/scottming/Code/dummy/mix.exs",
+        "capabilities":{
+          "workspace":{
+            "didChangeConfiguration":{
+              "dynamicRegistration":true
+            },
+            "didChangeWatchedFiles":{
+              "dynamicRegistration":true,
+              "relativePatternSupport":true
+            },
+            "symbol":{
+
+            },
+            "workspaceFolders":true,
+            "configuration":true,
+            "inlayHint":{
+              "refreshSupport":true
+            }
+          },
+          "textDocument":{
+            "completion":{
+              "completionItem":{
+                "snippetSupport":true,
+                "resolveSupport":{
+                  "properties":[
+                    "additionalTextEdits"
+                  ]
+                }
+              },
+              "completionList":{
+                "itemDefaults":[
+                  "commitCharacters",
+                  "editRange",
+                  "insertTextMode",
+                  "data"
+                ]
+              }
+            },
+            "hover":{
+              "contentFormat":[
+                "markdown"
+              ]
+            },
+            "definition":{
+              "linkSupport":true
+            },
+            "codeAction":{
+              "codeActionLiteralSupport":{
+                "codeActionKind":{
+                  "valueSet":[
+                    "refactor",
+                    "quickfix",
+                    "source"
+                  ]
+                }
+              },
+              "dataSupport":true,
+              "resolveSupport":{
+                "properties":[
+                  "edit",
+                  "command"
+                ]
+              }
+            },
+            "rename":{
+              "prepareSupport":true
+            },
+            "inlayHint":{
+              "dynamicRegistration":false,
+              "resolveSupport":{
+                "properties":[
+                  "textEdits",
+                  "tooltip",
+                  "label.tooltip",
+                  "label.location",
+                  "label.command"
+                ]
+              }
+            }
+          },
+          "window":{
+            "workDoneProgress":true
+          },
+          "experimental":{
+            "serverStatusNotification":true
+          }
+        },
+        "workspaceFolders":[
+          {
+            "uri":"file:///Users/scottming/Code/dummy/mix.exs",
+            "name":""
+          }
+        ]
+      }
+    }
     )
     |> Jason.decode!()
   end


### PR DESCRIPTION
Zed already supports custom LS for Elixir. I have found an issue with Lexical during startup, and the log displays the following. 
```elixir
10:21:49.299 [info] Application lx_server started at :nonode@nohost
10:21:49.315 [error] Process #PID<0.140.0> terminating
** (UndefinedFunctionError) function nil.parse/1 is undefined
    nil.parse(nil)
    (lx_proto 0.3.0) lib/lexical/proto/field.ex:23: anonymous fn/4 in LXical.Proto.Field.extract/3
    (elixir 1.15.4) lib/enum.ex:4830: Enumerable.List.reduce/3
    (elixir 1.15.4) lib/enum.ex:2564: Enum.reduce_while/3
    (lx_proto 0.3.0) lib/lexical/proto/field.ex:22: LXical.Proto.Field.extract/3
    (lx_protocol 0.3.0) /Users/scottming/Code/lexical/apps/proto/lib/lexical/proto/macros/parse.ex:41: LXical.Protocol.Requests.Initialize.LSP.parse/1
    (lx_protocol 0.3.0) lib/lexical/protocol/requests.ex:9: LXical.Protocol.Requests.Initialize.parse/1
    (lx_server 0.3.0) lib/lexical/server/transport/std_io.ex:90: LXical.Server.Transport.StdIO.loop/3
Initial Call: LXical.Server.Transport.StdIO.init/1
Ancestors: [LXical.Server.Supervisor, #PID<0.133.0>]
```


However, I am currently unable to access detailed logs from the client. After printing it out, I discovered that the `processId` field is `nil`.

At the same time, I checked the LSP specification and found that `ProcessId` can be nullable: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize. It makes sense to fix this issue on the Lexical side.