### PR TITLE
Only enable the reindexer if indexing is enabled

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/application.ex
+++ b/apps/remote_control/lib/lexical/remote_control/application.ex
@@ -16,7 +16,7 @@ defmodule Lexical.RemoteControl.Application do
     children =
       if RemoteControl.project_node?() do
         [
-          {RemoteControl.Commands.Reindex, nil},
+          maybe_reindex(),
           RemoteControl.Module.Loader,
           {RemoteControl.Dispatch, progress: true},
           RemoteControl.ModuleMappings,
@@ -44,8 +44,12 @@ defmodule Lexical.RemoteControl.Application do
          &RemoteControl.Search.Indexer.create_index/1,
          &RemoteControl.Search.Indexer.update_index/2
        ]}
-    else
-      nil
+    end
+  end
+
+  defp maybe_reindex do
+    if Features.indexing_enabled? do
+      {RemoteControl.Commands.Reindex, nil}
     end
   end
 end

--- a/apps/server/test/lexical/server/provider/handlers/code_lens_test.exs
+++ b/apps/server/test/lexical/server/provider/handlers/code_lens_test.exs
@@ -21,9 +21,8 @@ defmodule Lexical.Server.Provider.Handlers.CodeLensTest do
     start_supervised(Document.Store)
     project = project(:umbrella)
 
-    {:ok, _} = start_supervised({DynamicSupervisor, Server.Project.Supervisor.options()})
-
-    {:ok, _} = start_supervised({Server.Project.Supervisor, project})
+    start_supervised!({DynamicSupervisor, Server.Project.Supervisor.options()})
+    start_supervised!({Server.Project.Supervisor, project})
 
     RemoteControl.Api.register_listener(project, self(), [project_compiled()])
     RemoteControl.Api.schedule_compile(project, true)
@@ -35,6 +34,7 @@ defmodule Lexical.Server.Provider.Handlers.CodeLensTest do
 
   defp with_indexing_enabled(_) do
     patch(Lexical.Features, :indexing_enabled?, true)
+    patch(Lexical.RemoteControl.Api, :index_running?, false)
     :ok
   end
 


### PR DESCRIPTION
The reindexer was starting up and trying to update a non-existent store, which would crash.