### PR TITLE
Make the operational behavior of the ancestors of structures and modules more consistent

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/entity.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/entity.ex
@@ -94,24 +94,8 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Entity do
       resolve_struct(charlist, node_range, document, position)
     else
       _ ->
-        if follow_percent?(document, position) do
-          resolve_struct(charlist, node_range, document, position)
-        else
-          resolve_module(charlist, node_range, document, position)
-        end
+        resolve_module(charlist, node_range, document, position)
     end
-  end
-
-  # |%MyStruct{}
-  defp follow_percent?(document, position) do
-    after_cursor =
-      Document.fragment(
-        document,
-        position,
-        Position.new(document, position.line, position.character + 1)
-      )
-
-    after_cursor == "%"
   end
 
   defp resolve_struct(charlist, node_range, document, %Position{} = position) do
@@ -262,6 +246,9 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Entity do
   # There is a fixed set of situations where an alias is being used as
   # a `:struct`, otherwise resolve as a `:module`.
   defp kind_of_alias(path)
+
+  # |%Foo{}
+  defp kind_of_alias([{:%, _, _}]), do: :struct
 
   # %|Foo{}
   # %|Foo.Bar{}

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/entity.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/entity.ex
@@ -91,7 +91,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Entity do
   defp resolve_alias(charlist, node_range, document, position) do
     {{_line, start_column}, _} = node_range
 
-    with true <- not suffix_contains_module?(charlist, start_column, position),
+    with false <- suffix_contains_module?(charlist, start_column, position),
          {:ok, path} <- Ast.path_at(document, position),
          :struct <- kind_of_alias(path) do
       resolve_struct(charlist, node_range, document, position)

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/entity_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/entity_test.exs
@@ -227,7 +227,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.EntityTest do
           Lines{}
       ]
 
-      assert {:ok, {:struct, On.Multiple.Lines}, resolved_range} = resolve(code)
+      assert {:ok, {:module, On.Multiple.Lines}, resolved_range} = resolve(code)
 
       assert resolved_range =~ """
              %«On.
@@ -236,13 +236,13 @@ defmodule Lexical.RemoteControl.CodeIntelligence.EntityTest do
              """
     end
 
-    test "includes trailing module segments" do
+    test "shouldn't includes trailing module segments" do
       code = ~q[
         %My|Struct.Nested{}
       ]
 
-      assert {:ok, {:struct, MyStruct.Nested}, resolved_range} = resolve(code)
-      assert resolved_range =~ ~S[%«MyStruct.Nested»{}]
+      assert {:ok, {:module, MyStruct}, resolved_range} = resolve(code)
+      assert resolved_range =~ ~S[%«MyStruct».Nested{}]
     end
 
     test "expands current module" do

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/entity_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/entity_test.exs
@@ -236,7 +236,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.EntityTest do
              """
     end
 
-    test "shouldn't includes trailing module segments" do
+    test "shouldn't include trailing module segments" do
       code = ~q[
         %My|Struct.Nested{}
       ]


### PR DESCRIPTION
Taking `Mix.Task.Compiler.Diagnostic` as an example, the references are inconsistent when the cursor is on `%Mix.Task.|Compiler.Diagnostic{}` compared to when it is on `Mix.Task.|Compiler.Diagnostic`.

I believe that maintaining consistency between them would provide a better user experience and make it easier to extend for future features, such as renaming.

<img width="821" alt="CleanShot 2023-10-12 at 22 31 41@2x" src="https://github.com/lexical-lsp/lexical/assets/12830256/e1bb20a0-b8f5-4508-a30e-a66130b345d1">


<img width="867" alt="CleanShot 2023-10-12 at 22 31 52@2x" src="https://github.com/lexical-lsp/lexical/assets/12830256/f4eff43f-a2e4-4690-afdf-2eda8e0a7b3b">


