### PR TITLE
Fix invocation with rtx

### DIFF
--- a/apps/remote_control/priv/port_wrapper.sh
+++ b/apps/remote_control/priv/port_wrapper.sh
@@ -16,7 +16,7 @@ case "$(detect_version_manager)" in
         asdf env erl exec "$@" &
         ;;
     rtx)
-        eval "$(rtx env -s bash)"
+        rtx exec -- "$@" &
         ;;
     *)
         exec "$@" &


### PR DESCRIPTION
Fixes the LSP from crashing when used with a project that also uses `rtx`

Invocation of the LSP when using `rtx` resulted on timeout errors that were ultimately due to the port wrapper script
not invoking the provided launcher binary but instead just evaluating env vars and exiting.
