### PR TITLE
Fix: Stutter when completing inside string interpolations

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control.ex
+++ b/apps/remote_control/lib/lexical/remote_control.ex
@@ -34,7 +34,7 @@ defmodule Lexical.RemoteControl do
   end
 
   def get_project do
-    :persistent_term.get({__MODULE__, :project}, nil)
+    :persistent_term.get({__MODULE__, :project})
   end
 
   def set_project(%Project{} = project) do

--- a/apps/remote_control/lib/lexical/remote_control.ex
+++ b/apps/remote_control/lib/lexical/remote_control.ex
@@ -34,7 +34,7 @@ defmodule Lexical.RemoteControl do
   end
 
   def get_project do
-    :persistent_term.get({__MODULE__, :project})
+    :persistent_term.get({__MODULE__, :project}, nil)
   end
 
   def set_project(%Project{} = project) do

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/interpolation_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/interpolation_test.exs
@@ -1,0 +1,66 @@
+defmodule Lexical.Server.CodeIntelligence.Completion.Translations.InterpolationTest do
+  use Lexical.Test.Server.CompletionCase
+
+  test "variables are completed inside strings", %{project: project} do
+    source =
+      ~S[
+       variable = 3
+       "#{var|}"
+      ]
+      |> String.trim()
+
+    assert {:ok, completion} =
+             project
+             |> complete(source)
+             |> fetch_completion(kind: :variable)
+
+    expected =
+      ~S[
+       variable = 3
+       "#{variable}"
+      ]
+      |> String.trim()
+
+    assert apply_completion(completion) == expected
+  end
+
+  test "erlang modules are completed inside strings", %{project: project} do
+    source = ~S[
+      "#{:erlan|}"
+    ]
+
+    assert {:ok, completion} =
+             project
+             |> complete(source)
+             |> fetch_completion(label: ":erlang")
+
+    assert String.trim(apply_completion(completion)) == ~S["#{:erlang}"]
+  end
+
+  test "elixir modules are completed inside strings", %{project: project} do
+    source = ~S[
+      "#{Kern|}"
+    ]
+
+    assert {:ok, completion} =
+             project
+             |> complete(source)
+             |> fetch_completion(label: "Kernel")
+
+    assert String.trim(apply_completion(completion)) == ~S["#{Kernel}"]
+  end
+
+  test "structs are completed inside strings", %{project: project} do
+    source = ~S[
+      "#{inspect(%Project.Structs.Us|)}"
+    ]
+
+    assert {:ok, completion} =
+             project
+             |> complete(source)
+             |> fetch_completion(kind: :struct)
+
+    assert String.trim(apply_completion(completion)) ==
+             ~S["#{inspect(%Project.Structs.User{$1})}"]
+  end
+end


### PR DESCRIPTION
When completing certain things in string interpolations, the prefix can't be processed by the tokenizer, so `token_stream` returns the EOL from the previous line. We used the length of the EOL as the length of the prefix, which was often not enough, so we'd get a stutter when applying the text edit if the prefix was longer than 2 characters.

The fix is to detect the EOL, and in that case, use Code.Fragment to parse the prefix.

Fixes #462