### PR TITLE
Fix the issue of project.log not displaying logs when developing Lexical with version 1.15.

### DIFF
--- a/apps/remote_control/test/test_helper.exs
+++ b/apps/remote_control/test/test_helper.exs
@@ -6,3 +6,9 @@ with :nonode@nohost <- Node.self() do
 end
 
 ExUnit.start(exclude: [:skip])
+
+if Version.match?(System.version(), ">= 1.15.0") do
+  Logger.configure(level: :none)
+else
+  Logger.remove_backend(:console)
+end

--- a/apps/server/test/test_helper.exs
+++ b/apps/server/test/test_helper.exs
@@ -1,2 +1,8 @@
 ExUnit.configure(timeout: :infinity)
 ExUnit.start()
+
+if Version.match?(System.version(), ">= 1.15.0") do
+  Logger.configure(level: :none)
+else
+  Logger.remove_backend(:console)
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,10 +11,3 @@ config :remote_control,
 
 config :server, transport: NoOp
 config :stream_data, initial_size: 50
-
-if Version.match?(System.version(), ">= 1.15.0") do
-  Logger.configure(level: :none)
-else
-  Logger.remove_backend(:console)
-  Logger.remove_backend(JsonRpc.Backend)
-end


### PR DESCRIPTION
In `test.exs`, `Logger.configure` is called when the project node starts, which causes log information not to be displayed after Elixir version 1.15. If we only want to ignore excessive logs during test execution, it would be more appropriate to handle this in `test_helpers`.