### PR TITLE
Added Window.send_messages

### DIFF
--- a/apps/proto/.formatter.exs
+++ b/apps/proto/.formatter.exs
@@ -7,7 +7,8 @@ proto_dsl = [
   defrequest: 1,
   defrequest: 2,
   defresponse: 1,
-  deftype: 1
+  deftype: 1,
+  server_request: 3
 ]
 
 [

--- a/apps/proto/lib/lexical/proto.ex
+++ b/apps/proto/lib/lexical/proto.ex
@@ -10,7 +10,7 @@ defmodule Lexical.Proto do
       import Proto.Alias, only: [defalias: 1]
       import Proto.Enum, only: [defenum: 1]
       import Proto.Notification, only: [defnotification: 1, defnotification: 2]
-      import Proto.Request, only: [defrequest: 1, defrequest: 2]
+      import Proto.Request, only: [defrequest: 1, defrequest: 2, server_request: 3]
       import Proto.Response, only: [defresponse: 1]
       import Proto.Type, only: [deftype: 1]
     end

--- a/apps/proto/lib/lexical/proto/request.ex
+++ b/apps/proto/lib/lexical/proto/request.ex
@@ -20,8 +20,8 @@ defmodule Lexical.Proto.Request do
     quote do
       unquote(do_defrequest(method, types, __CALLER__))
 
-      def response_type do
-        unquote(response_module_ast)
+      def parse_response(response) do
+        unquote(response_module_ast).parse(response)
       end
     end
   end

--- a/apps/proto/lib/lexical/proto/request.ex
+++ b/apps/proto/lib/lexical/proto/request.ex
@@ -10,13 +10,29 @@ defmodule Lexical.Proto.Request do
   end
 
   defmacro defrequest(method, params_module_ast) do
+    types = fetch_types(params_module_ast, __CALLER__)
+    do_defrequest(method, types, __CALLER__)
+  end
+
+  defmacro server_request(method, params_module_ast, response_module_ast) do
+    types = fetch_types(params_module_ast, __CALLER__)
+
+    quote do
+      unquote(do_defrequest(method, types, __CALLER__))
+
+      def response_type do
+        unquote(response_module_ast)
+      end
+    end
+  end
+
+  defp fetch_types(params_module_ast, env) do
     params_module =
       params_module_ast
-      |> Macro.expand(__CALLER__)
+      |> Macro.expand(env)
       |> Code.ensure_compiled!()
 
-    types = params_module.__meta__(:raw_types)
-    do_defrequest(method, types, __CALLER__)
+    params_module.__meta__(:raw_types)
   end
 
   defp do_defrequest(method, types, caller) do

--- a/apps/proto/lib/lexical/proto/response.ex
+++ b/apps/proto/lib/lexical/proto/response.ex
@@ -4,6 +4,7 @@ defmodule Lexical.Proto.Response do
   alias Lexical.Proto.Macros.{
     Access,
     Meta,
+    Parse,
     Struct,
     Typespec
   }
@@ -23,8 +24,8 @@ defmodule Lexical.Proto.Response do
       unquote(Struct.build(jsonrpc_types, __CALLER__))
       @type t :: unquote(Typespec.typespec())
       unquote(Meta.build(jsonrpc_types))
-
       unquote(constructors())
+      unquote(Parse.build(result: response_type))
 
       defimpl Jason.Encoder, for: unquote(__CALLER__.module) do
         def encode(%_{error: nil} = response, opts) do

--- a/apps/protocol/lib/generated/lexical/protocol/types/lsp_object.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/lsp_object.ex
@@ -1,0 +1,6 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.LSPObject do
+  alias Lexical.Proto
+  use Proto
+  deftype []
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/message/action_item.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/message/action_item.ex
@@ -1,0 +1,6 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.Message.ActionItem do
+  alias Lexical.Proto
+  use Proto
+  deftype title: string()
+end

--- a/apps/protocol/lib/generated/lexical/protocol/types/show_message_request/params.ex
+++ b/apps/protocol/lib/generated/lexical/protocol/types/show_message_request/params.ex
@@ -1,0 +1,10 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule Lexical.Protocol.Types.ShowMessageRequest.Params do
+  alias Lexical.Proto
+  alias Lexical.Protocol.Types
+  use Proto
+
+  deftype actions: optional(list_of(Types.Message.ActionItem)),
+          message: string(),
+          type: Types.Message.Type
+end

--- a/apps/protocol/lib/lexical/protocol/json_rpc.ex
+++ b/apps/protocol/lib/lexical/protocol/json_rpc.ex
@@ -38,6 +38,13 @@ defmodule Lexical.Protocol.JsonRpc do
     Requests.decode(method, request)
   end
 
+  defp do_decode(%{"id" => _id, "result" => _result} = response) do
+    # this is due to a client -> server message, but we can't decode it properly yet.
+    # since we can't match up the response type to the message.
+
+    {:ok, response}
+  end
+
   defp do_decode(%{"method" => method} = notification) do
     Notifications.decode(method, notification)
   end

--- a/apps/protocol/lib/lexical/protocol/requests.ex
+++ b/apps/protocol/lib/lexical/protocol/requests.ex
@@ -1,5 +1,6 @@
 defmodule Lexical.Protocol.Requests do
   alias Lexical.Proto
+  alias Lexical.Protocol.Responses
   alias Lexical.Protocol.Types
 
   # Client -> Server request
@@ -68,7 +69,15 @@ defmodule Lexical.Protocol.Requests do
   defmodule RegisterCapability do
     use Proto
 
-    defrequest "client/registerCapability", Types.Registration.Params
+    server_request "client/registerCapability", Types.Registration.Params, Responses.Empty
+  end
+
+  defmodule ShowMessageRequest do
+    use Proto
+
+    server_request "window/showMessageRequest",
+                   Types.ShowMessageRequest.Params,
+                   Responses.ShowMessage
   end
 
   use Proto, decoders: :requests

--- a/apps/protocol/lib/lexical/protocol/responses.ex
+++ b/apps/protocol/lib/lexical/protocol/responses.ex
@@ -3,6 +3,12 @@ defmodule Lexical.Protocol.Responses do
   alias Lexical.Proto.Typespecs
   alias Lexical.Protocol.Types
 
+  defmodule Empty do
+    use Proto
+
+    defresponse optional(Types.LSPObject)
+  end
+
   defmodule InitializeResult do
     use Proto
 
@@ -49,6 +55,13 @@ defmodule Lexical.Protocol.Responses do
     use Proto
 
     defresponse optional(Types.Hover)
+  end
+
+  # Client -> Server responses
+
+  defmodule ShowMessage do
+    use Proto
+    defresponse optional(Types.Message.ActionItem)
   end
 
   use Typespecs, for: :responses

--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -33,7 +33,11 @@ defmodule Lexical.Server.State do
   require Logger
 
   import Api.Messages
-  defstruct configuration: nil, initialized?: false, shutdown_received?: false
+
+  defstruct configuration: nil,
+            initialized?: false,
+            shutdown_received?: false,
+            in_flight_requests: %{}
 
   @supported_code_actions [
     :quick_fix
@@ -68,6 +72,42 @@ defmodule Lexical.Server.State do
 
   def initialize(%__MODULE__{initialized?: true}, %Initialize{}) do
     {:error, :already_initialized}
+  end
+
+  def in_flight?(%__MODULE__{} = state, request_id) do
+    Map.has_key?(state.in_flight_requests, to_string(request_id))
+  end
+
+  def add_request(%__MODULE__{} = state, request, callback) do
+    Transport.write(request)
+
+    in_flight_requests =
+      Map.put(state.in_flight_requests, to_string(request.id), {request, callback})
+
+    %__MODULE__{state | in_flight_requests: in_flight_requests}
+  end
+
+  def finish_request(%__MODULE__{} = state, response) do
+    %{"id" => response_id} = response
+
+    case Map.pop(state.in_flight_requests, to_string(response_id)) do
+      {{%request_module{} = request, callback}, in_flight_requests} ->
+        response_type = request_module.response_type()
+
+        case response_type.parse(response) do
+          {:ok, response} ->
+            callback.(request, {:ok, response.result})
+
+          error ->
+            Logger.info("failed to parse #{response_type}, #{inspect(error)}")
+            callback.(request, error)
+        end
+
+        %__MODULE__{state | in_flight_requests: in_flight_requests}
+
+      _ ->
+        state
+    end
   end
 
   def default_configuration(%__MODULE__{configuration: config}) do

--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -92,14 +92,12 @@ defmodule Lexical.Server.State do
 
     case Map.pop(state.in_flight_requests, to_string(response_id)) do
       {{%request_module{} = request, callback}, in_flight_requests} ->
-        response_type = request_module.response_type()
-
-        case response_type.parse(response) do
+        case request_module.parse_response(response) do
           {:ok, response} ->
             callback.(request, {:ok, response.result})
 
           error ->
-            Logger.info("failed to parse #{response_type}, #{inspect(error)}")
+            Logger.info("failed to parse response for #{request_module}, #{inspect(error)}")
             callback.(request, error)
         end
 

--- a/apps/server/lib/lexical/server/window.ex
+++ b/apps/server/lib/lexical/server/window.ex
@@ -1,6 +1,9 @@
 defmodule Lexical.Server.Window do
+  alias Lexical.Protocol.Id
   alias Lexical.Protocol.Notifications.LogMessage
   alias Lexical.Protocol.Notifications.ShowMessage
+  alias Lexical.Protocol.Requests
+  alias Lexical.Protocol.Types
   alias Lexical.Server.Transport
 
   @type level :: :error | :warning | :info | :log
@@ -25,5 +28,37 @@ defmodule Lexical.Server.Window do
     show_message = apply(ShowMessage, level, [message])
     Transport.write(show_message)
     :ok
+  end
+
+  @spec show_message(String.t(), level()) :: :ok
+  def show_message(message, message_type) do
+    request = Requests.ShowMessageRequest.new(id: Id.next(), message: message, type: message_type)
+    Lexical.Server.server_request(request)
+  end
+
+  @doc """
+  Shows a message request and handles the response
+
+  Displays a message to the user in the UI and waits for a response.
+  The result type handed to the callback function is a
+  `Lexical.Protocol.Types.Message.ActionItem` or nil if there was no response
+  from the user.
+  """
+  @spec show_message(String.t(), level(), [String.t()], (any() -> any())) :: :ok
+  def show_message(message, message_type, actions, on_response) do
+    action_items =
+      Enum.map(actions, fn action_string ->
+        Types.Message.ActionItem.new(title: action_string)
+      end)
+
+    request =
+      Requests.ShowMessageRequest.new(
+        id: Id.next(),
+        message: message,
+        actions: action_items,
+        type: message_type
+      )
+
+    Lexical.Server.server_request(request, fn _request, response -> on_response.(response) end)
   end
 end

--- a/apps/server/lib/lexical/server/window.ex
+++ b/apps/server/lib/lexical/server/window.ex
@@ -10,6 +10,9 @@ defmodule Lexical.Server.Window do
 
   @levels [:error, :warning, :info, :log]
 
+  @type message_result :: {:errory, term()} | {:ok, nil} | {:ok, Types.Message.ActionItem.t()}
+  @type on_response_callback :: (message_result() -> any())
+
   @spec log(level, String.t()) :: :ok
   def log(level, message) when level in @levels and is_binary(message) do
     log_message = apply(LogMessage, level, [message])
@@ -43,9 +46,13 @@ defmodule Lexical.Server.Window do
   The result type handed to the callback function is a
   `Lexical.Protocol.Types.Message.ActionItem` or nil if there was no response
   from the user.
+
+  The strings passed in as the `actions` command are displayed to the user, and when
+  they select one, the `Types.Message.ActionItem` is passed to the callback function.
   """
-  @spec show_message(String.t(), level(), [String.t()], (any() -> any())) :: :ok
-  def show_message(message, message_type, actions, on_response) do
+  @spec show_message(String.t(), level(), [String.t()], on_response_callback) :: :ok
+  def show_message(message, message_type, actions, on_response)
+      when is_function(on_response, 1) do
     action_items =
       Enum.map(actions, fn action_string ->
         Types.Message.ActionItem.new(title: action_string)


### PR DESCRIPTION
We're going to need some sort of confirmation / messaging, so I thought it was the appropriate time to add Window.send_message. This allows us to send a message to the user, and optionally await some kind of response.

To accomplish this, I had to wedge in the notion of a server sent request, which took some doing, as we don't have a mapping from requests to responses (we sort of do now). This required doing some work in the proto layer, as requests didn't have the ability to parse themselves (since they originate from the server).

I tested this in both emacs and vscode, and it seems to work