### PR TITLE
Fix the struct `KeyError` diagnostics

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build/error.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/error.ex
@@ -258,20 +258,21 @@ defmodule Lexical.RemoteControl.Build.Error do
 
   def error_to_diagnostic(
         %Document{} = source,
-        %ArgumentError{} = argument_error,
+        %error_struct{} = argument_error,
         stack,
         _quoted_ast
-      ) do
+      )
+      when error_struct in [ArgumentError, KeyError] do
     reversed_stack = Enum.reverse(stack)
 
     [{_, _, _, context}, {_, call, _, second_to_last_context} | _] = reversed_stack
 
     pipe_or_struct? = call in [:|>, :__struct__]
-    expanding_macro? = second_to_last_context[:file] == ~c"expanding macro"
+    expanding? = second_to_last_context[:file] in [~c"expanding macro", ~c"expanding struct"]
     message = Exception.message(argument_error)
 
     position =
-      if pipe_or_struct? or expanding_macro? do
+      if pipe_or_struct? or expanding? do
         context_to_position(context)
       else
         stack_to_position(stack)


### PR DESCRIPTION
We haven't handled the `KeyError` case before


```elixir
19:42:14.925 [error] Invalid diagnostic: {:exception, {%FunctionClauseError{module: LXical.RemoteControl.Build.Error, function: :error_to_diagnostic, arity: 4, kind: nil, args: [#LXical.Document<path: "/Users/scottming/Code/lexical/apps/remote_control/test/lexical/remote_control/build/error_test.exs", version: 60, dirty?: true, lines: %Lines<"defmodule Lexical.RemoteControl.Build.ErrorTest do..."(520 lines)>, ...>, %KeyError{key: :c, term: nil, message: "key :c not found"}, [{Foo, :__struct__, 1, [file: ~c"expanding struct
```