### PR TITLE
Fixes erlang/OTP buildingg on macOS Sonoma (nix-darwin)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ lexical_debug
 priv/plts
 
 apps/common/src/future_elixir_parser.erl
+
+# nix files
+result

--- a/flake.nix
+++ b/flake.nix
@@ -4,26 +4,41 @@
   inputs.nixpkgs.url = "flake:nixpkgs";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs =
-    { self
-    , nixpkgs
-    , flake-utils
-    }:
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
     flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        erl = pkgs.beam.packages.erlang;
-        lexical = erl.callPackage ./nix/lexical.nix {};
-      in
-      {
+      system: let
+        # little hack as we can't use `pkgs.system` yet
+        is_darwin = system == "aarch64-darwin" || system == "x86_64-darwin";
+        pkgs = import nixpkgs {inherit system;};
+        inherit (pkgs.beam) packagesWith;
+        inherit (pkgs.beam.interpreters) erlang;
+        # yeah, it will take a long time to build...
+        # nedeed because macOS sonoma breaks the JIT
+        # reference: https://elixirforum.com/t/bus-error-after-upgrading-to-sonoma-beta/56354/44
+        # another option is to use erlang/OTP >= 23.3.2.7 which disables JIT automatically on macOS
+        darwin_override_erl = erlang.overrideAttrs (old: {
+          configureFlags = old.configureFlags ++ ["--disable-jit"];
+        });
+
+        erl =
+          if is_darwin
+          then darwin_override_erl
+          else erlang;
+
+        erl' = packagesWith erl;
+        lexical = erl'.callPackage ./nix/lexical.nix {};
+      in {
         packages = {
           inherit lexical;
 
           default = lexical;
 
           # Private package used to automatically generate hash for Mix deps
-          __fodHashGen = lexical.mixFodDeps.overrideAttrs(final: curr: {
+          __fodHashGen = lexical.mixFodDeps.overrideAttrs (final: curr: {
             outputHash = pkgs.lib.fakeSha256;
           });
         };

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
 
         mkLexical = {erlang}: erlang.callPackage ./nix/lexical.nix {};
       in rec {
-        overlay = _final: _prev: {
+        overlays.default = _final: _prev: {
           inherit mkLexical;
           inherit (packages) lexical;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -11,32 +11,18 @@
   }:
     flake-utils.lib.eachDefaultSystem (
       system: let
-        # little hack as we can't use `pkgs.system` yet
-        is_darwin = system == "aarch64-darwin" || system == "x86_64-darwin";
         pkgs = import nixpkgs {inherit system;};
-        inherit (pkgs.beam) packagesWith;
-        inherit (pkgs.beam.interpreters) erlang;
-        # yeah, it will take a long time to build...
-        # nedeed because macOS sonoma breaks the JIT
-        # reference: https://elixirforum.com/t/bus-error-after-upgrading-to-sonoma-beta/56354/44
-        # another option is to use erlang/OTP >= 23.3.2.7 which disables JIT automatically on macOS
-        darwin_override_erl = erlang.overrideAttrs (old: {
-          configureFlags = old.configureFlags ++ ["--disable-jit"];
-        });
+        inherit (pkgs.beam.packages) erlang_26;
 
-        erl =
-          if is_darwin
-          then darwin_override_erl
-          else erlang;
-
-        erl' = packagesWith erl;
-        lexical = erl'.callPackage ./nix/lexical.nix {};
-      in {
-        packages = {
-          inherit lexical;
-
+        mkLexical = {erlang}: erlang.callPackage ./nix/lexical.nix {};
+      in rec {
+        overlay = _final: _prev: {
+          inherit mkLexical;
+          inherit (packages) lexical;
+        };
+        packages = rec {
+          lexical = mkLexical {erlang = erlang_26;};
           default = lexical;
-
           # Private package used to automatically generate hash for Mix deps
           __fodHashGen = lexical.mixFodDeps.overrideAttrs (final: curr: {
             outputHash = pkgs.lib.fakeSha256;
@@ -44,13 +30,11 @@
         };
 
         devShells.default = pkgs.mkShell {
-          packages =
-            [
-              erl.elixir
-            ]
-            ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-              pkgs.darwin.apple_sdk.frameworks.CoreFoundation
-              pkgs.darwin.apple_sdk.frameworks.CoreServices
+          packages = with pkgs;
+            [erlang_26.elixir]
+            ++ lib.optionals pkgs.stdenv.isDarwin [
+              darwin.apple_sdk.frameworks.CoreFoundation
+              darwin.apple_sdk.frameworks.CoreServices
             ];
         };
       }


### PR DESCRIPTION
- system: macOS Sonoma 14.2, aarch64
- using `nix-darwin`

It’s known that erlang OTP < 25.3.2.7 causes “Bus error” on macOS Sonoma, which breaks the JIT integration. Solution. is to either use erlang/OTP >= 23.2.7 OR disable JIT manually on older versions.

As i’m using `nix` and this project lovely has a `flake.nix` I have modified to disable

If you prefer I can directly uses a higher version of erlang/OTP, however I do prefer the option to provide an overlay for lexical for `nix` users or better: package can receive the desired versino of erlang/OTP to use to build it.

The actual error from building in macOS Sonoma is:
```
warning: Git tree '/Users/zoedsoupe/dev/personal/lexical' is dirty
error: builder for '/nix/store/4759iwcng26ad6fy0x526xcq9gsjlqin-lexical-development.drv' failed with exit code 138;
       last 8 log lines:
       > unpacking sources
       > unpacking source archive /nix/store/ygiq7lnlhdyyh3j7iyjb4mc9ciw9ad7x-qfz9gscwawyyvn4cahqmms0valrnh83w-source
       > source root is qfz9gscwawyyvn4cahqmms0valrnh83w-source
       > patching sources
       > updateAutotoolsGnuConfigScriptsPhase
       > configuring
       > installing
       > /nix/store/9sk191pyc5hsvfs927ym6ii7szbz78n2-stdenv-darwin/setup: line 1608: 91336 Bus error: 10           mix deps.get ${MIX_ENV:+--only $MIX_ENV}
       For full logs, run 'nix log /nix/store/4759iwcng26ad6fy0x526xcq9gsjlqin-lexical-development.drv'.
error: 1 dependencies of derivation '/nix/store/9as76wycvdm83z3hf71biwyq87qg02nj-lexical-development.drv' failed to build
```

Reference:
- https://elixirforum.com/t/bus-error-after-upgrading-to-sonoma-beta/56354/27
- https://github.com/NixOS/nixpkgs/issues/257880
