### PR TITLE
Quieted noisy tests

### DIFF
--- a/apps/remote_control/test/lexical/remote_control/build/document/compilers/eex_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/document/compilers/eex_test.exs
@@ -9,7 +9,8 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EExTest do
 
   use ExUnit.Case
 
-  import Compilers.EEx
+  import Compilers.EEx, only: [recognizes?: 1]
+  import Lexical.Test.Quiet
   import Lexical.Test.CodeSigil
 
   def with_capture_server(_) do
@@ -25,6 +26,10 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EExTest do
 
   def document_with_content(content) do
     Document.new("file:///file.eex", content, 0)
+  end
+
+  def compile(document) do
+    quiet(:stderr, fn -> Compilers.EEx.compile(document) end)
   end
 
   setup_all do

--- a/apps/remote_control/test/lexical/remote_control/build/document/compilers/heex_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/document/compilers/heex_test.exs
@@ -8,8 +8,7 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.HeexTest do
   alias Lexical.RemoteControl.ModuleMappings
 
   import Lexical.Test.CodeSigil
-  import Compilers.HEEx, only: [compile: 1]
-
+  import Lexical.Test.Quiet
   use ExUnit.Case
 
   def with_capture_server(_) do
@@ -29,6 +28,12 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.HeexTest do
 
     on_exit(fn ->
       Code.compiler_options(prev_compiler_options)
+    end)
+  end
+
+  def compile(document) do
+    quiet(:stderr, fn ->
+      Compilers.HEEx.compile(document)
     end)
   end
 

--- a/apps/remote_control/test/lexical/remote_control/completion_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/completion_test.exs
@@ -4,6 +4,7 @@ defmodule Lexical.RemoteControl.CompletionTest do
 
   import Lexical.Test.CursorSupport
   import Lexical.Test.CodeSigil
+  import Lexical.Test.Quiet
 
   use ExUnit.Case, async: true
 
@@ -89,7 +90,10 @@ defmodule Lexical.RemoteControl.CompletionTest do
     {position, document} = pop_cursor(source, as: :document)
 
     text = Document.to_string(document)
-    Code.compile_string(text)
+
+    quiet(:stderr, fn ->
+      Code.compile_string(text)
+    end)
 
     Completion.struct_fields(document, position)
   end

--- a/projects/lexical_test/lib/lexical/test/quiet.ex
+++ b/projects/lexical_test/lib/lexical/test/quiet.ex
@@ -1,0 +1,15 @@
+defmodule Lexical.Test.Quiet do
+  import ExUnit.CaptureIO
+
+  def quiet(io_device \\ :stdio, fun) do
+    test_pid = self()
+
+    capture_io(io_device, fn ->
+      send(test_pid, {:result, fun.()})
+    end)
+
+    receive do
+      {:result, result} -> result
+    end
+  end
+end


### PR DESCRIPTION
Quieted most of the noisy tests, though project builds are emitting noise through a mechanism that capture_io can't handle.

Fixes #401 