### PR TITLE
Correctly activate rtx during boot

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -161,14 +161,14 @@ jobs:
       # and running the workflow steps.
       matrix:
         include:
-          - elixir: "1.15.3-otp-26"
-            otp: "26.0.2"
-          - elixir: "1.15.3-otp-25"
-            otp: "25.3"
-          - elixir: "1.14.5-otp-25"
-            otp: "25.3"
-          - elixir: "1.13.4-otp-25"
-            otp: "25.3"
+          - elixir: "1.15.6"
+            otp: "26"
+          - elixir: "1.15.6"
+            otp: "25"
+          - elixir: "1.14"
+            otp: "25"
+          - elixir: "1.13"
+            otp: "25"
     steps:
       # Step: Check out the code.
       - name: Checkout code

--- a/bin/activate_version_manager.sh
+++ b/bin/activate_version_manager.sh
@@ -15,17 +15,15 @@
 #
 
 activate_version_manager() {
-    _detect_version_manager ||
-        _try_activating_asdf && _detect_asdf ||
+    if (_detect_asdf || _detect_rtx); then
+        return 0
+    fi
+
+    echo >&2 "No activated version manager detected. Searching for version manager..."
+
+    _try_activating_asdf && _detect_asdf ||
         _try_activating_rtx && _detect_rtx
     return $?
-}
-
-_detect_version_manager() {
-    if ! (_detect_asdf || _detect_rtx); then
-        echo >&2 "No active version manager detected."
-        return 1
-    fi
 }
 
 _detect_asdf() {

--- a/bin/activate_version_manager.sh
+++ b/bin/activate_version_manager.sh
@@ -16,20 +16,20 @@
 
 activate_version_manager() {
     _detect_version_manager ||
-        (_try_activating_asdf && _detect_asdf) ||
-        (_try_activating_rtx && _detect_rtx)
+        _try_activating_asdf && _detect_asdf ||
+        _try_activating_rtx && _detect_rtx
     return $?
 }
 
 _detect_version_manager() {
     if ! (_detect_asdf || _detect_rtx); then
-        echo >&2 "No version manager detected"
+        echo >&2 "No active version manager detected."
         return 1
     fi
 }
 
 _detect_asdf() {
-    if command -v asdf >/dev/null && asdf which elixir >/dev/null 2>&1; then
+    if command -v asdf >/dev/null && asdf which elixir >/dev/null 2>&1 && _ensure_which_elixir asdf; then
         echo >&2 "Detected Elixir through asdf: $(asdf which elixir)"
         return 0
     else
@@ -38,12 +38,17 @@ _detect_asdf() {
 }
 
 _detect_rtx() {
-    if command -v rtx >/dev/null && rtx which elixir >/dev/null 2>&1; then
+    if command -v rtx >/dev/null && rtx which elixir >/dev/null 2>&1 && _ensure_which_elixir rtx; then
         echo >&2 "Detected Elixir through rtx: $(rtx which elixir)"
         return 0
     else
         return 1
     fi
+}
+
+_ensure_which_elixir() {
+    [[ $(which elixir) == *"$1"* ]]
+    return $?
 }
 
 _try_activating_asdf() {
@@ -63,15 +68,12 @@ _try_activating_asdf() {
 _try_activating_rtx() {
     if which rtx >/dev/null; then
         echo >&2 "Found rtx. Activating..."
-        eval "$($(which rtx) activate bash)"
+        eval "$(rtx activate bash)"
+        eval "$(rtx env)"
         return $?
     else
         return 1
     fi
 }
 
-# Run activate_version_manager if we're being run directly. If we're being
-# sourced, let the caller run the function.
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-    activate_version_manager
-fi
+activate_version_manager

--- a/bin/start_lexical.sh
+++ b/bin/start_lexical.sh
@@ -3,8 +3,9 @@ set -eo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-if ! "$script_dir"/activate_version_manager.sh; then
-    echo "Could not activate a version manager."
+# shellcheck disable=SC1091
+if ! . "$script_dir"/activate_version_manager.sh; then
+    echo "Could not activate a version manager. Trying system installation."
 fi
 
 case $1 in

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -28,12 +28,16 @@ COPY integration/boot/set_up_asdf.sh integration/boot/set_up_asdf.sh
 RUN integration/boot/set_up_asdf.sh
 
 COPY apps apps
-COPY bin bin
 COPY config config
 COPY projects projects
 COPY mix* .
 
-COPY integration/boot/set_up_lexical.sh integration/boot/set_up_lexical.sh
-RUN integration/boot/set_up_lexical.sh
+RUN mix local.hex --force
+RUN mix deps.get
+RUN mix compile
+
+COPY bin bin
+
+RUN mix package
 
 CMD bash

--- a/integration/boot/set_up_lexical.sh
+++ b/integration/boot/set_up_lexical.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -eo pipefail
-
-cd /lexical
-
-mix local.hex --force
-mix deps.get
-mix package

--- a/integration/test.sh
+++ b/integration/test.sh
@@ -58,7 +58,7 @@ run_test() {
 
 test_using_system_installation() {
     local expect=(
-        "No active version manager detected"
+        "No activated version manager detected"
         "Could not activate a version manager"
     )
 
@@ -72,7 +72,7 @@ test_find_asdf_directory() {
         'export ASDF_DIR=/version_managers/asdf_vm'
     )
     local expect=(
-        "No active version manager detected"
+        "No activated version manager detected"
         "Found asdf. Activating"
         "Detected Elixir through asdf"
     )
@@ -113,7 +113,7 @@ test_unactivated_rtx() {
         'export PATH="/version_managers/rtx_vm:$PATH"'
     )
     local expect=(
-        "No active version manager detected"
+        "No activated version manager detected"
         "Found rtx"
         "Detected Elixir through rtx"
     )

--- a/integration/test.sh
+++ b/integration/test.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Disable warning for interpolations in single quotes:
+# shellcheck disable=2016
+
 set -eo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
@@ -52,10 +56,9 @@ run_test() {
     fi
 }
 
-# Tests:
-
 test_using_system_installation() {
     local expect=(
+        "No active version manager detected"
         "Could not activate a version manager"
     )
 
@@ -64,38 +67,59 @@ test_using_system_installation() {
 }
 
 test_find_asdf_directory() {
+    local setup=(
+        'mv "$(which elixir)" "$(which elixir).hidden" && '
+        'export ASDF_DIR=/version_managers/asdf_vm'
+    )
     local expect=(
-        "No version manager detected"
-        "Found asdf"
+        "No active version manager detected"
+        "Found asdf. Activating"
         "Detected Elixir through asdf"
     )
-    local setup="export ASDF_DIR=/version_managers/asdf_vm"
 
-    run_test "$setup" "${expect[@]}"
+    run_test "${setup[*]}" "${expect[@]}"
     return $?
 }
 
 test_activated_asdf() {
+    local setup=(
+        'mv "$(which elixir)" "$(which elixir).hidden" && '
+        "ASDF_DIR=/version_managers/asdf_vm . /version_managers/asdf_vm/asdf.sh"
+    )
     local expect=(
         "Detected Elixir through asdf"
     )
-    local setup="ASDF_DIR=/version_managers/asdf_vm . /version_managers/asdf_vm/asdf.sh"
 
-    run_test "$setup" "${expect[@]}"
+    run_test "${setup[*]}" "${expect[@]}"
     return $?
 }
 
 test_activated_rtx() {
+    local setup=(
+        'mv "$(which elixir)" "$(which elixir).hidden" && '
+        'eval "$(/version_managers/rtx_vm/rtx activate bash)"'
+    )
     local expect=(
         "Detected Elixir through rtx"
     )
-    # shellcheck disable=2016
-    local setup='eval "$(/version_managers/rtx_vm/rtx activate bash)"'
 
-    run_test "$setup" "${expect[@]}"
+    run_test "${setup[*]}" "${expect[@]}"
     return $?
 }
 
-# Run all tests
+test_unactivated_rtx() {
+    local setup=(
+        'mv "$(which elixir)" "$(which elixir).hidden" && '
+        'export PATH="/version_managers/rtx_vm:$PATH"'
+    )
+    local expect=(
+        "No active version manager detected"
+        "Found rtx"
+        "Detected Elixir through rtx"
+    )
+
+    run_test "${setup[*]}" "${expect[@]}"
+    return $?
+}
 
 run_tests_and_exit

--- a/integration/test_utils.sh
+++ b/integration/test_utils.sh
@@ -27,19 +27,9 @@ assert_contains() {
 
     if [ ${#not_found[@]} -ne 0 ]; then
         log_error "Assertion failed!"
-
-        log "\n  ${cyan}Expected:${reset}\n\n"
-
-        for expected in "${not_found[@]}"; do
-            prefix_lines "    " "$expected"
-        done
-
-        log "\n  ${cyan}To be in:${reset}\n\n"
-
-        prefix_lines "    " "$output"
-
+        log_section "Expected" "${not_found[@]}"
+        log_section "To be in" "$output"
         log "\n\n"
-
         return 1
     fi
 }
@@ -84,6 +74,17 @@ log_success() {
 
 log_info() {
     log "${faint}$1${reset}\n"
+}
+
+log_section() {
+    local title="$1"
+    local content=("${@:2}")
+
+    log "\n  ${cyan}${title}:${reset}\n\n"
+
+    for item in "${content[@]}"; do
+        prefix_lines "    " "$item"
+    done
 }
 
 prefix_lines() {


### PR DESCRIPTION
Closes #423

Depending on how an editor was started (from command line or other), rtx environment variables could be missing that would cause Lexical to fail to boot. The salient change using both of these commands to activate rtx:

```
eval "$(rtx activate bash)"
eval "$(rtx env)"
```

This ensures that the environment is properly set up, i.e. `$PATH` is as expected.

The additional changes to this commit improve the integration tests and prevents errors from being masked by the system installation.