### PR TITLE
Fix specs in `Lexical.Document.Path`

### DIFF
--- a/projects/lexical_shared/lib/lexical/document/path.ex
+++ b/projects/lexical_shared/lib/lexical/document/path.ex
@@ -5,19 +5,21 @@ defmodule Lexical.Document.Path do
   @file_scheme "file"
 
   @type uri_or_path :: Lexical.uri() | Lexical.path()
+
   @doc """
   Given a uri or a path, either return the uri unmodified or converts the path to a uri
   """
+  @spec ensure_uri(uri_or_path()) :: Lexical.uri()
   def ensure_uri("file://" <> _ = uri), do: uri
 
   def ensure_uri(path), do: to_uri(path)
 
-  def ensure_path("file://" <> _ = uri), do: from_uri(uri)
-
   @doc """
   Given a uri or a path, either return the path unmodified or converts the uri to a path
   """
-  @spec ensure_uri(uri_or_path()) :: Lexical.uri()
+  @spec ensure_path(uri_or_path()) :: Lexical.path()
+  def ensure_path("file://" <> _ = uri), do: from_uri(uri)
+
   def ensure_path(path), do: path
 
   @doc """


### PR DESCRIPTION
Closes #361 