### PR TITLE
Support mise (new name for rtx)

### DIFF
--- a/bin/activate_version_manager.sh
+++ b/bin/activate_version_manager.sh
@@ -2,7 +2,7 @@
 
 # The purpose of these functions is to detect and activate the correct
 # installed version manager in the current shell session. Currently, we
-# try to detect asdf and rtx.
+# try to detect asdf, rtx, and mise (new name for rtx).
 #
 # The general approach involves the following steps:
 #
@@ -12,17 +12,20 @@
 #      Elixir, we're all set.
 #   3. Try to find and activate an rtx installation. If it provides
 #      Elixir, we're all set.
+#   4. Try to find and activate a mise installation. If it provides
+#      Elixir, we're all set.
 #
 
 activate_version_manager() {
-    if (_detect_asdf || _detect_rtx); then
+    if (_detect_asdf || _detect_rtx || _detect_mise); then
         return 0
     fi
 
     echo >&2 "No activated version manager detected. Searching for version manager..."
 
     { _try_activating_asdf && _detect_asdf; } ||
-        { _try_activating_rtx && _detect_rtx; }
+        { _try_activating_rtx && _detect_rtx; } ||
+            { _try_activating_mise && _detect_mise; }
     return $?
 }
 
@@ -38,6 +41,15 @@ _detect_asdf() {
 _detect_rtx() {
     if command -v rtx >/dev/null && rtx which elixir >/dev/null 2>&1 && _ensure_which_elixir rtx; then
         echo >&2 "Detected Elixir through rtx: $(rtx which elixir)"
+        return 0
+    else
+        return 1
+    fi
+}
+
+_detect_mise() {
+    if command -v mise >/dev/null && mise which elixir >/dev/null 2>&1 && _ensure_which_elixir mise; then
+        echo >&2 "Detected Elixir through mise: $(mise which elixir)"
         return 0
     else
         return 1
@@ -68,6 +80,17 @@ _try_activating_rtx() {
         echo >&2 "Found rtx. Activating..."
         eval "$(rtx activate bash)"
         eval "$(rtx env)"
+        return $?
+    else
+        return 1
+    fi
+}
+
+_try_activating_mise() {
+    if which mise >/dev/null; then
+        echo >&2 "Found mise. Activating..."
+        eval "$(mise activate bash)"
+        eval "$(mise env)"
         return $?
     else
         return 1


### PR DESCRIPTION
Apparently the author of `rtx` changed its name to `mise` recently (rationale here: https://mise.jdx.dev/rtx.html). When you install `rtx` via `homebrew` and run `brew upgrade`, it automatically changes it to `mise` and with it the `rtx` command is changed to `mise` as well (but everything else works in the same way as `rtx`). This PR supports `mise`.