### PR TITLE
Properly handle expand_alias failures

### DIFF
--- a/apps/common/lib/lexical/ast.ex
+++ b/apps/common/lib/lexical/ast.ex
@@ -387,22 +387,24 @@ defmodule Lexical.Ast do
   # Expands aliases given the rules in the special form
   # https://hexdocs.pm/elixir/1.13.4/Kernel.SpecialForms.html#__aliases__/1
   def reify_alias(current_module, [:"Elixir" | _] = reified) do
-    [current_module | reified]
+    {:ok, [current_module | reified]}
   end
 
   def reify_alias(current_module, [:__MODULE__ | rest]) do
-    [current_module | rest]
+    {:ok, [current_module | rest]}
   end
 
   def reify_alias(current_module, [atom | _rest] = reified) when is_atom(atom) do
-    [current_module | reified]
+    {:ok, [current_module | reified]}
   end
 
   def reify_alias(current_module, [unreified | rest]) do
     env = %Macro.Env{module: current_module}
-    reified = Macro.expand(unreified, env)
 
-    [reified | rest]
+    case Macro.expand(unreified, env) do
+      module when is_atom(module) -> {:ok, [module | rest]}
+      _ -> :error
+    end
   end
 
   # private

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/source/reducer.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/source/reducer.ex
@@ -26,6 +26,12 @@ defmodule Lexical.RemoteControl.Search.Indexer.Source.Reducer do
     }
   end
 
+  def human_location(%__MODULE__{} = reducer) do
+    {line, column} = reducer.position
+    path = reducer.analysis.document.path
+    "#{path} #{line}:#{column}"
+  end
+
   def entries(%__MODULE__{} = reducer) do
     Enum.reverse(reducer.entries)
   end


### PR DESCRIPTION
I initially assumed that the cases where `expand_alias` would fail would be rare, so I did a hard match on `{:ok, alias}`. I was wrong, the cases are much more common, and this is causing irritation for people trying to use indexing. This change logs the cases where expand_alias fails, and skips the entries, which should give better developer experience and should also allow us to see what's causing the failures.