### PR TITLE
Fix spec for `Lexical.Ast.cursor_path/2`

### DIFF
--- a/apps/common/lib/lexical/ast.ex
+++ b/apps/common/lib/lexical/ast.ex
@@ -223,7 +223,7 @@ defmodule Lexical.Ast do
   may return an empty list.
   """
   @spec cursor_path(
-          Document.t() | Macro.t(),
+          Document.t(),
           Position.t() | {Position.line(), Position.character()}
         ) ::
           [Macro.t()]


### PR DESCRIPTION
It doesn't support passing an AST at the moment.