### PR TITLE
Omit name and body during updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,3 +53,5 @@ jobs:
           generateReleaseNotes: true
           allowUpdates: true
           artifactErrorsFailBuild: true
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true


### PR DESCRIPTION
I re-ran the release to regenerate the artifacts, and it clobbered my release notes. I think this will prevent that from happening in the future.