### PR TITLE
Fix crash on boot due to precedence bug and stdio log

### DIFF
--- a/bin/activate_version_manager.sh
+++ b/bin/activate_version_manager.sh
@@ -21,8 +21,8 @@ activate_version_manager() {
 
     echo >&2 "No activated version manager detected. Searching for version manager..."
 
-    _try_activating_asdf && _detect_asdf ||
-        _try_activating_rtx && _detect_rtx
+    { _try_activating_asdf && _detect_asdf; } ||
+        { _try_activating_rtx && _detect_rtx; }
     return $?
 }
 

--- a/bin/start_lexical.sh
+++ b/bin/start_lexical.sh
@@ -5,7 +5,7 @@ script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 # shellcheck disable=SC1091
 if ! . "$script_dir"/activate_version_manager.sh; then
-    echo "Could not activate a version manager. Trying system installation."
+    echo >&2 "Could not activate a version manager. Trying system installation."
 fi
 
 case $1 in

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -3,10 +3,13 @@
 # Build: docker build -t lx -f integration/Dockerfile .
 # Run:   docker run -it lx
 
-ARG ELIXIR_VERSION=1.15.6
-ARG ERLANG_VERSION=26.1.1
+ARG SYS_ELIXIR_VERSION=1.15.6
+ARG SYS_ERLANG_VERSION=26.1.1
 
-FROM hexpm/elixir:${ELIXIR_VERSION}-erlang-${ERLANG_VERSION}-ubuntu-jammy-20230126
+FROM hexpm/elixir:${SYS_ELIXIR_VERSION}-erlang-${SYS_ERLANG_VERSION}-ubuntu-jammy-20230126
+
+ENV ELIXIR_VERSION=1.15.6-otp-26
+ENV ERLANG_VERSION=26.1.1
 
 RUN apt-get update
 RUN apt-get install -y \

--- a/integration/boot/set_up_asdf.sh
+++ b/integration/boot/set_up_asdf.sh
@@ -13,9 +13,9 @@ asdf update
 
 export KERL_CONFIGURE_OPTIONS="--disable-debug --without-javac --without-termcap --without-wx"
 asdf plugin add erlang https://github.com/asdf-vm/asdf-erlang.git
-asdf install erlang latest
-asdf global erlang latest
+asdf install erlang "$ERLANG_VERSION"
+asdf global erlang "$ERLANG_VERSION"
 
 asdf plugin add elixir https://github.com/asdf-vm/asdf-elixir.git
-asdf install elixir latest
-asdf global elixir latest
+asdf install elixir "$ELIXIR_VERSION"
+asdf global elixir "$ELIXIR_VERSION"

--- a/integration/boot/set_up_rtx.sh
+++ b/integration/boot/set_up_rtx.sh
@@ -28,7 +28,7 @@ eval "$(./rtx activate bash)"
 
 export KERL_CONFIGURE_OPTIONS="--disable-debug --without-javac --without-termcap --without-wx"
 ./rtx plugins install erlang
-./rtx use --global erlang@latest
+./rtx use --global "erlang@$ERLANG_VERSION"
 
 ./rtx plugins install elixir
-./rtx use --global elixir@latest
+./rtx use --global "elixir@$ELIXIR_VERSION"

--- a/integration/test.sh
+++ b/integration/test.sh
@@ -56,7 +56,7 @@ run_test() {
     fi
 }
 
-test_using_system_installation() {
+test_system_installation() {
     local expect=(
         "No activated version manager detected"
         "Could not activate a version manager"
@@ -66,7 +66,20 @@ test_using_system_installation() {
     return $?
 }
 
-test_find_asdf_directory() {
+test_asdf_already_activated() {
+    local setup=(
+        'mv "$(which elixir)" "$(which elixir).hidden" && '
+        'ASDF_DIR=/version_managers/asdf_vm . /version_managers/asdf_vm/asdf.sh'
+    )
+    local expect=(
+        "Detected Elixir through asdf"
+    )
+
+    run_test "${setup[*]}" "${expect[@]}"
+    return $?
+}
+
+test_asdf_dir_found() {
     local setup=(
         'mv "$(which elixir)" "$(which elixir).hidden" && '
         'export ASDF_DIR=/version_managers/asdf_vm'
@@ -81,12 +94,16 @@ test_find_asdf_directory() {
     return $?
 }
 
-test_activated_asdf() {
+test_asdf_used_when_activated_rtx_missing_elixir() {
     local setup=(
         'mv "$(which elixir)" "$(which elixir).hidden" && '
-        "ASDF_DIR=/version_managers/asdf_vm . /version_managers/asdf_vm/asdf.sh"
+        'eval "$(/version_managers/rtx_vm/rtx activate bash)" && '
+        'rtx uninstall "elixir@$ELIXIR_VERSION" && '
+        'export ASDF_DIR=/version_managers/asdf_vm'
     )
     local expect=(
+        "No activated version manager detected"
+        "Found asdf. Activating"
         "Detected Elixir through asdf"
     )
 
@@ -94,7 +111,7 @@ test_activated_asdf() {
     return $?
 }
 
-test_activated_rtx() {
+test_rtx_already_activated() {
     local setup=(
         'mv "$(which elixir)" "$(which elixir).hidden" && '
         'eval "$(/version_managers/rtx_vm/rtx activate bash)"'
@@ -107,7 +124,7 @@ test_activated_rtx() {
     return $?
 }
 
-test_unactivated_rtx() {
+test_rtx_binary_found_and_activated() {
     local setup=(
         'mv "$(which elixir)" "$(which elixir).hidden" && '
         'export PATH="/version_managers/rtx_vm:$PATH"'
@@ -115,6 +132,23 @@ test_unactivated_rtx() {
     local expect=(
         "No activated version manager detected"
         "Found rtx"
+        "Detected Elixir through rtx"
+    )
+
+    run_test "${setup[*]}" "${expect[@]}"
+    return $?
+}
+
+test_rtx_used_when_activated_asdf_missing_elixir() {
+    local setup=(
+        'mv "$(which elixir)" "$(which elixir).hidden" && '
+        'ASDF_DIR=/version_managers/asdf_vm . /version_managers/asdf_vm/asdf.sh && '
+        'asdf uninstall elixir "$ELIXIR_VERSION" && '
+        'export PATH="/version_managers/rtx_vm:$PATH"'
+    )
+    local expect=(
+        "No activated version manager detected"
+        "Found rtx. Activating"
         "Detected Elixir through rtx"
     )
 


### PR DESCRIPTION
The checks in `activate_version_manager.sh` need explicit `{ }` to prevent `_detect_rtx` from always running. This would cause the script to exit with an error spuriously, which would trigger an error message that was being written to stdio. Because we use stdio as our transport, that would cause the LS client to crash.

This fixes the crash reported in #440. However, it will still run the server using asdf if both asdf and rtx are installed with the correct versions of Elixir.