### PR TITLE
Fix: Erlang function calls in pipes were incorrectly formatted

### DIFF
--- a/apps/common/lib/lexical/ast/env.ex
+++ b/apps/common/lib/lexical/ast/env.ex
@@ -170,7 +170,10 @@ defmodule Lexical.Ast.Env do
       {:arrow_op, nil, _}, _ ->
         {:halt, true}
 
-      _x, _acc ->
+      {:atom, _, _}, _ ->
+        {:cont, false}
+
+      _token, _acc ->
         {:halt, false}
     end)
   end

--- a/apps/common/test/lexical/ast/env_test.exs
+++ b/apps/common/test/lexical/ast/env_test.exs
@@ -605,6 +605,11 @@ defmodule Lexical.Ast.EnvTest do
       assert in_context?(env, :pipe)
     end
 
+    test "is true if we're in a remote erlang call" do
+      env = new_env("[] |> :string.|")
+      assert in_context?(env, :pipe)
+    end
+
     test "is false if the pipe is in a function call and the cursor is outside it" do
       env = new_env("foo( a |> b |> c)|")
       refute in_context?(env, :pipe)


### PR DESCRIPTION
Erlang remote calls were not being recognized as being in a pipeline context because they're just atoms, and that wasn't included as a valid token inside of pipelines. Thus, `in_context?(x, :pipe)` would return false, and the first arguments to the functions would appear

Fixes #475