### PR TITLE
Refactor completions to always use text edits

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion.ex
@@ -71,10 +71,10 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
         |> Enum.map(&Translatable.translate(&1, Builder, env))
 
       true ->
-        {document, position} = Builder.strip_struct_reference(env)
+        {stripped, position} = Builder.strip_struct_operator_for_elixir_sense(env)
 
         project
-        |> RemoteControl.Api.complete(document, position)
+        |> RemoteControl.Api.complete(stripped, position)
         |> to_completion_items(project, env, context)
     end
   end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/builder.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/builder.ex
@@ -1,5 +1,15 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Builder do
-  alias Future.Code, as: Code
+  @moduledoc """
+  Default completion builder.
+
+  For broader compatibility and control, this builder always creates text
+  edits, as opposed to simple text insertions. This allows the replacement
+  range to be adjusted based on the kind of completion.
+
+  When completions are built using `plain_text/3` or `snippet/3`, the
+  replacement range will be determined by the preceding token.
+  """
+
   alias Lexical.Ast.Env
   alias Lexical.Completion.Builder
   alias Lexical.Document
@@ -13,20 +23,15 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Builder do
   @behaviour Builder
 
   @impl Builder
-  def snippet(%Env{}, snippet_text, options \\ []) do
-    options
-    |> Keyword.put(:insert_text, snippet_text)
-    |> Keyword.put(:insert_text_format, :snippet)
-    |> Completion.Item.new()
-    |> boost(0)
+  def snippet(%Env{} = env, text, options \\ []) do
+    range = prefix_range(env)
+    text_edit_snippet(env, text, range, options)
   end
 
   @impl Builder
-  def plain_text(%Env{}, insert_text, options \\ []) do
-    options
-    |> Keyword.put(:insert_text, insert_text)
-    |> Completion.Item.new()
-    |> boost(0)
+  def plain_text(%Env{} = env, text, options \\ []) do
+    range = prefix_range(env)
+    text_edit(env, text, range, options)
   end
 
   @impl Builder
@@ -83,57 +88,94 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Builder do
     %Completion.Item{item | sort_text: sort_text}
   end
 
-  # end builder behaviour
-
-  @spec strip_struct_reference(Env.t()) :: {Document.t(), Position.t()}
-  def strip_struct_reference(%Env{} = env) do
-    if Env.in_context?(env, :struct_reference) do
-      do_strip_struct_reference(env)
-    else
-      {env.document, env.position}
-    end
+  # HACK: This fixes ElixirSense struct completions for certain cases.
+  # We should try removing when we update or remove ElixirSense.
+  @spec strip_struct_operator_for_elixir_sense(Env.t()) ::
+          {Document.t() | String.t(), Position.t()}
+  def strip_struct_operator_for_elixir_sense(%Env{} = env) do
+    do_strip_struct_operator(env)
   end
 
   # private
 
-  defp do_strip_struct_reference(env) do
-    completion_length =
-      case Code.Fragment.cursor_context(env.prefix) do
-        {:struct, {:dot, {:alias, struct_name}, []}} ->
-          # add one because of the trailing period
-          length(struct_name) + 1
+  defp prefix_range(%Env{} = env) do
+    end_char = env.position.character
+    start_char = end_char - prefix_length(env)
+    {start_char, end_char}
+  end
 
-        {:struct, {:local_or_var, local_name}} ->
-          length(local_name)
+  defp prefix_length(%Env{} = env) do
+    case Env.prefix_tokens(env, 1) do
+      [{:operator, :"::", _}] ->
+        0
 
-        {:struct, struct_name} ->
-          length(struct_name)
+      [{:operator, :., _}] ->
+        0
 
-        {:local_or_var, local_name} ->
-          length(local_name)
-      end
+      [{:operator, :in, _}] ->
+        # they're typing integer and got "in" out, which the lexer thinks
+        # is Kernel.in/2
+        2
 
-    column = env.position.character
-    percent_position = column - (completion_length + 1)
+      [{:atom, token, _}] ->
+        length(token) + 1
 
-    new_line_start = String.slice(env.line, 0, percent_position - 1)
-    new_line_end = String.slice(env.line, percent_position..-1)
-    new_line = [new_line_start, new_line_end]
-    new_position = Position.new(env.document, env.position.line, env.position.character - 1)
-    line_to_replace = env.position.line
+      [{_, token, _}] when is_binary(token) ->
+        String.length(token)
 
-    new_document =
-      env.document.lines
-      |> Enum.with_index(1)
-      |> Enum.reduce([], fn
-        {line(ending: ending), ^line_to_replace}, acc ->
-          [acc, new_line, ending]
+      [{_, token, _}] when is_list(token) ->
+        length(token)
 
-        {line(text: line_text, ending: ending), _}, acc ->
-          [acc, line_text, ending]
-      end)
-      |> IO.iodata_to_binary()
+      [{_, token, _}] when is_atom(token) ->
+        token |> Atom.to_string() |> String.length()
+    end
+  end
 
-    {new_document, new_position}
+  defp do_strip_struct_operator(env) do
+    with true <- Env.in_context?(env, :struct_reference),
+         {:ok, completion_length} <- fetch_struct_completion_length(env) do
+      column = env.position.character
+      percent_position = column - (completion_length + 1)
+
+      new_line_start = String.slice(env.line, 0, percent_position - 1)
+      new_line_end = String.slice(env.line, percent_position..-1)
+      new_line = [new_line_start, new_line_end]
+      new_position = Position.new(env.document, env.position.line, env.position.character - 1)
+      line_to_replace = env.position.line
+
+      new_document =
+        env.document.lines
+        |> Enum.with_index(1)
+        |> Enum.reduce([], fn
+          {line(ending: ending), ^line_to_replace}, acc ->
+            [acc, new_line, ending]
+
+          {line(text: line_text, ending: ending), _}, acc ->
+            [acc, line_text, ending]
+        end)
+        |> IO.iodata_to_binary()
+
+      {new_document, new_position}
+    else
+      _ ->
+        {env.document, env.position}
+    end
+  end
+
+  defp fetch_struct_completion_length(env) do
+    case Code.Fragment.cursor_context(env.prefix) do
+      {:struct, {:dot, {:alias, struct_name}, []}} ->
+        # add one because of the trailing period
+        {:ok, length(struct_name) + 1}
+
+      {:struct, {:local_or_var, local_name}} ->
+        {:ok, length(local_name)}
+
+      {:struct, struct_name} ->
+        {:ok, length(struct_name)}
+
+      {:local_or_var, local_name} ->
+        {:ok, length(local_name)}
+    end
   end
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/bitstring_option.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/bitstring_option.ex
@@ -13,35 +13,12 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.BitstringOptio
   end
 
   def translate(%Candidate.BitstringOption{} = option, builder, %Env{} = env) do
-    start_character = env.position.character - prefix_length(env)
-
     env
-    |> builder.text_edit(option.name, {start_character, env.position.character},
+    |> builder.plain_text(option.name,
       filter_text: option.name,
       kind: :unit,
       label: option.name
     )
     |> builder.boost(5)
-  end
-
-  defp prefix_length(%Env{} = env) do
-    case Env.prefix_tokens(env, 1) do
-      [{:operator, :"::", _}] ->
-        0
-
-      [{:operator, :in, _}] ->
-        # they're typing integer and got "in" out, which the lexer thinks
-        # is Kernel.in/2
-        2
-
-      [{_, token, _}] when is_binary(token) ->
-        String.length(token)
-
-      [{_, token, _}] when is_list(token) ->
-        length(token)
-
-      [{_, token, _}] when is_atom(token) ->
-        token |> Atom.to_string() |> String.length()
-    end
   end
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/map_field.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/map_field.ex
@@ -5,11 +5,23 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MapField do
 
   defimpl Translatable, for: Candidate.MapField do
     def translate(%Candidate.MapField{} = map_field, builder, %Env{} = env) do
-      builder.plain_text(env, map_field.name,
+      builder.text_edit(env, map_field.name, range(env),
         detail: map_field.name,
         label: map_field.name,
         kind: :field
       )
+    end
+
+    defp range(%Env{} = env) do
+      case Env.prefix_tokens(env, 1) do
+        # ensure the text edit doesn't overwrite the dot operator
+        # when we're completing immediately after it: some_map.|
+        [{:operator, :., {_line, char}}] ->
+          {char + 1, env.position.character}
+
+        [{_, _, {_line, char}}] ->
+          {char, env.position.character}
+      end
     end
   end
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/module_attribute.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/module_attribute.ex
@@ -17,21 +17,27 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleAttribut
       """
     ) |> String.trim()
 
-    with_doc =
-      builder.snippet(env, doc_snippet,
-        detail: "Module documentation block",
-        kind: :property,
-        label: "@moduledoc"
-      )
+    case fetch_range(env) do
+      {:ok, range} ->
+        with_doc =
+          builder.text_edit_snippet(env, doc_snippet, range,
+            detail: "Module documentation block",
+            kind: :property,
+            label: "@moduledoc"
+          )
 
-    without_doc =
-      builder.plain_text(env, "@moduledoc false",
-        detail: "Skip module documentation",
-        kind: :property,
-        label: "@moduledoc"
-      )
+        without_doc =
+          builder.text_edit(env, "@moduledoc false", range,
+            detail: "Skip module documentation",
+            kind: :property,
+            label: "@moduledoc"
+          )
 
-    [with_doc, without_doc]
+        [with_doc, without_doc]
+
+      :error ->
+        :skip
+    end
   end
 
   def translate(%Candidate.ModuleAttribute{name: "@doc"}, builder, env) do
@@ -41,28 +47,63 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleAttribut
       """
     ) |> String.trim()
 
-    with_doc =
-      builder.snippet(env, doc_snippet,
-        detail: "Function documentation",
-        kind: :property,
-        label: "@doc"
-      )
+    case fetch_range(env) do
+      {:ok, range} ->
+        with_doc =
+          builder.text_edit_snippet(env, doc_snippet, range,
+            detail: "Function documentation",
+            kind: :property,
+            label: "@doc"
+          )
 
-    without_doc =
-      builder.plain_text(env, "@doc false",
-        detail: "Skip function docs",
-        kind: :property,
-        label: "@doc"
-      )
+        without_doc =
+          builder.text_edit(env, "@doc false", range,
+            detail: "Skip function docs",
+            kind: :property,
+            label: "@doc"
+          )
 
-    [with_doc, without_doc]
+        [with_doc, without_doc]
+
+      :error ->
+        :skip
+    end
   end
 
   def translate(%Candidate.ModuleAttribute{} = attribute, builder, env) do
-    builder.plain_text(env, attribute.name,
-      detail: "module attribute",
-      kind: :constant,
-      label: attribute.name
-    )
+    case fetch_range(env) do
+      {:ok, range} ->
+        builder.text_edit(env, attribute.name, range,
+          detail: "module attribute",
+          kind: :constant,
+          label: attribute.name
+        )
+
+      :error ->
+        :skip
+    end
+  end
+
+  defp fetch_range(%Env{} = env) do
+    case fetch_at_op_on_same_line(env) do
+      {:ok, {:at_op, _, {_line, char}}} ->
+        {:ok, {char, env.position.character}}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp fetch_at_op_on_same_line(%Env{} = env) do
+    Enum.reduce_while(Env.prefix_tokens(env), :error, fn
+      {:at_op, _, _} = at_op, _acc ->
+        {:halt, {:ok, at_op}}
+
+      {:eol, _, _}, _acc ->
+        {:halt, :error}
+
+      _, acc ->
+        {:cont, acc}
+    end)
   end
 end

--- a/apps/server/lib/lexical/server/iex/helpers.ex
+++ b/apps/server/lib/lexical/server/iex/helpers.ex
@@ -104,7 +104,42 @@ defmodule Lexical.Server.IEx.Helpers do
     Node.connect(:"#{manager_name}@127.0.0.1")
   end
 
-  def project(project \\ :lexical) when is_atom(project) do
+  @doc """
+  Create a Lexical Project for an application in the same directory as
+  Lexical.
+
+  Alternatively, a project for one of our test fixtures can be created
+  using the `fixture: true` option.
+
+  ## Examples
+
+      iex> project()
+      %Lexical.Project{
+        root_uri: "file:///.../lexical
+        ...
+      }
+
+      iex> project(:my_project)
+      %Lexical.Project{
+        root_uri: "file:///.../my_project"
+        ...
+      }
+
+      iex> project(:navigations, fixture: true)
+      %Lexical.Project{
+        root_uri: "file:///.../lexical/apps/remote_control/test/fixtures/navigations"
+        ...
+      }
+
+  """
+  def project(project \\ :lexical, opts \\ []) do
+    project =
+      if opts[:fixture] do
+        "lexical/apps/remote_control/test/fixtures/#{project}"
+      else
+        project
+      end
+
     # We're using a cache here because we need project's
     # entropy to be the same after every call.
     trans(project, fn ->

--- a/apps/server/test/lexical/server/code_intelligence/completion/builder_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/builder_test.exs
@@ -16,108 +16,6 @@ defmodule Lexical.Server.CodeIntelligence.Completion.BuilderTest do
     env
   end
 
-  describe "strip_struct_reference/1" do
-    test "with a reference followed by  __" do
-      {doc, _position} =
-        "%__"
-        |> new_env()
-        |> strip_struct_reference()
-
-      assert doc == "__"
-    end
-
-    test "with a reference followed by a module name" do
-      {doc, _position} =
-        "%Module"
-        |> new_env()
-        |> strip_struct_reference()
-
-      assert doc == "Module"
-    end
-
-    test "with a reference followed by a module and a dot" do
-      {doc, _position} =
-        "%Module."
-        |> new_env()
-        |> strip_struct_reference()
-
-      assert doc == "Module."
-    end
-
-    test "with a reference followed by a nested module" do
-      {doc, _position} =
-        "%Module.Sub"
-        |> new_env()
-        |> strip_struct_reference()
-
-      assert doc == "Module.Sub"
-    end
-
-    test "with a reference followed by an alias" do
-      code = ~q[
-        alias Something.Else
-        %El|
-      ]t
-
-      {doc, _position} =
-        code
-        |> new_env()
-        |> strip_struct_reference()
-
-      assert doc == "alias Something.Else\nEl"
-    end
-
-    test "on a line with two references, replacing the first" do
-      {doc, _position} =
-        "%First{} = %Se"
-        |> new_env()
-        |> strip_struct_reference()
-
-      assert doc == "%First{} = Se"
-    end
-
-    test "on a line with two references, replacing the second" do
-      {doc, _position} =
-        "%Fir| = %Second{}"
-        |> new_env()
-        |> strip_struct_reference()
-
-      assert doc == "Fir = %Second{}"
-    end
-
-    test "with a plain module" do
-      env = new_env("Module")
-      {doc, _position} = strip_struct_reference(env)
-
-      assert doc == env.document
-    end
-
-    test "with a plain module strip_struct_reference a dot" do
-      env = new_env("Module.")
-      {doc, _position} = strip_struct_reference(env)
-
-      assert doc == env.document
-    end
-
-    test "leaves leading spaces in place" do
-      {doc, _position} =
-        "     %Some"
-        |> new_env()
-        |> strip_struct_reference()
-
-      assert doc == "     Some"
-    end
-
-    test "works in a function definition" do
-      {doc, _position} =
-        "def my_function(%Lo|)"
-        |> new_env()
-        |> strip_struct_reference()
-
-      assert doc == "def my_function(Lo)"
-    end
-  end
-
   def item(label, opts \\ []) do
     opts
     |> Keyword.merge(label: label)
@@ -164,6 +62,108 @@ defmodule Lexical.Server.CodeIntelligence.Completion.BuilderTest do
 
       assert [^global_max, ^group_a_max, ^group_a_min, ^group_b_max, ^group_b_min] =
                sort_items(items)
+    end
+  end
+
+  describe "strip_struct_operator_for_elixir_sense/1" do
+    test "with a reference followed by  __" do
+      {doc, _position} =
+        "%__"
+        |> new_env()
+        |> strip_struct_operator_for_elixir_sense()
+
+      assert doc == "__"
+    end
+
+    test "with a reference followed by a module name" do
+      {doc, _position} =
+        "%Module"
+        |> new_env()
+        |> strip_struct_operator_for_elixir_sense()
+
+      assert doc == "Module"
+    end
+
+    test "with a reference followed by a module and a dot" do
+      {doc, _position} =
+        "%Module."
+        |> new_env()
+        |> strip_struct_operator_for_elixir_sense()
+
+      assert doc == "Module."
+    end
+
+    test "with a reference followed by a nested module" do
+      {doc, _position} =
+        "%Module.Sub"
+        |> new_env()
+        |> strip_struct_operator_for_elixir_sense()
+
+      assert doc == "Module.Sub"
+    end
+
+    test "with a reference followed by an alias" do
+      code = ~q[
+        alias Something.Else
+        %El|
+      ]t
+
+      {doc, _position} =
+        code
+        |> new_env()
+        |> strip_struct_operator_for_elixir_sense()
+
+      assert doc == "alias Something.Else\nEl"
+    end
+
+    test "on a line with two references, replacing the first" do
+      {doc, _position} =
+        "%First{} = %Se"
+        |> new_env()
+        |> strip_struct_operator_for_elixir_sense()
+
+      assert doc == "%First{} = Se"
+    end
+
+    test "on a line with two references, replacing the second" do
+      {doc, _position} =
+        "%Fir| = %Second{}"
+        |> new_env()
+        |> strip_struct_operator_for_elixir_sense()
+
+      assert doc == "Fir = %Second{}"
+    end
+
+    test "with a plain module" do
+      env = new_env("Module")
+      {doc, _position} = strip_struct_operator_for_elixir_sense(env)
+
+      assert doc == env.document
+    end
+
+    test "with a plain module strip_struct_reference a dot" do
+      env = new_env("Module.")
+      {doc, _position} = strip_struct_operator_for_elixir_sense(env)
+
+      assert doc == env.document
+    end
+
+    test "leaves leading spaces in place" do
+      {doc, _position} =
+        "     %Some"
+        |> new_env()
+        |> strip_struct_operator_for_elixir_sense()
+
+      assert doc == "     Some"
+    end
+
+    test "works in a function definition" do
+      {doc, _position} =
+        "def my_function(%Lo|)"
+        |> new_env()
+        |> strip_struct_operator_for_elixir_sense()
+
+      assert doc == "def my_function(Lo)"
     end
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/bitstring_option_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/bitstring_option_test.exs
@@ -132,7 +132,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.BitstringOptio
 
     test "variables are included", %{project: project} do
       code = ~q[
-      bin_length = 5
+        bin_length = 5
         <<foo::binary-size(bin_l|)
       ]
 
@@ -141,7 +141,10 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.BitstringOptio
                |> complete(code)
                |> fetch_completion(kind: :variable)
 
-      assert completion.insert_text == "bin_length"
+      assert apply_completion(completion) == ~q[
+        bin_length = 5
+        <<foo::binary-size(bin_length)
+      ]
     end
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/callback_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/callback_test.exs
@@ -4,10 +4,10 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.CallbackTest d
   describe "callback completions" do
     test "suggest callbacks", %{project: project} do
       source = ~q[
-      defmodule MyServer do
-        use GenServer
-        def handle_inf|
-      end
+        defmodule MyServer do
+          use GenServer
+          def handle_inf|
+        end
       ]
 
       {:ok, completion} =
@@ -15,7 +15,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.CallbackTest d
         |> complete(source)
         |> fetch_completion(kind: :function)
 
-      assert completion.insert_text == "handle_info(${1:msg}, ${2:state})"
+      assert apply_completion(completion) =~ "def handle_info(${1:msg}, ${2:state})"
     end
 
     test "do not add parens if they're already present", %{project: project} do
@@ -24,14 +24,14 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.CallbackTest d
           use GenServer
           def handle_inf|(msg, state)
         end
-        ]
+      ]
 
       {:ok, completion} =
         project
         |> complete(source)
         |> fetch_completion(kind: :function)
 
-      assert completion.insert_text == "handle_info"
+      assert apply_completion(completion) =~ "def handle_info(msg, state)"
     end
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
@@ -6,7 +6,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
   describe "Kernel* macros" do
     test "do/end only has a single completion", %{project: project} do
       assert [completion] = complete(project, "def my_thing do|")
-      assert completion.insert_text == "do\n  $0\nend"
+      assert apply_completion(completion) == "def my_thing do\n  $0\nend"
       assert completion.label == "do/end block"
     end
 
@@ -29,7 +29,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.detail
       assert completion.label == "def (Define a function)"
       assert completion.insert_text_format == :snippet
-      assert completion.insert_text == "def ${1:name}($2) do\n  $0\nend\n"
+      assert apply_completion(completion) == "def ${1:name}($2) do\n  $0\nend\n"
     end
 
     test "defp only has a single completion", %{project: project} do
@@ -50,7 +50,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.detail
       assert completion.label == "defp (Define a private function)"
       assert completion.insert_text_format == :snippet
-      assert completion.insert_text == "defp ${1:name}($2) do\n  $0\nend\n"
+      assert apply_completion(completion) == "defp ${1:name}($2) do\n  $0\nend\n"
     end
 
     test "defmacro only has a single completion", %{project: project} do
@@ -72,7 +72,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.detail
       assert completion.label == "defmacro (Define a macro)"
       assert completion.insert_text_format == :snippet
-      assert completion.insert_text == "defmacro ${1:name}($2) do\n  $0\nend\n"
+      assert apply_completion(completion) == "defmacro ${1:name}($2) do\n  $0\nend\n"
     end
 
     test "defmacrop only has a single completion", %{project: project} do
@@ -94,7 +94,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.detail
       assert completion.label == "defmacrop (Define a private macro)"
       assert completion.insert_text_format == :snippet
-      assert completion.insert_text == "defmacrop ${1:name}($2) do\n  $0\nend\n"
+      assert apply_completion(completion) == "defmacrop ${1:name}($2) do\n  $0\nend\n"
     end
 
     test "defmodule only has a single completion", %{project: project} do
@@ -117,7 +117,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "defmodule (Define a module)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == """
+      assert apply_completion(completion) == """
              defmodule ${1:File} do
                $0
              end
@@ -134,7 +134,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "defmodule (Define a module)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == """
+      assert apply_completion(completion) == """
              defmodule ${1:Foo.Project.MyTest} do
                $0
              end
@@ -151,7 +151,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "defmodule (Define a module)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == """
+      assert apply_completion(completion) == """
              defmodule ${1:Path.To.File} do
                $0
              end
@@ -168,7 +168,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "defmodule (Define a module)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == """
+      assert apply_completion(completion) == """
              defmodule ${1:Path} do
                $0
              end
@@ -195,7 +195,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "defprotocol (Define a protocol)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == """
+      assert apply_completion(completion) == """
              defprotocol ${1:protocol name} do
                $0
              end
@@ -221,7 +221,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "defimpl (Define a protocol implementation)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == ~S"""
+      assert apply_completion(completion) == """
              defimpl ${1:protocol name}, for: ${2:type} do
                $0
              end
@@ -238,7 +238,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "defoverridable (Mark a function as overridable)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == "defoverridable ${1:keyword or behaviour} $0"
+      assert apply_completion(completion) == "defoverridable ${1:keyword or behaviour} $0"
     end
 
     test "defdelegate returns a snippet", %{project: project} do
@@ -250,10 +250,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.detail
       assert completion.label == "defdelegate (Define a delegate function)"
       assert completion.insert_text_format == :snippet
-
-      assert completion.insert_text == ~S"""
-             defdelegate ${1:call}, to: ${2:module} $0
-             """
+      assert apply_completion(completion) == "defdelegate ${1:call}, to: ${2:module} $0\n"
     end
 
     test "defguard returns a snippet", %{project: project} do
@@ -265,10 +262,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.detail
       assert completion.label == "defguard (Define a guard macro)"
       assert completion.insert_text_format == :snippet
-
-      assert completion.insert_text == ~S"""
-             defguard ${1:call} $0
-             """
+      assert apply_completion(completion) == "defguard ${1:call} $0\n"
     end
 
     test "defguardp returns a snippet", %{project: project} do
@@ -280,10 +274,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.detail
       assert completion.label == "defguardp (Define a private guard macro)"
       assert completion.insert_text_format == :snippet
-
-      assert completion.insert_text == ~S"""
-             defguardp ${1:call} $0
-             """
+      assert apply_completion(completion) == "defguardp ${1:call} $0\n"
     end
 
     test "defexception returns a snippet", %{project: project} do
@@ -295,10 +286,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.detail
       assert completion.label == "defexception (Define an exception)"
       assert completion.insert_text_format == :snippet
-
-      assert completion.insert_text == ~S"""
-             defexception [${1:fields}] $0
-             """
+      assert apply_completion(completion) == "defexception [${1:fields}] $0\n"
     end
 
     test "defstruct returns a snippet", %{project: project} do
@@ -310,10 +298,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.detail
       assert completion.label == "defstruct (Define a struct)"
       assert completion.insert_text_format == :snippet
-
-      assert completion.insert_text == ~S"""
-             defstruct [${1:fields}] $0
-             """
+      assert apply_completion(completion) == "defstruct [${1:fields}] $0\n"
     end
 
     test "alias returns a snippet", %{project: project} do
@@ -325,7 +310,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.detail
       assert completion.label == "alias (alias a module's name)"
       assert completion.insert_text_format == :snippet
-      assert completion.insert_text == "alias $0"
+      assert apply_completion(completion) == "alias $0"
     end
 
     test "use returns a snippet", %{project: project} do
@@ -336,7 +321,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
 
       assert completion.label == "use (invoke another module's __using__ macro)"
       assert completion.insert_text_format == :snippet
-      assert completion.insert_text == "use $0"
+      assert apply_completion(completion) == "use $0"
     end
 
     test "import returns a snippet", %{project: project} do
@@ -348,7 +333,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.detail
       assert completion.label == "import (import a module's functions)"
       assert completion.insert_text_format == :snippet
-      assert completion.insert_text == "import $0"
+      assert apply_completion(completion) == "import $0"
     end
 
     test "require returns a snippet", %{project: project} do
@@ -360,7 +345,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.detail
       assert completion.label == "require (require a module's macros)"
       assert completion.insert_text_format == :snippet
-      assert completion.insert_text == "require $0"
+      assert apply_completion(completion) == "require $0"
     end
 
     test "quote returns a snippet", %{project: project} do
@@ -373,7 +358,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "quote (quote block)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == ~S"""
+      assert apply_completion(completion) == """
              quote ${1:options} do
                $0
              end
@@ -390,7 +375,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "receive (receive block)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == ~S"""
+      assert apply_completion(completion) == """
              receive do
                ${1:message shape} -> $0
              end
@@ -407,7 +392,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "try (try / catch / rescue block)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == ~S"""
+      assert apply_completion(completion) == """
              try do
                $0
              end
@@ -424,7 +409,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "with block"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == ~S"""
+      assert apply_completion(completion) == """
              with ${1:match} do
                $0
              end
@@ -441,7 +426,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "if (If statement)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == ~S"""
+      assert apply_completion(completion) == """
              if ${1:test} do
                $0
              end
@@ -458,7 +443,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "unless (Unless statement)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == ~S"""
+      assert apply_completion(completion) == """
              unless ${1:test} do
                $0
              end
@@ -475,7 +460,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "case (Case statement)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == ~S"""
+      assert apply_completion(completion) == """
              case ${1:test} do
                ${2:match} -> $0
              end
@@ -492,7 +477,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "cond (Cond statement)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == ~S"""
+      assert apply_completion(completion) == """
              cond do
                ${1:test} ->
                  $0
@@ -510,7 +495,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.label == "for (comprehension)"
       assert completion.insert_text_format == :snippet
 
-      assert completion.insert_text == ~S"""
+      assert apply_completion(completion) == """
              for ${1:match} <- ${2:enumerable} do
                $0
              end
@@ -611,7 +596,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.kind == :function
       assert completion.insert_text_format == :snippet
       assert completion.label == "macro_add(a, b)"
-      assert completion.insert_text == "macro_add(${1:a}, ${2:b})"
+
+      assert apply_completion(completion) =~ "macro_add(${1:a}, ${2:b})"
     end
 
     test "completes required macros", %{project: project} do
@@ -629,7 +615,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.kind == :function
       assert completion.insert_text_format == :snippet
       assert completion.label == "macro_add(a, b)"
-      assert completion.insert_text == "macro_add(${1:a}, ${2:b})"
+
+      assert apply_completion(completion) =~ "Project.Macros.macro_add(${1:a}, ${2:b})"
     end
 
     test "completes aliased macros", %{project: project} do
@@ -648,7 +635,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
       assert completion.kind == :function
       assert completion.insert_text_format == :snippet
       assert completion.label == "macro_add(a, b)"
-      assert completion.insert_text == "macro_add(${1:a}, ${2:b})"
+
+      assert apply_completion(completion) =~ "Macros.macro_add(${1:a}, ${2:b})"
     end
   end
 
@@ -672,19 +660,21 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
     assert ~S(test "message"           ) = stub.label
     assert "A stub test" = stub.detail
     assert :snippet = stub.insert_text_format
-    assert "test \"${0:message}\"\n" = stub.insert_text
+    assert apply_completion(stub) == inside_exunit_context("test \"${0:message}\"\n")
 
     assert ~S(test "message" do...     ) = with_body.label
     assert "A test" = with_body.detail
     assert :snippet = with_body.insert_text_format
 
-    assert "test \"${1:message}\" do\n  $0\nend\n" = with_body.insert_text
+    assert apply_completion(with_body) ==
+             inside_exunit_context("test \"${1:message}\" do\n  $0\nend\n")
 
     assert ~S(test "message", %{} do...) = with_context.label
     assert "A test that receives context" = with_context.detail
     assert :snippet = with_context.insert_text_format
 
-    assert "test \"${1:message}\", %{${2:context}} do\n  $0\nend\n" = with_context.insert_text
+    assert apply_completion(with_context) ==
+             inside_exunit_context("test \"${1:message}\", %{${2:context}} do\n  $0\nend\n")
   end
 
   test "describe blocks", %{project: project} do
@@ -695,7 +685,9 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
 
     assert describe.label == "describe \"message\""
     assert describe.insert_text_format == :snippet
-    assert describe.insert_text == "describe \"${1:message}\" do\n  $0\nend\n"
+
+    assert apply_completion(describe) ==
+             inside_exunit_context("describe \"${1:message}\" do\n  $0\nend\n")
   end
 
   test "syntax macros", %{project: project} do
@@ -709,11 +701,11 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
   end
 
   defp inside_exunit_context(text) do
-    ~q[
-      defmodule Test do
-        use ExUnit.Case
+    """
+    defmodule Test do
+      use ExUnit.Case
 
-        #{text}
-    ]
+      #{text}
+    """
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/map_field_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/map_field_test.exs
@@ -15,9 +15,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MapFieldTest d
              |> complete(source)
              |> fetch_completion(kind: :field)
 
-    assert completion.insert_text == "first_name"
     assert completion.detail == "first_name"
-    assert completion.label == "first_name"
+    assert apply_completion(completion) =~ "user.first_name"
   end
 
   test "a map's fields are completed after a dot", %{project: project} do
@@ -31,7 +30,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MapFieldTest d
              |> complete(source)
              |> fetch_completion(kind: :field)
 
-    assert first_name.insert_text == "first_name"
-    assert last_name.insert_text == "last_name"
+    assert apply_completion(first_name) =~ "user.first_name"
+    assert apply_completion(last_name) =~ "user.last_name"
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/module_attribute_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/module_attribute_test.exs
@@ -4,19 +4,33 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleAttribut
   describe "module attributes" do
     test "@moduledoc completions", %{project: project} do
       source = ~q[
-      defmodule Docs do
-        @modu|
-      end
+        defmodule Docs do
+          @modu|
+        end
       ]
+
       assert [snippet_completion, empty_completion] = complete(project, source)
 
       assert snippet_completion.detail
-      assert snippet_completion.insert_text == "@moduledoc \"\"\"\n      $0\n      \"\"\""
       assert snippet_completion.label == "@moduledoc"
 
+      # note: indentation should be correctly adjusted by editor
+      assert apply_completion(snippet_completion) == ~q[
+        defmodule Docs do
+          @moduledoc """
+              $0
+              """
+        end
+      ]
+
       assert empty_completion.detail
-      assert empty_completion.insert_text == "@moduledoc false"
       assert empty_completion.label == "@moduledoc"
+
+      assert apply_completion(empty_completion) == ~q[
+        defmodule Docs do
+          @moduledoc false
+        end
+      ]
     end
 
     test "@doc completions", %{project: project} do
@@ -34,14 +48,73 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleAttribut
                |> fetch_completion(kind: :property)
 
       assert snippet_completion.detail
-      assert snippet_completion.insert_text == "@doc \"\"\"\n      $0\n      \"\"\""
       assert snippet_completion.label == "@doc"
       assert snippet_completion.kind == :property
 
+      # note: indentation should be correctly adjusted by editor
+      assert apply_completion(snippet_completion) == ~q[
+        defmodule MyModule do
+          @doc """
+              $0
+              """
+          def other_thing do
+          end
+        end
+      ]
+
       assert empty_completion.detail
-      assert empty_completion.insert_text == "@doc false"
       assert empty_completion.label == "@doc"
       assert empty_completion.kind == :property
+
+      assert apply_completion(empty_completion) == ~q[
+        defmodule MyModule do
+          @doc false
+          def other_thing do
+          end
+        end
+      ]
+    end
+
+    test "local attribute completion with prefix", %{project: project} do
+      source = ~q[
+        defmodule Attr do
+          @my_attribute :foo
+          @my_|
+        end
+      ]
+
+      assert [completion] = complete(project, source)
+      assert completion.label == "@my_attribute"
+
+      assert apply_completion(completion) == ~q[
+        defmodule Attr do
+          @my_attribute :foo
+          @my_attribute
+        end
+      ]
+    end
+
+    test "local attribute completion immediately after @", %{project: project} do
+      source = ~q[
+        defmodule Attr do
+          @my_attribute :foo
+          @|
+        end
+      ]
+
+      assert {:ok, completion} =
+               project
+               |> complete(source)
+               |> fetch_completion("@my_attribute")
+
+      assert completion.label == "@my_attribute"
+
+      assert apply_completion(completion) == ~q[
+        defmodule Attr do
+          @my_attribute :foo
+          @my_attribute
+        end
+      ]
     end
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/module_or_behaviour_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/module_or_behaviour_test.exs
@@ -58,6 +58,18 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
     end
   end
 
+  describe "erlang module completions" do
+    test "unquoted atoms that are modules should emit a completion", %{project: project} do
+      assert {:ok, completion} =
+               project
+               |> complete(":erla|")
+               |> fetch_completion(":erlang")
+
+      assert completion.kind == :module
+      assert apply_completion(completion) == ":erlang"
+    end
+  end
+
   describe "struct references" do
     test "should work for top-level elixir structse", %{project: project} do
       source = ~q[
@@ -235,10 +247,10 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
         use En|
       ]
 
-      completions = complete(project, source)
-      assert length(completions) == 2
-      assert {:ok, _} = fetch_completion(completions, insert_text: "ExUnit")
-      assert {:ok, _} = fetch_completion(completions, insert_text: "ExUnitProperties")
+      assert [ex_unit_completion, ex_unit_properties_completion] = complete(project, source)
+
+      assert apply_completion(ex_unit_completion) =~ "use ExUnit"
+      assert apply_completion(ex_unit_properties_completion) =~ "use ExUnitProperties"
     end
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_field_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_field_test.exs
@@ -12,7 +12,6 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructFieldTes
              |> complete(source)
              |> fetch_completion(kind: :field)
 
-    assert completion.insert_text == "first_name"
     assert completion.detail == "first_name"
     assert completion.label == "first_name"
   end
@@ -29,7 +28,6 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructFieldTes
              |> complete(source)
              |> fetch_completion(kind: :field)
 
-    assert completion.insert_text == "first_name"
     assert completion.detail == "first_name"
     assert completion.label == "first_name"
   end
@@ -46,9 +44,9 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructFieldTes
              |> complete(source)
              |> fetch_completion(kind: :field)
 
-    assert completion.insert_text == "first_name"
     assert completion.detail == "first_name"
     assert completion.label == "first_name"
+    assert apply_completion(completion) =~ "struct.first_name"
   end
 
   test "a struct's fields are completed when the struct is aliased using as", %{project: project} do
@@ -63,9 +61,9 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructFieldTes
              |> complete(source)
              |> fetch_completion(kind: :field)
 
-    assert completion.insert_text == "first_name"
     assert completion.detail == "first_name"
     assert completion.label == "first_name"
+    assert apply_completion(completion) =~ "struct.first_name"
   end
 
   test "a struct defined in function arguments fields are completed", %{project: project} do
@@ -83,9 +81,9 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructFieldTes
              |> complete(source)
              |> fetch_completion(kind: :field)
 
-    assert completion.insert_text == "first_name"
     assert completion.detail == "first_name"
     assert completion.label == "first_name"
+    assert apply_completion(completion) =~ "user.first_name"
   end
 
   describe "in struct arguments" do

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_test.exs
@@ -45,6 +45,31 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructTest do
       assert apply_completion(completion) == expected
     end
 
+    test "should complete in an open block", %{project: project} do
+      source = ~q[
+        defmodule Example do
+          def foo do
+            %Project.Structs.Ac|
+      ]
+
+      assert [completion] = complete(project, source)
+      assert completion.kind == :struct
+      assert apply_completion(completion) =~ "    %Project.Structs.Account{$1}"
+    end
+
+    test "should complete aliases in an open block", %{project: project} do
+      source = ~q[
+        defmodule Example do
+          alias Project.Structs.Account
+          def foo do
+            %Ac|
+      ]
+
+      assert [completion] = complete(project, source)
+      assert completion.kind == :struct
+      assert apply_completion(completion) =~ "    %Account{$1}"
+    end
+
     test "should complete, but not add curlies for aliases after %", %{project: project} do
       source = ~q[
         alias Project.Structs.User
@@ -92,9 +117,14 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructTest do
       ]
 
       assert [completion] = complete(project, source)
-
-      assert completion.insert_text == "User"
       assert completion.kind == :module
+
+      assert apply_completion(completion) == ~q[
+        defmodule TestModule do
+        alias Project.Structs.User
+
+        User
+      ]
     end
 
     test "should complete non-aliased correctly", %{project: project} do
@@ -244,8 +274,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructTest do
 
     test "can be aliased", %{project: project} do
       assert [completion] = complete(project, "alias Project.Structs.A|")
-
-      assert completion.insert_text == "Account"
+      assert apply_completion(completion) == "alias Project.Structs.Account"
     end
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/variable_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/variable_test.exs
@@ -14,9 +14,15 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.VariableTest d
              |> complete(source)
              |> fetch_completion(kind: :variable)
 
-    assert completion.insert_text == "stinky"
     assert completion.label == "stinky"
     assert completion.detail == "stinky"
+
+    assert apply_completion(completion) == ~q[
+      def my_function do
+        stinky = :smelly
+        stinky
+      end
+    ]
   end
 
   test "all variables are returned", %{project: project} do


### PR DESCRIPTION
After discussing with @scohen yesterday about various issues with completions, we decided that some things would be simplified by always using text edits instead of insertions.

Closes #351.