### PR TITLE
Ignore `undefined variables` error for HEEx files

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build/document/compilers/eex.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document/compilers/eex.ex
@@ -80,7 +80,6 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EEx do
           |> Enum.reverse()
           |> Build.Error.refine_diagnostics()
           |> Enum.map(&Map.replace!(&1, :source, "EEx"))
-          |> reject_undefined_variables()
 
         {:error, diagnostics}
     end
@@ -92,7 +91,7 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EEx do
     apply(Code, :with_diagnostics, [fn -> do_eval_quoted(quoted_ast, path) end])
   end
 
-  defp do_eval_quoted(quoted_ast, path) do
+  def do_eval_quoted(quoted_ast, path) do
     try do
       {result, _} = Code.eval_quoted(quoted_ast, [assigns: %{}], file: path)
       {:ok, result}
@@ -109,20 +108,6 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EEx do
     # for example: `<%= @name %>`
     Enum.reject(errors, fn %Result{message: message} ->
       message =~ ~s[undefined variable "assigns"]
-    end)
-  end
-
-  defp reject_undefined_variables(errors) do
-    # NOTE: Ignoring error for undefined variables
-    # for example:
-    # ```heex
-    # <.inputs_for :let={finner} field={f[:inner]}>
-    #  <%= finner %>
-    # </.inputs_for>
-    # ```
-    # the `finner` variable is defined by `:let` of `inputs_for`
-    Enum.reject(errors, fn %Result{message: message} ->
-      message =~ ~s[undefined variable]
     end)
   end
 

--- a/apps/remote_control/lib/lexical/remote_control/build/document/compilers/eex.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document/compilers/eex.ex
@@ -45,7 +45,7 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EEx do
     end
   end
 
-  defp eval_quoted(%Document{} = document, quoted_ast) do
+  def eval_quoted(%Document{} = document, quoted_ast) do
     result =
       if Elixir.Features.with_diagnostics?() do
         eval_quoted_with_diagnostics(quoted_ast, document.path)
@@ -93,7 +93,8 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EEx do
 
   def do_eval_quoted(quoted_ast, path) do
     try do
-      {result, _} = Code.eval_quoted(quoted_ast, [assigns: %{}], file: path)
+      env = Map.put(__ENV__, :file, path)
+      {result, _} = Code.eval_quoted(quoted_ast, [assigns: %{}], env)
       {:ok, result}
     rescue
       exception ->

--- a/apps/remote_control/lib/lexical/remote_control/build/document/compilers/heex.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document/compilers/heex.ex
@@ -26,7 +26,7 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.HEEx do
 
   defp eval_heex_quoted(document) do
     with {:ok, quoted} <- heex_to_quoted(document) do
-      Compilers.EEx.eval_quoted(document, quoted, "heex")
+      Compilers.EEx.eval_quoted(document, quoted)
     end
   end
 

--- a/apps/remote_control/lib/lexical/remote_control/build/document/compilers/heex.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document/compilers/heex.ex
@@ -19,12 +19,9 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.HEEx do
   end
 
   def compile(%Document{} = document) do
-    case heex_to_quoted(document) do
-      {:ok, _} ->
-        Compilers.EEx.compile(document)
-
-      other ->
-        other
+    with {:ok, quoted} <- heex_to_quoted(document),
+         :ok <- Compilers.EEx.eval_quoted(document, quoted) do
+      {:ok, []}
     end
   end
 

--- a/apps/remote_control/lib/lexical/remote_control/build/error.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/error.ex
@@ -234,7 +234,7 @@ defmodule Lexical.RemoteControl.Build.Error do
     message = Exception.message(undefined_function)
 
     position =
-      if context == [] do
+      if context == [] and is_list(arguments) do
         arity = length(arguments)
         mfa = {module, function, arity}
         mfa_to_position(mfa, quoted_ast)

--- a/apps/remote_control/test/lexical/remote_control/build/document/compilers/eex_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/document/compilers/eex_test.exs
@@ -114,25 +114,5 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EExTest do
       assert result.source == "EEx"
       assert result.uri =~ "file:///file.eex"
     end
-
-    @tag :with_diagnostics
-    test "handles undefinied variable" do
-      document = document_with_content(~q[
-        <%= thing %>
-      ])
-
-      assert {:error, [%Result{} = result]} = compile(document)
-
-      if Features.with_diagnostics?() do
-        assert result.message =~ "undefined variable \"thing\""
-      else
-        assert result.message =~ "undefined function thing/0"
-      end
-
-      assert result.position in [1, {1, 5}]
-      assert result.severity == :error
-      assert result.source == "EEx"
-      assert result.uri =~ "file:///file.eex"
-    end
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/build/document/compilers/eex_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/document/compilers/eex_test.exs
@@ -114,5 +114,25 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EExTest do
       assert result.source == "EEx"
       assert result.uri =~ "file:///file.eex"
     end
+
+    @tag :with_diagnostics
+    test "handles undefinied variable" do
+      document = document_with_content(~q[
+        <%= thing %>
+      ])
+
+      assert {:error, [%Result{} = result]} = compile(document)
+
+      if Features.with_diagnostics?() do
+        assert result.message =~ "undefined variable \"thing\""
+      else
+        assert result.message =~ "undefined function thing/0"
+      end
+
+      assert result.position in [1, {1, 5}]
+      assert result.severity == :error
+      assert result.source == "EEx"
+      assert result.uri =~ "file:///file.eex"
+    end
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/build/document/compilers/eex_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/document/compilers/eex_test.exs
@@ -126,7 +126,7 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EExTest do
       if Features.with_diagnostics?() do
         assert result.message =~ "undefined variable \"thing\""
       else
-        assert result.message =~ "undefined function thing/0"
+        assert result.message =~ "function :erl_eval.thing/0 is undefined or private"
       end
 
       assert result.position in [1, {1, 5}]

--- a/apps/remote_control/test/lexical/remote_control/build/document/compilers/eex_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/document/compilers/eex_test.exs
@@ -126,7 +126,7 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EExTest do
       if Features.with_diagnostics?() do
         assert result.message =~ "undefined variable \"thing\""
       else
-        assert result.message =~ "function :erl_eval.thing/0 is undefined or private"
+        assert result.message =~ "undefined function thing/0"
       end
 
       assert result.position in [1, {1, 5}]

--- a/apps/remote_control/test/lexical/remote_control/build/document/compilers/heex_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/document/compilers/heex_test.exs
@@ -55,23 +55,6 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.HeexTest do
       assert {:error, []} = compile(document)
     end
 
-    test "ignore undefinied variables" do
-      document = document_with_content(~q(
-        <.form :let={f} as={:myform} form={@form}>
-          <.inputs_for :let={finner} field={f[:inner]}>
-            <%= finner %>
-          </.inputs_for>
-        </.form>
-      ))
-
-      if Features.with_diagnostics?() do
-        assert {:error, []} = compile(document)
-      else
-        assert {:error, [error]} = compile(document)
-        assert error.message =~ "undefined function finner/0"
-      end
-    end
-
     test "returns error when there are unclosed tags" do
       document = document_with_content(~q[
         <div>thing

--- a/apps/remote_control/test/lexical/remote_control/build/document/compilers/heex_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/document/compilers/heex_test.exs
@@ -55,6 +55,23 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.HeexTest do
       assert {:error, []} = compile(document)
     end
 
+    test "ignore undefinied variables" do
+      document = document_with_content(~q(
+        <.form :let={f} as={:myform} form={@form}>
+          <.inputs_for :let={finner} field={f[:inner]}>
+            <%= finner %>
+          </.inputs_for>
+        </.form>
+      ))
+
+      if Features.with_diagnostics?() do
+        assert {:error, []} = compile(document)
+      else
+        assert {:error, [error]} = compile(document)
+        assert error.message =~ "undefined function finner/0"
+      end
+    end
+
     test "returns error when there are unclosed tags" do
       document = document_with_content(~q[
         <div>thing


### PR DESCRIPTION
The error comes from EEx's `eval_quoted`. However, the EEx engine cannot directly recognize variables defined with `:let`. This forces me to ignore diagnostics that start with `undefined variable` for both EEx and HEEx files.

Additionally, as I mentioned in the initial PR, HEEx files heavily rely on definitions from other Elixir files. Therefore, when we compile a single file using the HEEx engine, there are bound to be some limitations.

Fixes #460 