### PR TITLE
Find function references

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_reference.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_reference.ex
@@ -119,7 +119,10 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionReference do
        ) do
     arity = call_arity(args_arity)
     block = Reducer.current_block(reducer)
-    range = get_reference_range(reducer.analysis.document, start_metadata, end_metadata)
+
+    range =
+      get_reference_range(reducer.analysis.document, start_metadata, end_metadata, function_name)
+
     {:ok, module} = RemoteControl.Analyzer.expand_alias(module, reducer.analysis, range.start)
     mfa = Formats.mfa(module, function_name, arity)
 
@@ -134,22 +137,32 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionReference do
     )
   end
 
-  defp get_reference_range(document, start_metadata, end_metadata) do
+  defp get_reference_range(document, start_metadata, end_metadata, function_name) do
     {start_line, start_column} = start_position(start_metadata)
     start_position = Position.new(document, start_line, start_column)
     has_parens? = not Keyword.get(end_metadata, :no_parens, false)
 
     {end_line, end_column} =
-      with nil <- Metadata.position(end_metadata, :closing) do
-        position = Metadata.position(end_metadata)
+      case Metadata.position(end_metadata, :closing) do
+        {line, column} ->
+          if has_parens? do
+            {line, column + 1}
+          else
+            {line, column}
+          end
 
-        if has_parens? do
-          position
-        else
-          {line, column} = position
-          # add two for the parens
-          {line, column + 2}
-        end
+        nil ->
+          {line, column} = Metadata.position(end_metadata)
+
+          if has_parens? do
+            {line, column + 1}
+          else
+            name_length = function_name |> Atom.to_string() |> String.length()
+            # without parens, the metadata points to the beginning of the call, so
+            # we need to add the length of the function name to be sure we have it
+            # all
+            {line, column + name_length}
+          end
       end
 
     end_position = Position.new(document, end_line, end_column)
@@ -186,7 +199,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionReference do
 
     # syntax specific functions to exclude from our matches
     excluded_operators =
-      ~w[-> && ** ++ -- .. "..//" ! <> =~ @ |> | || * + - / != !== < <= == === > >=]a
+      ~w[<- -> && ** ++ -- .. "..//" ! <> =~ @ |> | || * + - / != !== < <= == === > >=]a
 
     excluded_keywords = ~w[and if import in not or raise require try use]a
 

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_reference.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_reference.ex
@@ -121,7 +121,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionReference do
     block = Reducer.current_block(reducer)
     range = get_reference_range(reducer.analysis.document, start_metadata, end_metadata)
     {:ok, module} = RemoteControl.Analyzer.expand_alias(module, reducer.analysis, range.start)
-    mfa = "#{Formats.module(module)}.#{function_name}/#{arity}"
+    mfa = Formats.mfa(module, function_name, arity)
 
     Entry.reference(
       reducer.analysis.document.path,

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/source/reducer.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/source/reducer.ex
@@ -141,6 +141,8 @@ defmodule Lexical.RemoteControl.Search.Indexer.Source.Reducer do
     %__MODULE__{reducer | entries: [entry | reducer.entries]}
   end
 
+  defp push_entry(%__MODULE__{} = reducer, _), do: reducer
+
   defp maybe_pop_block(%__MODULE__{} = reducer) do
     if block_ended?(reducer) do
       pop_block(reducer)

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v1.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v1.ex
@@ -43,7 +43,6 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1 do
   @spec entries_to_rows(Enumerable.t(Entry.t())) :: [tuple()]
   def entries_to_rows(entries) do
     entries
-    |> Stream.uniq_by(& &1.ref)
     |> Stream.flat_map(&to_rows(&1))
     |> Enum.reduce(%{}, fn {key, value}, acc ->
       Map.update(acc, key, [value], fn old_values -> [value | old_values] end)

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/function_definition_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/function_definition_test.exs
@@ -36,7 +36,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinitionTest
       assert zero_arity.type == :public_function
       assert zero_arity.subtype == :definition
       assert zero_arity.subject == "Parent.zero_arity/0"
-      assert "def zero_arity, do: true" == extract(code, zero_arity.range)
+      assert "def zero_arity, do" == extract(code, zero_arity.range)
     end
 
     test "finds zero arity public functions (with parens)" do
@@ -144,7 +144,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinitionTest
       assert zero_arity.type == :private_function
       assert zero_arity.subtype == :definition
       assert zero_arity.subject == "Parent.zero_arity/0"
-      assert "defp zero_arity, do: true" == extract(code, zero_arity.range)
+      assert "defp zero_arity, do" == extract(code, zero_arity.range)
     end
 
     test "finds zero arity one-line private functions (with parens)" do
@@ -159,7 +159,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinitionTest
       assert zero_arity.type == :private_function
       assert zero_arity.subtype == :definition
       assert zero_arity.subject == "Parent.zero_arity/0"
-      assert "defp zero_arity(), do: true" == extract(code, zero_arity.range)
+      assert "defp zero_arity(), do" == extract(code, zero_arity.range)
     end
 
     test "finds zero arity private functions (no parens)" do
@@ -206,7 +206,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinitionTest
       assert one_arity.type == :private_function
       assert one_arity.subtype == :definition
       assert one_arity.subject == "Parent.one_arity/1"
-      assert "defp one_arity(a), do: a + 1" == extract(code, one_arity.range)
+      assert "defp one_arity(a), do" == extract(code, one_arity.range)
     end
 
     test "finds one arity private functions" do
@@ -238,7 +238,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinitionTest
       assert one_arity.type == :private_function
       assert one_arity.subtype == :definition
       assert one_arity.subject == "Parent.multi_arity/3"
-      assert "defp multi_arity(a, b, c), do: {a, b, c}" == extract(code, one_arity.range)
+      assert "defp multi_arity(a, b, c), do" == extract(code, one_arity.range)
     end
 
     test "finds multi arity private functions" do

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/function_reference_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/function_reference_test.exs
@@ -237,12 +237,12 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionReferenceTest 
 
         map(l, fn i -> downcase(i) end)
       }
+
       assert {:ok, [r1, r2], _} = index(code)
       assert r1.subject == "Enum.map/2"
       assert "map(l, fn i -> downcase(i) end)" = extract(code, r1.range)
-
       assert r2.subject == "String.downcase/1"
-      assert "downcase(i) " = extract(code, r2.range)
+      assert "downcase(i)" = extract(code, r2.range)
     end
   end
 

--- a/projects/lexical_shared/lib/lexical/formats.ex
+++ b/projects/lexical_shared/lib/lexical/formats.ex
@@ -97,6 +97,10 @@ defmodule Lexical.Formats do
     end
   end
 
+  def mfa(module, function, arity) do
+    "#{module(module)}.#{function}/#{arity}"
+  end
+
   defp templatize(count, template) do
     count_string = Integer.to_string(count)
     String.replace(template, "${count}", count_string)

--- a/projects/lexical_test/lib/lexical/test/range_support.ex
+++ b/projects/lexical_test/lib/lexical/test/range_support.ex
@@ -43,8 +43,8 @@ defmodule Lexical.Test.RangeSupport do
   end
 
   def extract(%Document{} = document, %Range{} = range) do
-    zero_based_start_character = range.start.character - 1
-    zero_based_end_character = range.end.character - 1
+    zero_based_start_character = max(range.start.character - 1, 0)
+    zero_based_end_character = max(range.end.character - 1, 0)
     start_line = range.start.line
     end_line = range.end.line
 
@@ -55,21 +55,19 @@ defmodule Lexical.Test.RangeSupport do
     |> Enum.map(fn
       line(line_number: line_number, text: line_text)
       when line_number == start_line and line_number == end_line ->
-        String.slice(line_text, zero_based_start_character..range.end.character)
+        length = zero_based_end_character - zero_based_start_character
+        String.slice(line_text, zero_based_start_character, length)
 
       line(line_number: ^start_line, text: line_text, ending: ending) ->
         line_length = String.length(line_text)
-
-        prefix =
-          String.slice(
-            line_text,
-            zero_based_start_character..line_length
-          )
+        length = line_length - zero_based_start_character
+        prefix = String.slice(line_text, zero_based_start_character, length)
 
         [prefix, ending]
 
       line(line_number: ^end_line, text: line_text) ->
-        String.slice(line_text, 0..zero_based_end_character)
+        length = zero_based_end_character
+        String.slice(line_text, 0, length)
 
       line(text: line_text, ending: ending) ->
         [line_text, ending]


### PR DESCRIPTION
Find references: Functions

Implemented find references for functions.
Initially, very few references were found, and this was because we
were deduping the index by id. Removing this call allows us to see the
entire project's references, with the notable exception of imported
macros. I believe we'll need to augment the extractor with a
compilation tracer if we wish to see those. The bad news is lexical
takes around 12 seconds to compile, but around 3 seconds to index.