### PR TITLE
Made build directory specific to elixir and erlang versions

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build.ex
@@ -3,6 +3,7 @@ defmodule Lexical.RemoteControl.Build do
   alias Lexical.Project
   alias Lexical.RemoteControl
   alias Lexical.RemoteControl.Build.State
+  alias Lexical.VM.Versions
 
   require Logger
   use GenServer
@@ -10,6 +11,15 @@ defmodule Lexical.RemoteControl.Build do
   @tick_interval_millis 50
 
   # Public interface
+
+  def path(%Project{} = project) do
+    %{elixir: elixir, erlang: erlang} = Versions.current()
+    erlang_major = erlang |> String.split(".") |> List.first()
+    elixir_version = Version.parse!(elixir)
+    elixir_major = "#{elixir_version.major}.#{elixir_version.minor}"
+    build_root = Project.build_path(project)
+    Path.join([build_root, "erl-#{erlang_major}", "elixir-#{elixir_major}"])
+  end
 
   def schedule_compile(%Project{} = project, force? \\ false) do
     RemoteControl.call(project, GenServer, :cast, [__MODULE__, {:compile, force?}])

--- a/apps/remote_control/lib/lexical/remote_control/mix.ex
+++ b/apps/remote_control/lib/lexical/remote_control/mix.ex
@@ -21,7 +21,7 @@ defmodule Lexical.RemoteControl.Mix do
       try do
         Mix.ProjectStack.post_config(prune_code_paths: false)
 
-        build_path = Project.build_path(project)
+        build_path = RemoteControl.Build.path(project)
         project_root = Project.root_path(project)
 
         project

--- a/apps/server/lib/lexical/server/project/node.ex
+++ b/apps/server/lib/lexical/server/project/node.ex
@@ -98,7 +98,9 @@ defmodule Lexical.Server.Project.Node do
   end
 
   defp delete_build_artifacts(%Project{} = project) do
-    case File.rm_rf(Project.build_path(project)) do
+    build_path = RemoteControl.Build.path(project)
+
+    case File.rm_rf(build_path) do
       {:ok, _deleted} -> :ok
       error -> error
     end


### PR DESCRIPTION
Build directories are now specific to elixir and erlang versions. This allows us to keep artifacts around even if versions change. This helps move us towards not having to do full builds on start.

This PR also deletes builds older than two months that haven't changed to save hard disk space

Fixes #429