### PR TITLE
Added reindex command

### DIFF
--- a/apps/proto/.formatter.exs
+++ b/apps/proto/.formatter.exs
@@ -8,6 +8,7 @@ proto_dsl = [
   defrequest: 2,
   defresponse: 1,
   deftype: 1,
+  server_request: 2,
   server_request: 3
 ]
 

--- a/apps/proto/lib/lexical/proto.ex
+++ b/apps/proto/lib/lexical/proto.ex
@@ -10,7 +10,10 @@ defmodule Lexical.Proto do
       import Proto.Alias, only: [defalias: 1]
       import Proto.Enum, only: [defenum: 1]
       import Proto.Notification, only: [defnotification: 1, defnotification: 2]
-      import Proto.Request, only: [defrequest: 1, defrequest: 2, server_request: 3]
+
+      import Proto.Request,
+        only: [defrequest: 1, defrequest: 2, server_request: 2, server_request: 3]
+
       import Proto.Response, only: [defresponse: 1]
       import Proto.Type, only: [deftype: 1]
     end

--- a/apps/protocol/lib/generated/lexical/protocol/types/code_lens.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/code_lens.ex
@@ -1,0 +1,7 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.CodeLens do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+  deftype command: optional(Types.Command), data: optional(any()), range: Types.Range
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/code_lens/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/code_lens/params.ex
@@ -1,0 +1,10 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.CodeLens.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+
+  deftype partial_result_token: optional(Types.Progress.Token),
+          text_document: Types.TextDocument.Identifier,
+          work_done_token: optional(Types.Progress.Token)
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/execute_command/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/execute_command/params.ex
@@ -1,0 +1,10 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.ExecuteCommand.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+
+  deftype arguments: optional(list_of(any())),
+          command: string(),
+          work_done_token: optional(Types.Progress.Token)
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/execute_command/registration/options.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/execute_command/registration/options.ex
@@ -1,0 +1,6 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.ExecuteCommand.Registration.Options do
+  alias Lexical.Proto
+  use Proto
+  deftype commands: list_of(string()), work_done_progress: optional(boolean())
+end

--- a/apps/protocol/lib/lexical/protocol/requests.ex
+++ b/apps/protocol/lib/lexical/protocol/requests.ex
@@ -92,5 +92,11 @@ defmodule Lexical.Protocol.Requests do
                    Responses.ShowMessage
   end
 
+  defmodule CodeLensRefresh do
+    use Proto
+
+    server_request "workspace/codeLens/refresh", Responses.Empty
+  end
+
   use Proto, decoders: :requests
 end

--- a/apps/protocol/lib/lexical/protocol/requests.ex
+++ b/apps/protocol/lib/lexical/protocol/requests.ex
@@ -52,6 +52,12 @@ defmodule Lexical.Protocol.Requests do
     defrequest "textDocument/codeAction", Types.CodeAction.Params
   end
 
+  defmodule CodeLens do
+    use Proto
+
+    defrequest "textDocument/codeLens", Types.CodeLens.Params
+  end
+
   defmodule Completion do
     use Proto
 
@@ -62,6 +68,12 @@ defmodule Lexical.Protocol.Requests do
     use Proto
 
     defrequest "textDocument/hover", Types.Hover.Params
+  end
+
+  defmodule ExecuteCommand do
+    use Proto
+
+    defrequest "workspace/executeCommand", Types.ExecuteCommand.Params
   end
 
   # Server -> Client requests

--- a/apps/protocol/lib/lexical/protocol/responses.ex
+++ b/apps/protocol/lib/lexical/protocol/responses.ex
@@ -39,6 +39,11 @@ defmodule Lexical.Protocol.Responses do
     defresponse optional(list_of(Types.CodeAction))
   end
 
+  defmodule CodeLens do
+    use Proto
+    defresponse optional(list_of(Types.CodeLens))
+  end
+
   defmodule Completion do
     use Proto
 
@@ -55,6 +60,12 @@ defmodule Lexical.Protocol.Responses do
     use Proto
 
     defresponse optional(Types.Hover)
+  end
+
+  defmodule ExecuteCommand do
+    use Proto
+
+    defresponse optional(any())
   end
 
   # Client -> Server responses

--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -9,6 +9,7 @@ defmodule Lexical.RemoteControl.Api do
   alias Lexical.RemoteControl.CodeAction
   alias Lexical.RemoteControl.CodeIntelligence
   alias Lexical.RemoteControl.CodeMod
+  alias Lexical.RemoteControl.Commands
 
   require Logger
 
@@ -112,5 +113,9 @@ defmodule Lexical.RemoteControl.Api do
 
   def broadcast(%Project{} = project, message) do
     RemoteControl.call(project, RemoteControl.Dispatch, :broadcast, [message])
+  end
+
+  def reindex(%Project{} = project) do
+    RemoteControl.call(project, Commands.Reindex, :perform, [project])
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -118,4 +118,8 @@ defmodule Lexical.RemoteControl.Api do
   def reindex(%Project{} = project) do
     RemoteControl.call(project, Commands.Reindex, :perform, [project])
   end
+
+  def index_running?(%Project{} = project) do
+    RemoteControl.call(project, Commands.Reindex, :running?, [])
+  end
 end

--- a/apps/remote_control/lib/lexical/remote_control/api/messages.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api/messages.ex
@@ -39,6 +39,10 @@ defmodule Lexical.RemoteControl.Api.Messages do
 
   defrecord :struct_discovered, module: nil, fields: []
 
+  defrecord :project_reindex_requested, project: nil
+
+  defrecord :project_reindexed, project: nil, elapsed_ms: 0, status: :success
+
   @type compile_status :: :successful | :error
   @type name_and_arity :: {atom, non_neg_integer}
   @type field_list :: Keyword.t() | [atom]
@@ -118,4 +122,14 @@ defmodule Lexical.RemoteControl.Api.Messages do
           )
 
   @type struct_discovered :: record(:struct_discovered, module: module(), fields: field_list())
+
+  @type project_reindex_requested ::
+          record(:project_reindex_requested, project: Lexical.Project.t())
+
+  @type project_reindexed ::
+          record(:project_reindexed,
+            project: Lexical.Project.t(),
+            elapsed_ms: non_neg_integer(),
+            status: :success | {:error, term()}
+          )
 end

--- a/apps/remote_control/lib/lexical/remote_control/application.ex
+++ b/apps/remote_control/lib/lexical/remote_control/application.ex
@@ -16,6 +16,7 @@ defmodule Lexical.RemoteControl.Application do
     children =
       if RemoteControl.project_node?() do
         [
+          {RemoteControl.Commands.Reindex, nil},
           RemoteControl.Module.Loader,
           {RemoteControl.Dispatch, progress: true},
           RemoteControl.ModuleMappings,

--- a/apps/remote_control/lib/lexical/remote_control/commands/reindex.ex
+++ b/apps/remote_control/lib/lexical/remote_control/commands/reindex.ex
@@ -35,9 +35,7 @@ defmodule Lexical.RemoteControl.Commands.Reindex do
     def reindex_uri(%__MODULE__{} = state, uri) do
       case entries_for_uri(uri) do
         {:ok, path, entries} ->
-          new_pending_updates = Map.put(state.pending_updates, path, entries)
-
-          %__MODULE__{state | pending_updates: new_pending_updates}
+          put_in(state.pending_updates[path], entries)
 
         _ ->
           state

--- a/apps/remote_control/lib/lexical/remote_control/commands/reindex.ex
+++ b/apps/remote_control/lib/lexical/remote_control/commands/reindex.ex
@@ -1,0 +1,136 @@
+defmodule Lexical.RemoteControl.Commands.Reindex do
+  defmodule State do
+    alias Lexical.Ast.Analysis
+    alias Lexical.Document
+    alias Lexical.RemoteControl.Search
+    alias Lexical.RemoteControl.Search.Indexer
+
+    require Logger
+    defstruct reindex_fun: nil, index_task: nil, pending_updates: %{}
+
+    def new(reindex_fun) do
+      %__MODULE__{reindex_fun: reindex_fun}
+    end
+
+    def set_task(%__MODULE__{} = state, {_, _} = task) do
+      %__MODULE__{state | index_task: task}
+    end
+
+    def clear_task(%__MODULE__{} = state) do
+      %__MODULE__{state | index_task: nil}
+    end
+
+    def reindex_uri(%__MODULE__{index_task: nil} = state, uri) do
+      case entries_for_uri(uri) do
+        {:ok, path, entries} ->
+          Search.Store.update(path, entries)
+
+        _ ->
+          :ok
+      end
+
+      state
+    end
+
+    def reindex_uri(%__MODULE__{} = state, uri) do
+      case entries_for_uri(uri) do
+        {:ok, path, entries} ->
+          new_pending_updates = Map.put(state.pending_updates, path, entries)
+
+          %__MODULE__{state | pending_updates: new_pending_updates}
+
+        _ ->
+          state
+      end
+    end
+
+    def flush_pending_updates(%__MODULE__{} = state) do
+      Enum.each(state.pending_updates, fn {path, entries} ->
+        Search.Store.update(path, entries)
+      end)
+
+      %__MODULE__{state | pending_updates: %{}}
+    end
+
+    defp entries_for_uri(uri) do
+      with {:ok, %Document{} = document, %Analysis{} = analysis} <-
+             Document.Store.fetch(uri, :analysis),
+           {:ok, entries} <- Indexer.Quoted.index(analysis) do
+        {:ok, document.path, entries}
+      else
+        error ->
+          Logger.error("Could not update index because #{inspect(error)}")
+          error
+      end
+    end
+  end
+
+  @moduledoc """
+  A simple genserver that prevents more than one reindexing job from running at the same time
+  """
+  alias Lexical.Document
+  alias Lexical.Project
+  alias Lexical.RemoteControl.Search
+
+  use GenServer
+
+  def start_link(reindex_fun) when is_function(reindex_fun, 1) do
+    GenServer.start_link(__MODULE__, reindex_fun, name: __MODULE__)
+  end
+
+  def start_link(_) do
+    start_link(&do_reindex/1)
+  end
+
+  def uri(uri) do
+    GenServer.cast(__MODULE__, {:reindex_uri, uri})
+  end
+
+  def perform(%Project{} = project) do
+    GenServer.call(__MODULE__, {:perform, project})
+  end
+
+  def running? do
+    GenServer.call(__MODULE__, :running?)
+  end
+
+  @impl GenServer
+  def init(reindex_fun) do
+    {:ok, State.new(reindex_fun)}
+  end
+
+  @impl GenServer
+  def handle_call(:running?, _from, %State{index_task: index_task} = state) do
+    {:reply, match?({_, _}, index_task), state}
+  end
+
+  def handle_call({:perform, project}, _from, %State{index_task: nil} = state) do
+    index_task = spawn_monitor(fn -> state.reindex_fun.(project) end)
+    {:reply, :ok, State.set_task(state, index_task)}
+  end
+
+  def handle_call({:perform, _project}, _from, state) do
+    {:reply, {:error, "Already Running"}, state}
+  end
+
+  @impl GenServer
+  def handle_cast({:reindex_uri, uri}, %State{} = state) do
+    {:noreply, State.reindex_uri(state, uri)}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, ref, :process, pid, _reason}, %State{index_task: {pid, ref}} = state) do
+    new_state =
+      state
+      |> State.flush_pending_updates()
+      |> State.clear_task()
+
+    {:noreply, new_state}
+  end
+
+  defp do_reindex(%Project{} = project) do
+    with {:ok, entries} <- Search.Indexer.create_index(project) do
+      Search.Store.replace(entries)
+    end
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/dispatch/handlers/indexing.ex
+++ b/apps/remote_control/lib/lexical/remote_control/dispatch/handlers/indexing.ex
@@ -1,10 +1,9 @@
 defmodule Lexical.RemoteControl.Dispatch.Handlers.Indexing do
-  alias Lexical.Ast.Analysis
   alias Lexical.Document
   alias Lexical.RemoteControl.Api.Messages
+  alias Lexical.RemoteControl.Commands
   alias Lexical.RemoteControl.Dispatch
   alias Lexical.RemoteControl.Search
-  alias Lexical.RemoteControl.Search.Indexer
 
   require Logger
   import Messages
@@ -26,11 +25,7 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.Indexing do
   end
 
   defp reindex(uri) do
-    with {:ok, %Document{} = document, %Analysis{} = analysis} <-
-           Document.Store.fetch(uri, :analysis),
-         {:ok, entries} <- Indexer.Quoted.index(analysis) do
-      Search.Store.update(document.path, entries)
-    end
+    Commands.Reindex.uri(uri)
   end
 
   def delete_path(uri) do

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer.ex
@@ -107,7 +107,7 @@ defmodule Lexical.RemoteControl.Search.Indexer do
         fn chunk ->
           block_bytes = chunk |> Enum.map(&Map.get(path_to_size_map, &1)) |> Enum.sum()
           result = Enum.map(chunk, processor)
-          update_progress.(block_bytes, nil)
+          update_progress.(block_bytes, "Indexing")
           result
         end,
         timeout: timeout

--- a/apps/remote_control/test/lexical/remote_control/commands/reindex_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/commands/reindex_test.exs
@@ -1,0 +1,89 @@
+defmodule Lexical.RemoteControl.Commands.ReindexTest do
+  alias Lexical.Document
+  alias Lexical.RemoteControl.Commands.Reindex
+  alias Lexical.RemoteControl.Search
+
+  import Lexical.Test.EventualAssertions
+  import Lexical.Test.Fixtures
+  import Lexical.Test.Entry.Builder
+
+  use ExUnit.Case
+  use Patch
+
+  setup do
+    reindex_fun = fn _ ->
+      Process.sleep(20)
+    end
+
+    start_supervised!({Reindex, reindex_fun})
+
+    {:ok, project: project()}
+  end
+
+  test "it should allow reindexing", %{project: project} do
+    assert :ok = Reindex.perform(project)
+    assert Reindex.running?()
+  end
+
+  test "it fails if another index is running", %{project: project} do
+    assert :ok = Reindex.perform(project)
+    assert {:error, "Already Running"} = Reindex.perform(project)
+  end
+
+  test "it eventually becomes available", %{project: project} do
+    assert :ok = Reindex.perform(project)
+    refute_eventually Reindex.running?()
+  end
+
+  test "another reindex can be enqueued", %{project: project} do
+    assert :ok = Reindex.perform(project)
+    assert_eventually :ok = Reindex.perform(project)
+  end
+
+  def put_entries(uri, entries) do
+    Process.put(uri, entries)
+  end
+
+  describe "uri/1" do
+    setup do
+      test = self()
+
+      patch(Reindex.State, :entries_for_uri, fn uri ->
+        entries =
+          test
+          |> Process.info()
+          |> get_in([:dictionary])
+          |> Enum.find_value(fn
+            {^uri, value} -> value
+            _ -> nil
+          end)
+
+        {:ok, Document.Path.ensure_path(uri), entries || []}
+      end)
+
+      patch(Search.Store, :update, fn uri, entries ->
+        send(test, {:entries, uri, entries})
+      end)
+
+      :ok
+    end
+
+    test "reindexes a specific uri" do
+      uri = "file:///file.ex"
+      entries = [reference()]
+      put_entries(uri, entries)
+      Reindex.uri(uri)
+      assert_receive {:entries, "/file.ex", ^entries}
+    end
+
+    test "buffers updates if a reindex is in progress", %{project: project} do
+      uri = "file:///file.ex"
+      new_entries = [reference(), definition()]
+      put_entries(uri, new_entries)
+      Reindex.perform(project)
+      Reindex.uri(uri)
+
+      assert_receive {:entries, "/file.ex", ^new_entries}
+    end
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
@@ -20,8 +20,8 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
     create_index = &Search.Indexer.create_index/1
     update_index = &Search.Indexer.update_index/2
 
-    start_supervised!(Commands.Reindex)
     start_supervised!(RemoteControl.Dispatch)
+    start_supervised!(Commands.Reindex)
     start_supervised!({Search.Store, [project, create_index, update_index]})
     start_supervised!(Lexical.Server.Application.document_store_child_spec())
 

--- a/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
@@ -2,6 +2,7 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
   alias Lexical.Document
   alias Lexical.RemoteControl
   alias Lexical.RemoteControl.Api
+  alias Lexical.RemoteControl.Commands
   alias Lexical.RemoteControl.Dispatch.Handlers.Indexing
   alias Lexical.RemoteControl.Search
 
@@ -19,6 +20,7 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
     create_index = &Search.Indexer.create_index/1
     update_index = &Search.Indexer.update_index/2
 
+    start_supervised!(Commands.Reindex)
     start_supervised!(RemoteControl.Dispatch)
     start_supervised!({Search.Store, [project, create_index, update_index]})
     start_supervised!(Lexical.Server.Application.document_store_child_spec())

--- a/apps/server/lib/lexical/server/project/search_listener.ex
+++ b/apps/server/lib/lexical/server/project/search_listener.ex
@@ -1,0 +1,55 @@
+defmodule Lexical.Server.Project.SearchListener do
+  alias Lexical.Formats
+  alias Lexical.Project
+  alias Lexical.Protocol.Id
+  alias Lexical.Protocol.Requests
+  alias Lexical.RemoteControl.Api
+  alias Lexical.Server
+  alias Lexical.Server.Window
+
+  import Api.Messages
+
+  use GenServer
+  require Logger
+
+  def start_link(%Project{} = project) do
+    GenServer.start_link(__MODULE__, [project], name: name(project))
+  end
+
+  defp name(%Project{} = project) do
+    :"#{Project.name(project)}::search_listener"
+  end
+
+  @impl GenServer
+  def init([%Project{} = project]) do
+    Api.register_listener(project, self(), [
+      project_reindex_requested(),
+      project_reindexed()
+    ])
+
+    {:ok, project}
+  end
+
+  @impl GenServer
+  def handle_info(project_reindex_requested(), %Project{} = project) do
+    Logger.info("project reindex requested")
+    send_code_lens_refresh()
+
+    {:noreply, project}
+  end
+
+  def handle_info(project_reindexed(elapsed_ms: elapsed), %Project{} = project) do
+    message = "Reindexed #{Project.name(project)} in #{Formats.time(elapsed, unit: :millisecond)}"
+    Logger.info(message)
+    send_code_lens_refresh()
+
+    Window.show_info_message(message)
+
+    {:noreply, project}
+  end
+
+  defp send_code_lens_refresh do
+    request = Requests.CodeLensRefresh.new(id: Id.next())
+    Server.server_request(request)
+  end
+end

--- a/apps/server/lib/lexical/server/project/supervisor.ex
+++ b/apps/server/lib/lexical/server/project/supervisor.ex
@@ -5,6 +5,7 @@ defmodule Lexical.Server.Project.Supervisor do
   alias Lexical.Server.Project.Intelligence
   alias Lexical.Server.Project.Node
   alias Lexical.Server.Project.Progress
+  alias Lexical.Server.Project.SearchListener
 
   use Supervisor
 
@@ -26,7 +27,8 @@ defmodule Lexical.Server.Project.Supervisor do
       {ProjectNodeSupervisor, project},
       {Node, project},
       {Diagnostics, project},
-      {Intelligence, project}
+      {Intelligence, project},
+      {SearchListener, project}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/apps/server/lib/lexical/server/provider/handlers.ex
+++ b/apps/server/lib/lexical/server/provider/handlers.ex
@@ -13,6 +13,9 @@ defmodule Lexical.Server.Provider.Handlers do
       %Requests.CodeAction{} ->
         {:ok, Handlers.CodeAction}
 
+      %Requests.CodeLens{} ->
+        {:ok, Handlers.CodeLens}
+
       %Requests.Completion{} ->
         {:ok, Handlers.Completion}
 
@@ -21,6 +24,9 @@ defmodule Lexical.Server.Provider.Handlers do
 
       %Requests.Hover{} ->
         {:ok, Handlers.Hover}
+
+      %Requests.ExecuteCommand{} ->
+        {:ok, Handlers.Commands}
 
       %request_module{} ->
         {:error, {:unhandled, request_module}}

--- a/apps/server/lib/lexical/server/provider/handlers/code_lens.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/code_lens.ex
@@ -7,6 +7,7 @@ defmodule Lexical.Server.Provider.Handlers.CodeLens do
   alias Lexical.Protocol.Requests
   alias Lexical.Protocol.Responses
   alias Lexical.Protocol.Types.CodeLens
+  alias Lexical.RemoteControl
   alias Lexical.Server.Provider.Env
   alias Lexical.Server.Provider.Handlers
 
@@ -51,6 +52,8 @@ defmodule Lexical.Server.Provider.Handlers.CodeLens do
 
   defp show_reindex_lens?(%Project{} = project, %Document{} = document) do
     document_path = Path.expand(document.path)
-    Features.indexing_enabled?() and document_path == Project.mix_exs_path(project)
+
+    Features.indexing_enabled?() and document_path == Project.mix_exs_path(project) and
+      not RemoteControl.Api.index_running?(project)
   end
 end

--- a/apps/server/lib/lexical/server/provider/handlers/code_lens.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/code_lens.ex
@@ -1,0 +1,50 @@
+defmodule Lexical.Server.Provider.Handlers.CodeLens do
+  alias Lexical.Document
+  alias Lexical.Document.Position
+  alias Lexical.Document.Range
+  alias Lexical.Project
+  alias Lexical.Protocol.Requests
+  alias Lexical.Protocol.Responses
+  alias Lexical.Protocol.Types.CodeLens
+  alias Lexical.Server.Provider.Env
+  alias Lexical.Server.Provider.Handlers
+
+  import Document.Line
+  require Logger
+
+  def handle(%Requests.CodeLens{} = request, %Env{} = env) do
+    lenses =
+      case reindex_lens(env.project, request.document) do
+        nil -> []
+        lens -> List.wrap(lens)
+      end
+
+    response = Responses.CodeLens.new(request.id, lenses)
+    {:reply, response}
+  end
+
+  defp reindex_lens(%Project{} = project, %Document{} = document) do
+    if Path.basename(document.path) == "mix.exs" do
+      range = def_project_range(document)
+      command = Handlers.Commands.reindex_command(project)
+
+      CodeLens.new(command: command, range: range)
+    end
+  end
+
+  @project_regex ~r/def\s+project\s/
+  defp def_project_range(%Document{} = document) do
+    # returns the line in mix.exs where `def project` occurs
+    Enum.reduce_while(document.lines, nil, fn
+      line(text: line_text, line_number: line_number), _ ->
+        if String.match?(line_text, @project_regex) do
+          start_pos = Position.new(document, line_number, 1)
+          end_pos = Position.new(document, line_number, String.length(line_text))
+          range = Range.new(start_pos, end_pos)
+          {:halt, range}
+        else
+          {:cont, nil}
+        end
+    end)
+  end
+end

--- a/apps/server/lib/lexical/server/provider/handlers/code_lens.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/code_lens.ex
@@ -2,6 +2,7 @@ defmodule Lexical.Server.Provider.Handlers.CodeLens do
   alias Lexical.Document
   alias Lexical.Document.Position
   alias Lexical.Document.Range
+  alias Lexical.Features
   alias Lexical.Project
   alias Lexical.Protocol.Requests
   alias Lexical.Protocol.Responses
@@ -24,7 +25,7 @@ defmodule Lexical.Server.Provider.Handlers.CodeLens do
   end
 
   defp reindex_lens(%Project{} = project, %Document{} = document) do
-    if Path.basename(document.path) == "mix.exs" do
+    if show_reindex_lens?(project, document) do
       range = def_project_range(document)
       command = Handlers.Commands.reindex_command(project)
 
@@ -46,5 +47,10 @@ defmodule Lexical.Server.Provider.Handlers.CodeLens do
           {:cont, nil}
         end
     end)
+  end
+
+  defp show_reindex_lens?(%Project{} = project, %Document{} = document) do
+    document_path = Path.expand(document.path)
+    Features.indexing_enabled?() and document_path == Project.mix_exs_path(project)
   end
 end

--- a/apps/server/lib/lexical/server/provider/handlers/commands.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/commands.ex
@@ -1,0 +1,65 @@
+defmodule Lexical.Server.Provider.Handlers.Commands do
+  alias Lexical.Formats
+  alias Lexical.Project
+  alias Lexical.Protocol.Requests
+  alias Lexical.Protocol.Responses
+  alias Lexical.Protocol.Types
+  alias Lexical.Protocol.Types.ErrorCodes
+  alias Lexical.RemoteControl
+  alias Lexical.Server.Provider.Env
+  alias Lexical.Server.Window
+
+  require ErrorCodes
+  require Logger
+
+  def names do
+    [reindex_name()]
+  end
+
+  def reindex_command(%Project{} = project) do
+    project_name = Project.name(project)
+
+    Types.Command.new(
+      title: "Rebuild #{project_name}'s code search index",
+      command: reindex_name()
+    )
+  end
+
+  def handle(%Requests.ExecuteCommand{} = request, %Env{} = env) do
+    response =
+      case request.command do
+        "Reindex" ->
+          Logger.info("Reindex #{Project.name(env.project)}")
+          reindex(env.project, request.id)
+
+        invalid ->
+          message = "#{invalid} is not a valid command"
+          internal_error(request.id, message)
+      end
+
+    {:reply, response}
+  end
+
+  defp reindex(%Project{} = project, request_id) do
+    case :timer.tc(RemoteControl.Api, :reindex, [project]) do
+      {elapsed, :ok} ->
+        message = "Reindexed #{Project.name(project)} in #{Formats.time(elapsed)}"
+        Window.show(:info, message)
+        Responses.ExecuteCommand.new(request_id, "ok")
+
+      {_elapsed, error} ->
+        Window.error("Indexing #{Project.name(project)} failed")
+        Logger.error("Indexing command failed due to #{inspect(error)}")
+
+        internal_error(request_id, "Indexing Failed")
+    end
+  end
+
+  defp internal_error(request_id, message) do
+    Responses.ExecuteCommand.error(request_id, :internal_error, message)
+  end
+
+  defp reindex_name do
+    "Reindex"
+  end
+end

--- a/apps/server/lib/lexical/server/provider/handlers/commands.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/commands.ex
@@ -12,8 +12,10 @@ defmodule Lexical.Server.Provider.Handlers.Commands do
   require ErrorCodes
   require Logger
 
+  @reindex_name "Reindex"
+
   def names do
-    [reindex_name()]
+    [@reindex_name]
   end
 
   def reindex_command(%Project{} = project) do
@@ -21,14 +23,14 @@ defmodule Lexical.Server.Provider.Handlers.Commands do
 
     Types.Command.new(
       title: "Rebuild #{project_name}'s code search index",
-      command: reindex_name()
+      command: @reindex_name
     )
   end
 
   def handle(%Requests.ExecuteCommand{} = request, %Env{} = env) do
     response =
       case request.command do
-        "Reindex" ->
+        @reindex_name ->
           Logger.info("Reindex #{Project.name(env.project)}")
           reindex(env.project, request.id)
 
@@ -57,9 +59,5 @@ defmodule Lexical.Server.Provider.Handlers.Commands do
 
   defp internal_error(request_id, message) do
     Responses.ExecuteCommand.error(request_id, :internal_error, message)
-  end
-
-  defp reindex_name do
-    "Reindex"
   end
 end

--- a/apps/server/lib/lexical/server/provider/handlers/commands.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/commands.ex
@@ -1,5 +1,4 @@
 defmodule Lexical.Server.Provider.Handlers.Commands do
-  alias Lexical.Formats
   alias Lexical.Project
   alias Lexical.Protocol.Requests
   alias Lexical.Protocol.Responses
@@ -43,14 +42,12 @@ defmodule Lexical.Server.Provider.Handlers.Commands do
   end
 
   defp reindex(%Project{} = project, request_id) do
-    case :timer.tc(RemoteControl.Api, :reindex, [project]) do
-      {elapsed, :ok} ->
-        message = "Reindexed #{Project.name(project)} in #{Formats.time(elapsed)}"
-        Window.show(:info, message)
+    case RemoteControl.Api.reindex(project) do
+      :ok ->
         Responses.ExecuteCommand.new(request_id, "ok")
 
-      {_elapsed, error} ->
-        Window.error("Indexing #{Project.name(project)} failed")
+      error ->
+        Window.show_error_message("Indexing #{Project.name(project)} failed")
         Logger.error("Indexing command failed due to #{inspect(error)}")
 
         internal_error(request_id, "Could not reindex: #{error}")

--- a/apps/server/lib/lexical/server/provider/handlers/commands.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/commands.ex
@@ -53,7 +53,7 @@ defmodule Lexical.Server.Provider.Handlers.Commands do
         Window.error("Indexing #{Project.name(project)} failed")
         Logger.error("Indexing command failed due to #{inspect(error)}")
 
-        internal_error(request_id, "Indexing Failed")
+        internal_error(request_id, "Could not reindex: #{error}")
     end
   end
 

--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -18,6 +18,7 @@ defmodule Lexical.Server.State do
   alias Lexical.Protocol.Types.CodeAction
   alias Lexical.Protocol.Types.Completion
   alias Lexical.Protocol.Types.DidChangeWatchedFiles
+  alias Lexical.Protocol.Types.ExecuteCommand
   alias Lexical.Protocol.Types.FileEvent
   alias Lexical.Protocol.Types.FileSystemWatcher
   alias Lexical.Protocol.Types.Registration
@@ -27,6 +28,7 @@ defmodule Lexical.Server.State do
   alias Lexical.Server.CodeIntelligence
   alias Lexical.Server.Configuration
   alias Lexical.Server.Project
+  alias Lexical.Server.Provider.Handlers
   alias Lexical.Server.Transport
 
   require CodeAction.Kind
@@ -269,15 +271,19 @@ defmodule Lexical.Server.State do
     code_action_options =
       CodeAction.Options.new(code_action_kinds: @supported_code_actions, resolve_provider: false)
 
+    command_options = ExecuteCommand.Registration.Options.new(commands: Handlers.Commands.names())
+
     completion_options =
       Completion.Options.new(trigger_characters: CodeIntelligence.Completion.trigger_characters())
 
     server_capabilities =
       Types.ServerCapabilities.new(
         code_action_provider: code_action_options,
+        code_lens_provider: true,
         completion_provider: completion_options,
         definition_provider: true,
         document_formatting_provider: true,
+        execute_command_provider: command_options,
         hover_provider: true,
         references_provider: Features.indexing_enabled?(),
         text_document_sync: sync_options

--- a/apps/server/test/lexical/server/provider/handlers/code_lens_test.exs
+++ b/apps/server/test/lexical/server/provider/handlers/code_lens_test.exs
@@ -1,0 +1,72 @@
+defmodule Lexical.Server.Provider.Handlers.CodeLensTest do
+  alias Lexical.Document
+  alias Lexical.Proto.Convert
+  alias Lexical.Protocol.Requests.CodeLens
+  alias Lexical.Protocol.Types
+  alias Lexical.RemoteControl
+  alias Lexical.Server
+  alias Lexical.Server.Provider.Env
+  alias Lexical.Server.Provider.Handlers
+
+  import Lexical.Test.Protocol.Fixtures.LspProtocol
+  import Lexical.RemoteControl.Api.Messages
+  import Lexical.Test.Fixtures
+  import Lexical.Test.RangeSupport
+
+  use ExUnit.Case, async: false
+
+  setup_all do
+    start_supervised(Document.Store)
+    project = project(:navigations)
+
+    {:ok, _} = start_supervised({DynamicSupervisor, Server.Project.Supervisor.options()})
+
+    {:ok, _} = start_supervised({Server.Project.Supervisor, project})
+
+    RemoteControl.Api.register_listener(project, self(), [project_compiled()])
+    RemoteControl.Api.schedule_compile(project, true)
+
+    assert_receive project_compiled(), 5000
+
+    {:ok, project: project}
+  end
+
+  defp with_mix_exs(%{project: project}) do
+    path = file_path(project, "mix.exs")
+    %{uri: Document.Path.ensure_uri(path)}
+  end
+
+  def build_request(path) do
+    uri = Document.Path.ensure_uri(path)
+
+    params = [
+      text_document: [uri: uri]
+    ]
+
+    with {:ok, _} <- Document.Store.open_temporary(uri),
+         {:ok, req} <- build(CodeLens, params) do
+      Convert.to_native(req)
+    end
+  end
+
+  def handle(request, project) do
+    Handlers.CodeLens.handle(request, %Env{project: project})
+  end
+
+  describe "code lens for mix.exs" do
+    setup [:with_mix_exs]
+
+    test "emits a code lens at the project definition", %{project: project, uri: referenced_uri} do
+      mix_exs_path = Document.Path.ensure_path(referenced_uri)
+      mix_exs = File.read!(mix_exs_path)
+
+      {:ok, request} = build_request(mix_exs_path)
+      {:reply, %{result: lenses}} = handle(request, project)
+
+      assert [%Types.CodeLens{} = code_lens] = lenses
+
+      assert extract(mix_exs, code_lens.range) =~ "def project"
+      assert code_lens.command == Handlers.Commands.reindex_command(project)
+    end
+  end
+end


### PR DESCRIPTION
Added a reindex code lens so we can rebuild indexes without resorting to manual operations.

As we build the indexing infrastructure out, we'll likely need to rebuild the index a lot. Presently, this means restarting the server, which can take some time, so I thought i'd add a command to do it instead. I tried using code actions, but this was a bit fraught, so instead, I used a code lens on the project definition in your mix.exs file.

Fixes #517 