### PR TITLE
Made schemas implement a bevaviour

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/legacy_v0.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/legacy_v0.ex
@@ -12,4 +12,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.LegacyV0 do
   def index_file_name do
     "source.index.ets"
   end
+
+  def to_rows(_) do
+    []
+  end
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v1.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v1.ex
@@ -33,19 +33,9 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V1 do
         _ -> false
       end)
       |> Stream.map(fn {_, entry} -> entry end)
-      |> entries_to_rows()
+      |> Schema.entries_to_rows(__MODULE__)
 
     {:ok, migrated}
-  end
-
-  @spec entries_to_rows(Enumerable.t(Entry.t())) :: [tuple()]
-  def entries_to_rows(entries) do
-    entries
-    |> Stream.flat_map(&to_rows(&1))
-    |> Enum.reduce(%{}, fn {key, value}, acc ->
-      Map.update(acc, key, [value], fn old_values -> [value | old_values] end)
-    end)
-    |> Enum.to_list()
   end
 
   def to_rows(%Entry{} = entry) do

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
@@ -47,7 +47,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
   end
 
   def insert(%__MODULE__{leader?: true} = state, entries) do
-    rows = Schemas.V1.entries_to_rows(entries)
+    rows = Schema.entries_to_rows(entries, current_schema())
     true = :ets.insert(state.table_name, rows)
     :ok
   end
@@ -86,7 +86,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
   end
 
   def replace_all(%__MODULE__{leader?: true} = state, entries) do
-    rows = Schemas.V1.entries_to_rows(entries)
+    rows = Schema.entries_to_rows(entries, current_schema())
 
     with true <- :ets.delete_all_objects(state.table_name),
          true <- :ets.insert(state.table_name, rows) do

--- a/apps/remote_control/test/lexical/remote_control/search/store/backends/ets/schema_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store/backends/ets/schema_test.exs
@@ -20,6 +20,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.SchemaTest do
 
   defmodule First do
     use Schema, version: 1
+    def to_rows(_), do: []
   end
 
   defmodule IncrementValue do
@@ -29,6 +30,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.SchemaTest do
       entries = Enum.map(entries, fn {k, v} -> {k, v + 1} end)
       {:ok, entries}
     end
+
+    def to_rows(_), do: []
   end
 
   defmodule IncrementKey do
@@ -37,11 +40,15 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.SchemaTest do
     def migrate(entries) do
       {:ok, Enum.map(entries, fn {k, v} -> {k + 1, v} end)}
     end
+
+    def to_rows(_), do: []
   end
 
   test "it ensures the uniqueness of versions in the schema order", %{project: project} do
     defmodule SameVersion do
       use Schema, version: 1
+
+      def to_rows(_), do: []
     end
 
     assert_raise ArgumentError, fn -> Schema.load(project, [First, SameVersion]) end
@@ -122,6 +129,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.SchemaTest do
       def migrate(_) do
         {:ok, []}
       end
+
+      def to_rows(_), do: []
     end
 
     entries = [{1, 1}, {2, 2}, {3, 3}]
@@ -139,6 +148,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.SchemaTest do
       def migrate(_) do
         {:error, :migration_failed}
       end
+
+      def to_rows(_), do: []
     end
 
     entries = [{1, 1}]
@@ -155,6 +166,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.SchemaTest do
       def index_file_name do
         First.index_file_name()
       end
+
+      def to_rows(_), do: []
     end
 
     entries = [{1, 1}, {2, 2}]


### PR DESCRIPTION
We were reaching into version specific schemas to do certain operations, and it seems like we really want the top-level schema module to do these things instead.