### PR TITLE
Workaround for indexing performance

### DIFF
--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/references_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/references_test.exs
@@ -17,6 +17,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.ReferencesTest do
     project = project()
     RemoteControl.set_project(project)
     start_supervised!(Document.Store)
+    start_supervised!(RemoteControl.Dispatch)
 
     start_supervised!(
       {Search.Store,
@@ -28,6 +29,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.ReferencesTest do
        ]}
     )
 
+    Search.Store.enable()
     assert_eventually Search.Store.loaded?()
     {:ok, project: project}
   end

--- a/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
@@ -19,10 +19,11 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
     create_index = &Search.Indexer.create_index/1
     update_index = &Search.Indexer.update_index/2
 
-    start_supervised!({Search.Store, [project, create_index, update_index]})
     start_supervised!(RemoteControl.Dispatch)
+    start_supervised!({Search.Store, [project, create_index, update_index]})
     start_supervised!(Lexical.Server.Application.document_store_child_spec())
 
+    Search.Store.enable()
     assert_eventually(Search.Store.loaded?(), 1500)
 
     {:ok, state} = Indexing.init([])

--- a/apps/remote_control/test/lexical/remote_control/search/store_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store_test.exs
@@ -1,4 +1,5 @@
 defmodule Lexical.RemoteControl.Search.StoreTest do
+  alias Lexical.RemoteControl.Dispatch
   alias Lexical.RemoteControl.Search.Store
   alias Lexical.RemoteControl.Search.Store.Backends.Ets
   alias Lexical.Test.Entry
@@ -228,8 +229,9 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
   end
 
   defp with_a_started_store(project, backend) do
+    start_supervised!(Dispatch)
     start_supervised!({Store, [project, &default_create/1, &default_update/2, backend]})
-
+    Store.enable()
     assert_eventually ready?(), 1500
 
     on_exit(fn ->


### PR DESCRIPTION
Indexing slows down project compilation by 4x, but I've been completely unable to figure out why. This PR works around the issue by waiting for the project to compile before indexing is enabled. I'll explain what I know next.

All I had to go on was the following: The code server had a message queue and the dirty schedulers had elevated levels. The odd thing is that these two things happened _after_ the indexer had completed. Whatever the indexer was doing continued to affect the compiler, even after the indexer was done.

I investigated the following hypothesis

 * We were overwhelming the file server with traffic x I disabled any reads and writes, still had the problem
 * We were contending on the `:global` locks x I removed the global registrations, the problem persisted
 * Indexing was exhausting the CPU, so compilation couldn't complete x I set the max concurrnecy of the indexer to 1, it still persisted

I then went and disabled more and more of the indexer and found the following, which was quite surprizing: Loading the ETS table slowed down compilation. To reiterate, the act of setting up the ETS table affected compilation, even after the ets table was set up.

Once I realized this, and that we were having contention in the code server, I tried the following:

 * Eliminating any module references in the index. This had a nice effect on the index size, but didn't afect compilation performance
 * I also avoided any calls to the code server in the indexing path, this also had no effect.

So this is a bit of a stumper for me. I have another branch with some changes to the iex helpers that make debugging this easier if anyone else wants to take a crack at it.