### PR TITLE
Fix the `expand_selector` in the case of a syntax error.

### DIFF
--- a/apps/common/lib/lexical/ast/analysis/import.ex
+++ b/apps/common/lib/lexical/ast/analysis/import.ex
@@ -17,7 +17,7 @@ defmodule Lexical.Ast.Analysis.Import do
     %__MODULE__{module: module, selector: expand_selector(selector), line: line}
   end
 
-  defp expand_selector(selectors) do
+  defp expand_selector(selectors) when is_list(selectors) do
     selectors =
       Enum.reduce(selectors, [], fn
         {{:__block__, _, [type]}, {:__block__, _, [selector]}}, acc
@@ -48,5 +48,10 @@ defmodule Lexical.Ast.Analysis.Import do
     else
       selectors
     end
+  end
+
+  # If the selectors is not valid, like: `import SomeModule, o `,  we default to :all
+  defp expand_selector(_) do
+    :all
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/analyzer/imports_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/analyzer/imports_test.exs
@@ -310,6 +310,20 @@ defmodule Lexical.Ast.Analysis.ImportsTest do
       refute_imported(imports, ImportedModule, :function, 1)
       refute_imported(imports, ImportedModule, :macro, 1)
     end
+
+    test "import all by default when a syntax error occurs in the latter part" do
+      imports = ~q[
+        import Parent.Child.ImportedModule, o
+        |
+      ] |> imports_at_cursor()
+
+      assert_imported(imports, ImportedModule, :macro, 1)
+
+      assert_imported(imports, ImportedModule, :function, 0)
+      assert_imported(imports, ImportedModule, :function, 0)
+      assert_imported(imports, ImportedModule, :function, 1)
+      assert_imported(imports, ImportedModule, :function, 2)
+    end
   end
 
   describe "import scopes" do


### PR DESCRIPTION
Fix the problem in `Document.Store` where it terminates due to `import` syntax errors.

```elixir
{LXical.Document.Store, 2} terminating
...
** (EXIT) an exception was raised:
        ** (Protocol.UndefinedError) protocol Enumerable not implemented for {:o, [_scope_id: #Reference<0.805024100.2513436673.258227>, line: 6, column: 47], nil} of type Tuple
            (elixir 1.15.7) lib/enum.ex:1: Enumerable.impl_for!/1
            (elixir 1.15.7) lib/enum.ex:166: Enumerable.reduce/3
            (elixir 1.15.7) lib/enum.ex:4387: Enum.reduce/3
            (lx_common 0.3.0) lib/lexical/ast/analysis/import.ex:22: LXical.Ast.Analysis.Import.expand_selector/1
            (lx_common 0.3.0) lib/lexical/ast/analysis/import.ex:17: [LXical.Ast.Analysis.Import.new/3](https://github.com/lexical-lsp/lexical/compare/LXical.Ast.Analysis.Import.new/3)
            (lx_common 0.3.0) lib/lexical/ast/analysis.ex:215: LXical.Ast.Analysis.analyze_node/2
            (lx_common 0.3.0) lib/lexical/ast/analysis.ex:71: anonymous fn/2 in LXical.Ast.Analysis.traverse/2
            (elixir 1.15.7) lib/macro.ex:688: anonymous fn/4 in [Macro.do](https://github.com/lexical-lsp/lexical/compare/Macro.do)_traverse_args/4
Pid: #PID<0.163.0>
```