### PR TITLE
Fix module completion error after a dot

### DIFF
--- a/apps/common/lib/lexical/ast/analysis/analyzer.ex
+++ b/apps/common/lib/lexical/ast/analysis/analyzer.ex
@@ -423,11 +423,13 @@ defmodule Lexical.Ast.Analysis.Analyzer do
 
   # In other cases, attempt to expand the unreified head element
   defp reify_alias(current_module, [unreified | rest]) do
-    env = %Macro.Env{module: current_module}
+    module = Module.concat(current_module)
+    env = %Macro.Env{module: module}
     reified = Macro.expand(unreified, env)
 
     if is_atom(reified) do
-      [reified | rest]
+      reified_segments = reified |> Module.split() |> Enum.map(&String.to_atom/1)
+      reified_segments ++ rest
     else
       rest
     end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/module_or_behaviour_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/module_or_behaviour_test.exs
@@ -56,6 +56,22 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.ModuleOrBehavi
       assert completion.label == "Enumerable"
       assert completion.detail =~ "Enumerable protocol"
     end
+
+    test "regression: modules should emit a completion after a dot in the context of a module",
+         %{project: project} do
+      code = ~q[
+        defmodule MyTest do
+          alias Project.|
+        end
+      ]
+
+      assert {:ok, completion} =
+               project
+               |> complete(code, trigger_character: ".")
+               |> fetch_completion("Foo")
+
+      assert completion.kind == :module
+    end
   end
 
   describe "erlang module completions" do


### PR DESCRIPTION
I'm having trouble replicating this in a test, but I was getting an error when I tried completing something like:

```elixir
defmodule Something do
  alias Lexical.|
end
```

The error was caused by an exception thrown in analysis due to an incorrect case in its `reify_alias` implementation. The analyzer deals with modules as lists of segments, e.g. `[:Foo, :Bar, :Baz]`, but the macro env requires that they be combined to `Foo.Bar.Baz`.