### PR TITLE
Removed optional synchronization for ETS backend

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/store/backend.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backend.ex
@@ -35,10 +35,9 @@ defmodule Lexical.RemoteControl.Search.Store.Backend do
   @callback prepare(priv_state()) :: {:ok, load_state()}
 
   @doc """
-  Optionally syncs the backend to the file system (optional)
-  If the force? option is true, the bacend ensures that it immediately writes its content
+  Synchronizes the backend to the file system (optional)
   """
-  @callback sync(Project.t(), boolean) :: :ok | {:error, any()}
+  @callback sync(Project.t()) :: :ok | {:error, any()}
 
   @doc """
   Inserts all entries into the backend
@@ -80,5 +79,5 @@ defmodule Lexical.RemoteControl.Search.Store.Backend do
   """
   @callback find_by_refs([reference()], type_query(), subtype_query()) :: [Entry.t()]
 
-  @optional_callbacks sync: 2
+  @optional_callbacks sync: 1
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
@@ -6,8 +6,6 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
 
   use GenServer
 
-  @sync_interval_ms 5000
-
   @behaviour Backend
 
   @impl Backend
@@ -21,8 +19,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
   end
 
   @impl Backend
-  def sync(%Project{}, force?) do
-    GenServer.call(genserver_name(), {:sync, force?})
+  def sync(%Project{}) do
+    GenServer.call(genserver_name(), :sync)
   end
 
   @impl Backend
@@ -91,7 +89,6 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
 
     with :undefined <- :global.whereis_name(leader_name),
          :ok <- become_leader(project) do
-      schedule_sync()
       {:noreply, create_leader(project)}
     else
       _ ->
@@ -106,8 +103,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
     {:reply, reply, new_state}
   end
 
-  def handle_call({:sync, force?}, _from, %State{} = state) do
-    state = State.sync(state, force?)
+  def handle_call(:sync, _from, %State{} = state) do
+    state = State.sync(state)
     {:reply, :ok, state}
   end
 
@@ -115,11 +112,6 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
     arguments = [state | arguments]
     reply = apply(State, function_name, arguments)
     {:reply, reply, state}
-  end
-
-  def handle_call(:force_sync, _from, %State{} = state) do
-    new_state = State.sync(state, false)
-    {:reply, :ok, new_state}
   end
 
   @impl GenServer
@@ -137,12 +129,6 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
     # This clause means we were randomly notified by the call to
     # :global.random_notify_name. We've been selected to be the leader!
     new_state = become_leader(state.project)
-    {:noreply, new_state}
-  end
-
-  def handle_info(:do_sync, %State{} = state) do
-    new_state = State.sync(state, true)
-    schedule_sync()
     {:noreply, new_state}
   end
 
@@ -212,9 +198,5 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
         String.contains?(node_name_string, project_substring) do
       :"#{node_name_string}@127.0.0.1"
     end
-  end
-
-  def schedule_sync do
-    Process.send_after(self(), :do_sync, @sync_interval_ms)
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/state.ex
@@ -66,7 +66,7 @@ defmodule Lexical.RemoteControl.Search.Store.State do
 
   def replace(%__MODULE__{} = state, entries) do
     with :ok <- state.backend.replace_all(entries),
-         :ok <- maybe_sync(state, false) do
+         :ok <- maybe_sync(state) do
       {:ok, %__MODULE__{state | fuzzy: Fuzzy.from_entries(entries)}}
     end
   end
@@ -104,7 +104,7 @@ defmodule Lexical.RemoteControl.Search.Store.State do
 
   def flush_buffered_updates(%__MODULE__{update_buffer: buffer} = state)
       when map_size(buffer) == 0 do
-    maybe_sync(state, true)
+    maybe_sync(state)
     {:ok, state}
   end
 
@@ -121,7 +121,7 @@ defmodule Lexical.RemoteControl.Search.Store.State do
       end)
 
     with %__MODULE__{} = state <- result,
-         :ok <- maybe_sync(state, true) do
+         :ok <- maybe_sync(state) do
       {:ok, drop_buffered_updates(state)}
     end
   end
@@ -204,9 +204,9 @@ defmodule Lexical.RemoteControl.Search.Store.State do
     state
   end
 
-  defp maybe_sync(%__MODULE__{} = state, force?) do
-    if function_exported?(state.backend, :sync, 2) do
-      state.backend.sync(state.project, force?)
+  defp maybe_sync(%__MODULE__{} = state) do
+    if function_exported?(state.backend, :sync, 1) do
+      state.backend.sync(state.project)
     else
       :ok
     end

--- a/apps/remote_control/test/lexical/remote_control/search/store/backends/ets_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store/backends/ets_test.exs
@@ -209,7 +209,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backend.EtsTest do
       entries = [definition(subject: My.Module)]
 
       assert :ok = Store.replace(entries)
-      Backends.Ets.sync(project, true)
+      Backends.Ets.sync(project)
 
       Store.stop()
 
@@ -241,7 +241,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backend.EtsTest do
   end
 
   def restart_store(%Project{} = project) do
-    Backends.Ets.sync(project, true)
+    Backends.Ets.sync(project)
 
     Store
     |> Process.whereis()


### PR DESCRIPTION
Since we made the store buffer updates, it doesn't make sense to also have the backkends do the same.