### PR TITLE
Add heex to filetype list for neovim

### DIFF
--- a/pages/installation.md
+++ b/pages/installation.md
@@ -183,7 +183,7 @@ configuration below as a reference:
     local configs = require("lspconfig.configs")
 
     local lexical_config = {
-      filetypes = { "elixir", "eelixir", },
+      filetypes = { "elixir", "eelixir", "heex" },
       cmd = { "/my/home/projects/_build/dev/package/lexical/bin/start_lexical.sh" },
       settings = {},
     }


### PR DESCRIPTION
It looks like Lexical supports HEEx files and they're included in e.g. Emacs setup instructions, so adding them to
Neovim as well. I can confirm that it works with my installation (macOS, nightly neovim from homebrew).
