### PR TITLE
Added completions for typespecs

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
@@ -53,6 +53,23 @@ defmodule Lexical.RemoteControl.Completion.Candidate do
     end
   end
 
+  defmodule Typespec do
+    @moduledoc false
+    defstruct [:argument_names, :arity, :doc, :metadata, :name, :signature, :spec]
+
+    def new(%{} = elixir_sense_map) do
+      arg_names =
+        case ArgumentNames.from_elixir_sense_map(elixir_sense_map) do
+          :error -> []
+          names -> names
+        end
+
+      __MODULE__
+      |> struct(elixir_sense_map)
+      |> Map.put(:argument_names, arg_names)
+    end
+  end
+
   defmodule Module do
     @moduledoc false
     defstruct [:full_name, :metadata, :name, :summary]
@@ -123,15 +140,6 @@ defmodule Lexical.RemoteControl.Completion.Candidate do
   defmodule ModuleAttribute do
     @moduledoc false
     defstruct [:name]
-
-    def new(%{} = elixir_sense_map) do
-      struct(__MODULE__, elixir_sense_map)
-    end
-  end
-
-  defmodule Typespec do
-    @moduledoc false
-    defstruct [:args_list, :arity, :doc, :metadata, :name, :signature, :spec]
 
     def new(%{} = elixir_sense_map) do
       struct(__MODULE__, elixir_sense_map)

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
@@ -39,9 +39,18 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
         [:deprecated]
       end
 
+    kind =
+      case callable do
+        %Candidate.Typespec{} ->
+          :type_parameter
+
+        _ ->
+          :function
+      end
+
     env
     |> Builder.snippet(insert_text,
-      kind: :function,
+      kind: kind,
       label: label(callable, env),
       sort_text: sort_text(callable),
       tags: tags

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
@@ -3,7 +3,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
   alias Lexical.RemoteControl.Completion.Candidate
   alias Lexical.Server.CodeIntelligence.Completion.Builder
 
-  @callables [Candidate.Function, Candidate.Macro, Candidate.Callback]
+  @callables [Candidate.Function, Candidate.Macro, Candidate.Callback, Candidate.Typespec]
 
   @syntax_macros ~w(= == == === =~ .. ..// ! != !== &&)
 

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/typespec.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/typespec.ex
@@ -1,0 +1,12 @@
+defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Typespec do
+  alias Lexical.Ast.Env
+  alias Lexical.Completion.Translatable
+  alias Lexical.RemoteControl.Completion.Candidate
+  alias Lexical.Server.CodeIntelligence.Completion.Translations.Callable
+
+  defimpl Translatable, for: Candidate.Typespec do
+    def translate(typespec, _builder, %Env{} = env) do
+      Callable.completion(typespec, env)
+    end
+  end
+end

--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -127,7 +127,12 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
       %Candidate.Protocol{name: "#{name}-protocol", full_name: full_name},
       %Candidate.Struct{name: "#{name}-struct", full_name: full_name},
       %Candidate.StructField{name: "#{name}-struct-field", origin: full_name},
-      %Candidate.Typespec{name: "#{name}-typespec"},
+      %Candidate.Typespec{
+        name: "#{name}-typespec",
+        argument_names: ["value"],
+        arity: 1,
+        metadata: %{}
+      },
       %Candidate.Variable{name: "#{name}-variable"}
     ]
 
@@ -149,6 +154,21 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
       assert {:ok, _} = fetch_completion(completions, label: "Foo-module")
       assert {:ok, _} = fetch_completion(completions, label: "Foo-protocol")
       assert {:ok, _} = fetch_completion(completions, label: "Foo-struct")
+    end
+
+    test "only modules, typespecs and module attributes are returned in types", %{
+      project: project
+    } do
+      completions =
+        for completion <- complete(project, "@spec F"), into: MapSet.new() do
+          completion.label
+        end
+
+      assert "Foo-module" in completions
+      assert "Foo-module-attribute" in completions
+      assert "Foo-submodule" in completions
+      assert "Foo-typespec(value)" in completions
+      assert Enum.count(completions) == 4
     end
 
     test "modules are sorted before functions", %{project: project} do


### PR DESCRIPTION
Prior, we were ignoring typespecs as completion candidates because they are only relevant in a couple of places. This adds detection for those places and only emits completion candidates if they're in a type, typep, opaque or spec.

Additionally, while in one of those contexts, it suppresses most other completions, because they are not relevant.

Fixes #473