### PR TITLE
Use Elixir and OTP versions in CI cache keys

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -41,26 +41,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set Variables
-        id: set_mix_lock_hash
-        run: |
-          mix_lock_hash="${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}"
-          echo "mix_lock_hash=$mix_lock_hash" >> "$GITHUB_OUTPUT"
-
       # Step: Define how to cache deps. Restores existing cache if present.
       - name: Cache deps
         id: cache-deps
         uses: actions/cache@v3
-        env:
-          cache-name: cache-elixir-deps-1
         with:
           path: |
             deps
             _build
 
-          key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-mix-${{ env.DEFAULT_ELIXIR }}-${{ env.DEFAULT_OTP }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-${{ env.cache-name }}-
+            ${{ runner.os }}-mix-${{ env.DEFAULT_ELIXIR }}-${{ env.DEFAULT_OTP }}-
 
       # Step: Download project dependencies. If unchanged, uses
       # the cached version.
@@ -120,9 +112,9 @@ jobs:
             deps
             _build
 
-          key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-mix-${{ env.DEFAULT_ELIXIR }}-${{ env.DEFAULT_OTP }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-${{ env.cache-name }}-
+            ${{ runner.os }}-mix-${{ env.DEFAULT_ELIXIR }}-${{ env.DEFAULT_OTP }}-
 
       # Step: Create dialyzer .plt files if they're not present
       - name: Cache dialyzer plt files
@@ -181,26 +173,18 @@ jobs:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
-      - name: Set Variables
-        id: set_mix_lock_hash
-        run: |
-          mix_lock_hash="${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}"
-          echo "mix_lock_hash=$mix_lock_hash" >> "$GITHUB_OUTPUT"
-
       # Step: Define how to cache deps. Restores existing cache if present.
       - name: Cache deps
         id: cache-deps
         uses: actions/cache@v3
-        env:
-          cache-name: cache-elixir-deps-1
         with:
           path: |
             deps
             _build
 
-          key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-${{ env.cache-name }}-
+            ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-
 
       # Step: Download project dependencies. If unchanged, uses
       # the cached version.


### PR DESCRIPTION
I was running into some [weird compilation issues](https://github.com/lexical-lsp/lexical/actions/runs/6721278415/job/18266663488) that I suspected was due to deps caching. Looking at the CI config, it seemed like the Elixir/OTP versions weren't being used in the cache key, which could cause caches to be shared between runs of different Elixir versions.

It's possible that some of the namespacing stuff we're doing caused the Elixir compiler to not invalidate/re-compile something that needed to be compiled on a different version -- I'm not sure.

Anyways, once I keyed the deps cache off of Elixir/OTP versions, the build started passing.