### PR TITLE
Fixed alias crash on unquote

### DIFF
--- a/apps/remote_control/test/lexical/remote_control/analyzer/imports_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/analyzer/imports_test.exs
@@ -443,5 +443,22 @@ defmodule Lexical.Ast.Analysis.ImportsTest do
 
       refute_imported(imports, Enum)
     end
+
+    test "imports to the current module work in a quote block" do
+      imports =
+        ~q[
+        defmodule Parent do
+          defmacro __using__(_) do
+            quote do
+              import unquote(__MODULE__).Child.ImportedModule
+              |
+            end
+          end
+        end
+        ]
+        |> imports_at_cursor()
+
+      assert_imported(imports, Parent.Child.ImportedModule)
+    end
   end
 end


### PR DESCRIPTION
Lots of modules seem to do `unquote(__MODULE__).OtherModule`, and we can support this rather than crash, which is what caused #542

Fixes #542