### PR TITLE
Improved lexical's index efficiency

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/commands/reindex.ex
+++ b/apps/remote_control/lib/lexical/remote_control/commands/reindex.ex
@@ -2,10 +2,13 @@ defmodule Lexical.RemoteControl.Commands.Reindex do
   defmodule State do
     alias Lexical.Ast.Analysis
     alias Lexical.Document
+    alias Lexical.ProcessCache
     alias Lexical.RemoteControl.Search
     alias Lexical.RemoteControl.Search.Indexer
 
     require Logger
+    require ProcessCache
+
     defstruct reindex_fun: nil, index_task: nil, pending_updates: %{}
 
     def new(reindex_fun) do
@@ -53,7 +56,7 @@ defmodule Lexical.RemoteControl.Commands.Reindex do
     defp entries_for_uri(uri) do
       with {:ok, %Document{} = document, %Analysis{} = analysis} <-
              Document.Store.fetch(uri, :analysis),
-           {:ok, entries} <- Indexer.Quoted.index(analysis) do
+           {:ok, entries} <- Indexer.Quoted.index_with_cleanup(analysis) do
         {:ok, document.path, entries}
       else
         error ->

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
@@ -7,8 +7,6 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
 
   defstruct [
     :application,
-    :elixir_version,
-    :erlang_version,
     :parent,
     :path,
     :range,
@@ -21,8 +19,6 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
 
   @type t :: %__MODULE__{
           application: module(),
-          elixir_version: version(),
-          erlang_version: version(),
           subject: subject(),
           parent: entry_reference(),
           path: Path.t(),
@@ -34,7 +30,6 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
         }
 
   alias Lexical.StructAccess
-  alias Lexical.VM.Versions
 
   use StructAccess
 
@@ -47,12 +42,8 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
   end
 
   defp new(path, ref, parent, subject, type, subtype, range, application) do
-    versions = Versions.current()
-
     %__MODULE__{
       application: application,
-      elixir_version: versions.elixir,
-      erlang_version: versions.erlang,
       subject: subject,
       parent: parent,
       path: path,

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_definition.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_definition.ex
@@ -39,7 +39,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinition do
     entry =
       Entry.definition(
         reducer.analysis.document.path,
-        block.ref,
+        make_ref(),
         block.parent_ref,
         mfa,
         type,

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_reference.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_reference.ex
@@ -140,7 +140,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionReference do
 
         Entry.reference(
           reducer.analysis.document.path,
-          block.ref,
+          make_ref(),
           block.parent_ref,
           mfa,
           :function,

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/quoted.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/quoted.ex
@@ -1,6 +1,15 @@
 defmodule Lexical.RemoteControl.Search.Indexer.Quoted do
   alias Lexical.Ast.Analysis
+  alias Lexical.ProcessCache
   alias Lexical.RemoteControl.Search.Indexer.Source.Reducer
+
+  require ProcessCache
+
+  def index_with_cleanup(%Analysis{} = analysis) do
+    ProcessCache.with_cleanup do
+      index(analysis)
+    end
+  end
 
   def index(%Analysis{valid?: true} = analysis) do
     {_, reducer} =

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schema.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schema.ex
@@ -55,6 +55,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schema do
   end
 
   alias Lexical.Project
+  alias Lexical.VM.Versions
 
   def load(%Project{} = project, schema_order) do
     ensure_unique_versions(schema_order)
@@ -89,7 +90,9 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schema do
   end
 
   def index_root(%Project{} = project) do
-    Project.workspace_path(project, "indexes")
+    versions = Versions.current()
+    index_path = ["indexes", versions.erlang, versions.elixir]
+    Project.workspace_path(project, index_path)
   end
 
   def index_file_path(%Project{} = project, schema) do

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v1.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v1.ex
@@ -14,14 +14,12 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1 do
 
   use Schema, version: 1
 
-  defkey :by_id, [:id, :type, :subtype, :elixir_version, :erlang_version]
+  defkey :by_id, [:id, :type, :subtype]
 
   defkey :by_subject, [
     :subject,
     :type,
     :subtype,
-    :elixir_version,
-    :erlang_version,
     :path
   ]
 
@@ -31,7 +29,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1 do
     migrated =
       entries
       |> Stream.filter(fn
-        {_, %_{elixir_version: _, erlang_version: _, type: _, subtype: _, ref: _}} -> true
+        {_, %_{type: _, subtype: _, ref: _}} -> true
         _ -> false
       end)
       |> Stream.map(fn {_, entry} -> entry end)
@@ -53,8 +51,6 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1 do
   def to_rows(%Entry{} = entry) do
     subject_key =
       by_subject(
-        elixir_version: entry.elixir_version,
-        erlang_version: entry.erlang_version,
         subject: to_subject(entry.subject),
         type: entry.type,
         subtype: entry.subtype,
@@ -65,18 +61,16 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1 do
       by_id(
         id: entry.ref,
         type: entry.type,
-        subtype: entry.subtype,
-        elixir_version: entry.elixir_version,
-        erlang_version: entry.erlang_version
+        subtype: entry.subtype
       )
 
     path_key = by_path(path: entry.path)
 
-    [{subject_key, entry}, {id_key, entry}, {path_key, id_key}]
+    [{subject_key, id_key}, {id_key, entry}, {path_key, id_key}]
   end
 
   # This case will handle any namespaced entries
-  def to_rows(%{elixir_version: _, erlang_version: _, type: _, subtype: _, ref: _} = entry) do
+  def to_rows(%{type: _, subtype: _, ref: _} = entry) do
     map = Map.delete(entry, :__struct__)
 
     Entry

--- a/apps/remote_control/test/lexical/remote_control/search/store_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store_test.exs
@@ -62,29 +62,6 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
         assert ref.subtype == :reference
       end
 
-      test "matching can exclude on elixir version" do
-        Store.replace([
-          reference(subject: Enum, elixir_version: "1.0.0"),
-          reference(subject: Enum)
-        ])
-
-        assert {:ok, [ref]} = Store.exact("Enum", subtype: :reference)
-        assert ref.subject == Enum
-        refute ref.elixir_version == "1.0.0"
-      end
-
-      test "matching can exclude on erlang version" do
-        Store.replace([
-          reference(subject: Enum, erlang_version: "1.0.0"),
-          reference(subject: Enum)
-        ])
-
-        assert {:ok, [ref]} = Store.exact("Enum", subtype: :reference)
-
-        assert ref.subject == Enum
-        refute ref.erlang_version == "1.0.0"
-      end
-
       test "matching with queries can exclude on type" do
         Store.replace([
           reference(subject: Foo.Bar.Baz),
@@ -123,26 +100,6 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
 
         assert entry_1.subject in [Foo.Bar.Baz, Foo.Bar.Bak]
         assert entry_2.subject in [Foo.Bar.Baz, Foo.Bar.Bak]
-      end
-
-      test "matching only returns entries specific to our elixir version" do
-        Store.replace([
-          definition(ref: 1, subject: Foo.Bar.Baz, elixir_version: "1.1"),
-          definition(ref: 2, subject: Foo.Bar.Baz)
-        ])
-
-        assert {:ok, [entry]} = Store.fuzzy("Foo.Bar.", type: :module, subtype: :definition)
-        assert entry.ref == 2
-      end
-
-      test "matching only returns entries specific to our erlang version" do
-        Store.replace([
-          definition(ref: 1, subject: Foo.Bar.Baz, erlang_version: "14.3.2.8"),
-          definition(ref: 2, subject: Foo.Bar.Baz)
-        ])
-
-        assert {:ok, [entry]} = Store.fuzzy("Foo.Bar.", type: :module, subtype: :definition)
-        assert entry.ref == 2
       end
     end
 

--- a/apps/remote_control/test/support/lexical/test/entry/entry_builder.ex
+++ b/apps/remote_control/test/support/lexical/test/entry/entry_builder.ex
@@ -1,20 +1,15 @@
 defmodule Lexical.Test.Entry.Builder do
   alias Lexical.Document.Range
   alias Lexical.RemoteControl.Search.Indexer.Entry
-  alias Lexical.VM.Versions
 
   import Lexical.Test.PositionSupport
 
   def entry(fields \\ []) do
-    versions = Versions.current()
-
     defaults = [
       subject: Module,
       ref: make_ref(),
       path: "/foo/bar/baz.ex",
       range: range(1, 1, 1, 5),
-      elixir_version: versions.elixir,
-      erlang_version: versions.erlang,
       type: :module
     ]
 

--- a/projects/lexical_shared/test/lexical/process_cache_test.exs
+++ b/projects/lexical_shared/test/lexical/process_cache_test.exs
@@ -11,50 +11,99 @@ defmodule Lexical.ProcessCacheTest do
     {:ok, now: 1}
   end
 
-  test "calls the compute function" do
-    assert 3 == trans("my key", fn -> 3 end)
+  describe "trans/2" do
+    test "calls the compute function" do
+      assert 3 == trans("my key", fn -> 3 end)
+    end
+
+    test "pulls from the process cache when an entry exists" do
+      assert 3 == trans("my key", fn -> 3 end)
+      assert 3 == trans("my key", fn -> 6 end)
+    end
+
+    test "times out after a given timeout", ctx do
+      now = ctx.now
+
+      patch(ProcessCache.Entry, :now_ts, cycle([now, now + 4999, now + 5000]))
+
+      assert 3 == trans("my key", fn -> 3 end)
+      assert {:ok, 3} == fetch("my key")
+      assert :error == fetch("my key")
+    end
+
+    test "calling get also clears the key after the timeout", ctx do
+      now = ctx.now
+
+      patch(ProcessCache.Entry, :now_ts, cycle([now, now + 4999, now + 5000]))
+
+      assert 3 == trans("my key", fn -> 3 end)
+      assert 3 == get("my key")
+      assert nil == get("my key")
+    end
+
+    test "the timeout is configurable", ctx do
+      now = ctx.now
+      patch(ProcessCache.Entry, :now_ts, cycle([now, now + 49, now + 50]))
+
+      assert 3 = trans("my key", 50, fn -> 3 end)
+      assert {:ok, 3} == fetch("my key")
+      assert :error == fetch("my key")
+    end
+
+    test "trans will replace an expired key", ctx do
+      now = ctx.now
+      patch(ProcessCache.Entry, :now_ts, cycle([now, now + 49, now + 50]))
+
+      assert 3 = trans("my key", 50, fn -> 3 end)
+      assert 3 = trans("my key", 50, fn -> 6 end)
+      assert 6 = trans("my key", 50, fn -> 6 end)
+    end
   end
 
-  test "pulls from the process cache when an entry exists" do
-    assert 3 == trans("my key", fn -> 3 end)
-    assert 3 == trans("my key", fn -> 6 end)
-  end
+  describe "with_cleanup" do
+    test "cleans up after a trans call" do
+      with_cleanup do
+        trans("my_key", fn -> 3 end)
+      end
 
-  test "times out after a given timeout", ctx do
-    now = ctx.now
+      assert :error = fetch("my_key")
+    end
 
-    patch(ProcessCache.Entry, :now_ts, cycle([now, now + 4999, now + 5000]))
+    test "cleans up multiple keys" do
+      with_cleanup do
+        trans("my_key", fn -> 1 end)
+        trans("my_key2", fn -> 1 end)
+        trans("my_key3", fn -> 1 end)
+      end
 
-    assert 3 == trans("my key", fn -> 3 end)
-    assert {:ok, 3} == fetch("my key")
-    assert :error == fetch("my key")
-  end
+      assert :error = fetch("my_key")
+      assert :error = fetch("my_key1")
+      assert :error = fetch("my_key2")
+    end
 
-  test "calling get also clears the key after the timeout", ctx do
-    now = ctx.now
+    test "cleans up even if a trans function raises" do
+      with_cleanup do
+        assert_raise RuntimeError, fn ->
+          with_cleanup do
+            trans("my_key", fn -> 1 end)
+            trans("my_key2", fn -> 1 end)
+            trans("my_key3", fn -> raise "oops" end)
+          end
+        end
 
-    patch(ProcessCache.Entry, :now_ts, cycle([now, now + 4999, now + 5000]))
+        assert :error = fetch("my_key")
+        assert :error = fetch("my_key2")
+        assert :error = fetch("my_key3")
+      end
+    end
 
-    assert 3 == trans("my key", fn -> 3 end)
-    assert 3 == get("my key")
-    assert nil == get("my key")
-  end
+    test "returns the last value" do
+      result =
+        with_cleanup do
+          trans("my_key", fn -> 1 end) + 1
+        end
 
-  test "the timeout is configurable", ctx do
-    now = ctx.now
-    patch(ProcessCache.Entry, :now_ts, cycle([now, now + 49, now + 50]))
-
-    assert 3 = trans("my key", 50, fn -> 3 end)
-    assert {:ok, 3} == fetch("my key")
-    assert :error == fetch("my key")
-  end
-
-  test "trans will replace an expired key", ctx do
-    now = ctx.now
-    patch(ProcessCache.Entry, :now_ts, cycle([now, now + 49, now + 50]))
-
-    assert 3 = trans("my key", 50, fn -> 3 end)
-    assert 3 = trans("my key", 50, fn -> 6 end)
-    assert 6 = trans("my key", 50, fn -> 6 end)
+      assert result == 2
+    end
   end
 end


### PR DESCRIPTION
For lexical, the index was using 450MB of disk and consumed about a gig in memory. This commit includes the following changes:

  * We stopped duplicating entries in a couple of the records, and now only store them once in the 'by_ref' key. This decreased the index size by 50%, and had no noticable effect on performance.
  * Several of the processes had cache entries lying around that caused them to consume quite a bit (hundreds of megs) of memory. I introduced a cache cleaning block and added it to the call sites, and this reduced the memory usage of those processes back to extremely low levels.
  * We were storing the erlang and elixir versions on each entry. Now we create separate indexes for each elixir/erlang version pair

In total, lexical was taking around 1gb of memory before these changes, and now it takes around 400mb. Disk space dropped from 450 megs to 250.