### PR TITLE
Bugfix: Document Store needs to be globally unique

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/bootstrap.ex
+++ b/apps/remote_control/lib/lexical/remote_control/bootstrap.ex
@@ -10,7 +10,8 @@ defmodule Lexical.RemoteControl.Bootstrap do
   alias Lexical.RemoteControl
   require Logger
 
-  def init(%Project{} = project, remote_control_config) do
+  def init(%Project{} = project, document_store_entropy, remote_control_config) do
+    Lexical.Document.Store.set_entropy(document_store_entropy)
     maybe_append_hex_path()
     Application.put_all_env(remote_control: remote_control_config)
 

--- a/apps/remote_control/lib/lexical/remote_control/project_node.ex
+++ b/apps/remote_control/lib/lexical/remote_control/project_node.ex
@@ -97,20 +97,18 @@ defmodule Lexical.RemoteControl.ProjectNode do
     end
   end
 
+  alias Lexical.Document
   alias Lexical.RemoteControl.ProjectNodeSupervisor
   use GenServer
 
   def start(project, paths) do
     node_name = Project.node_name(project)
     remote_control_config = Application.get_all_env(:remote_control)
+    bootstrap_args = [project, Document.Store.entropy(), remote_control_config]
 
     with {:ok, node_pid} <- ProjectNodeSupervisor.start_project_node(project),
          :ok <- start_node(project, paths),
-         :ok <-
-           :rpc.call(node_name, RemoteControl.Bootstrap, :init, [
-             project,
-             remote_control_config
-           ]) do
+         :ok <- :rpc.call(node_name, RemoteControl.Bootstrap, :init, bootstrap_args) do
       {:ok, node_pid}
     end
   end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
@@ -101,9 +101,13 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
 
   @impl GenServer
   def handle_call(:prepare, _from, %State{} = state) do
-    {reply, new_state} = State.prepare(state)
+    case State.prepare(state) do
+      {:error, :not_leader} = error ->
+        {:stop, :normal, error, state}
 
-    {:reply, reply, new_state}
+      {reply, new_state} ->
+        {:reply, reply, new_state}
+    end
   end
 
   def handle_call({:sync, force?}, _from, %State{} = state) do

--- a/projects/lexical_shared/lib/lexical/document/store.ex
+++ b/projects/lexical_shared/lib/lexical/document/store.ex
@@ -334,7 +334,28 @@ defmodule Lexical.Document.Store do
     {:noreply, State.unload(state, uri)}
   end
 
+  def set_entropy(entropy) do
+    :persistent_term.put(entropy_key(), entropy)
+    entropy
+  end
+
+  def entropy do
+    case :persistent_term.get(entropy_key(), :undefined) do
+      :undefined ->
+        [:positive]
+        |> System.unique_integer()
+        |> set_entropy()
+
+      entropy ->
+        entropy
+    end
+  end
+
   def name do
-    {:via, :global, __MODULE__}
+    {:via, :global, {__MODULE__, entropy()}}
+  end
+
+  defp entropy_key do
+    {__MODULE__, :entropy}
   end
 end


### PR DESCRIPTION
Due to all nodes being connected via distribution after the ETS store is enabled, we can no longer register a document store globally with a non-unique name because Document.Store needs to be associated with an editor.
This change creates some entropy when the server starts to make the document store's name unique, and passes that entropy to the project node.

Fixes #425