### PR TITLE
Fix the termination issue of `Document.Store` caused by incomplete syntax errors.

### DIFF
--- a/apps/common/lib/lexical/ast/analysis.ex
+++ b/apps/common/lib/lexical/ast/analysis.ex
@@ -333,7 +333,7 @@ defmodule Lexical.Ast.Analysis do
     end
   end
 
-  defp fetch_alias_as(options) do
+  defp fetch_alias_as(options) when is_list(options) do
     alias_as =
       Enum.find_value(options, fn
         {{:__block__, _, [:as]}, {:__aliases__, _, [alias_as]}} -> alias_as
@@ -344,5 +344,10 @@ defmodule Lexical.Ast.Analysis do
       nil -> :error
       _ -> {:ok, alias_as}
     end
+  end
+
+  # When the `as` section is incomplete, like: `alias Foo, a`
+  defp fetch_alias_as(_) do
+    :error
   end
 end

--- a/apps/common/test/lexical/ast_test.exs
+++ b/apps/common/test/lexical/ast_test.exs
@@ -296,6 +296,17 @@ defmodule Lexical.AstTest do
       refute analysis.ast
       assert {:error, _} = analysis.parse_error
     end
+
+    test "creates an analysis from a document with incomplete `as` section" do
+      code = ~q[
+        defmodule Invalid do
+          alias Foo, a
+        end
+      ]
+
+      assert %Analysis{} = analysis = analyze(code)
+      assert {:defmodule, _, _} = analysis.ast
+    end
   end
 
   defp ast(s) do


### PR DESCRIPTION
Today, while writing an alias "as", I unexpectedly discovered that `Document.Store` terminated due to an unmatched error.

```elixir
21:48:27.208 [error] Child :undefined of Supervisor LXical.Server.Provider.Queue.Supervisor terminated
** (exit) exited in: GenServer.call({:via, :global, {LXical.Document.Store, 322}}, {:fetch, "file:///Users/scottming/Code/dummy/lib/dummy.ex", :analysis}, 5000)
    ** (EXIT) an exception was raised:
        ** (Protocol.UndefinedError) protocol Enumerable not implemented for {:a, [_scope_id: #Reference<0.3819903562.3914334214.38740>, line: 16, column: 18], nil} of type Tuple
            (elixir 1.15.7) lib/enum.ex:1: Enumerable.impl_for!/1
            (elixir 1.15.7) lib/enum.ex:166: Enumerable.reduce/3
            (elixir 1.15.7) lib/enum.ex:1227: Enum.find_value/3
            (lx_common 0.3.0) lib/lexical/ast/analysis.ex:338: LXical.Ast.Analysis.fetch_alias_as/1
            (lx_common 0.3.0) lib/lexical/ast/analysis.ex:200: LXical.Ast.Analysis.analyze_node/2
            (lx_common 0.3.0) lib/lexical/ast/analysis.ex:71: anonymous fn/2 in LXical.Ast.Analysis.traverse/2
            (elixir 1.15.7) lib/macro.ex:688: anonymous fn/4 in Macro.do_traverse_args/4
            (stdlib 4.3.1.3) lists.erl:1462: :lists.mapfoldl_1/3
Pid: #PID<0.167.0>
```