### PR TITLE
Fix: Don't raise an exception if the build directory doesn't exist

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build.ex
@@ -3,6 +3,7 @@ defmodule Lexical.RemoteControl.Build do
   alias Lexical.Project
   alias Lexical.RemoteControl
   alias Lexical.RemoteControl.Build.State
+  alias Lexical.VM.Versions
 
   require Logger
   use GenServer
@@ -10,6 +11,15 @@ defmodule Lexical.RemoteControl.Build do
   @tick_interval_millis 50
 
   # Public interface
+
+  def path(%Project{} = project) do
+    %{elixir: elixir, erlang: erlang} = Versions.current()
+    erlang_major = erlang |> String.split(".") |> List.first()
+    elixir_version = Version.parse!(elixir)
+    elixir_major = "#{elixir_version.major}.#{elixir_version.minor}"
+    build_root = Project.build_path(project)
+    Path.join([build_root, "erl-#{erlang_major}", "elixir-#{elixir_major}"])
+  end
 
   def schedule_compile(%Project{} = project, force? \\ false) do
     RemoteControl.call(project, GenServer, :cast, [__MODULE__, {:compile, force?}])

--- a/apps/remote_control/lib/lexical/remote_control/build/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/state.ex
@@ -234,12 +234,18 @@ defmodule Lexical.RemoteControl.Build.State do
     build_root = Project.build_path(project)
     two_months_ago = System.system_time(:second) - @two_month_seconds
 
-    for file_name <- File.ls!(build_root),
-        absolute_path = Path.join(build_root, file_name),
-        File.dir?(absolute_path),
-        newest_beam_mtime(absolute_path) <=
-          two_months_ago do
-      File.rm_rf!(absolute_path)
+    case File.ls(build_root) do
+      {:ok, entries} ->
+        for file_name <- entries,
+            absolute_path = Path.join(build_root, file_name),
+            File.dir?(absolute_path),
+            newest_beam_mtime(absolute_path) <=
+              two_months_ago do
+          File.rm_rf!(absolute_path)
+        end
+
+      _ ->
+        :ok
     end
   end
 

--- a/apps/remote_control/lib/lexical/remote_control/mix.ex
+++ b/apps/remote_control/lib/lexical/remote_control/mix.ex
@@ -21,7 +21,7 @@ defmodule Lexical.RemoteControl.Mix do
       try do
         Mix.ProjectStack.post_config(prune_code_paths: false)
 
-        build_path = Project.build_path(project)
+        build_path = RemoteControl.Build.path(project)
         project_root = Project.root_path(project)
 
         project

--- a/apps/server/lib/lexical/server/project/node.ex
+++ b/apps/server/lib/lexical/server/project/node.ex
@@ -98,7 +98,9 @@ defmodule Lexical.Server.Project.Node do
   end
 
   defp delete_build_artifacts(%Project{} = project) do
-    case File.rm_rf(Project.build_path(project)) do
+    build_path = RemoteControl.Build.path(project)
+
+    case File.rm_rf(build_path) do
       {:ok, _deleted} -> :ok
       error -> error
     end


### PR DESCRIPTION
If the build directory didn't exist (as it didn't in CI), then an exception was raised when we tried to delete it. This would cause remote control to not boot and the whole system would crash around us. 

Simple solution, don't use bang functions.