### PR TITLE
Respond with `nil` instead of an error when formatting fails

### DIFF
--- a/apps/server/lib/lexical/server/provider/handlers/formatting.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/formatting.ex
@@ -18,8 +18,7 @@ defmodule Lexical.Server.Provider.Handlers.Formatting do
 
       {:error, reason} ->
         Logger.error("Formatter failed #{inspect(reason)}")
-
-        {:reply, Responses.Formatting.error(request.id, :request_failed, inspect(reason))}
+        {:reply, Responses.Formatting.new(request.id, nil)}
     end
   end
 end


### PR DESCRIPTION
Responding with an error can cause clients to display a pop-up or other notification of the failed request. This can be annoying, however, because diagnostics from the failure will already be displayed.

---

This commit was extracted from #375.