### PR TITLE
Fixed crash that would happen during imports

### DIFF
--- a/apps/common/lib/lexical/ast/analysis/import.ex
+++ b/apps/common/lib/lexical/ast/analysis/import.ex
@@ -3,7 +3,11 @@ defmodule Lexical.Ast.Analysis.Import do
   @type function_name :: atom()
   @type function_arity :: {function_name(), arity()}
   @type selector ::
-          :functions | :macros | [only: [function_arity()]] | [except: [function_arity()]]
+          :functions
+          | :macros
+          | :sigils
+          | [only: [function_arity()]]
+          | [except: [function_arity()]]
   @type t :: %{
           module: module(),
           selector: selector(),
@@ -29,6 +33,9 @@ defmodule Lexical.Ast.Analysis.Import do
 
               :macros ->
                 :macros
+
+              :sigils ->
+                :sigils
 
               keyword when is_list(keyword) ->
                 Enum.map(keyword, fn

--- a/apps/common/lib/lexical/ast/analysis/import.ex
+++ b/apps/common/lib/lexical/ast/analysis/import.ex
@@ -35,6 +35,11 @@ defmodule Lexical.Ast.Analysis.Import do
                   {{:__block__, _, [function_name]}, {:__block__, _, [arity]}} ->
                     {function_name, arity}
                 end)
+
+              _ ->
+                # they're likely in the middle of typing in something, and have produced an
+                # invalid import
+                []
             end
 
           [{type, expanded} | acc]

--- a/apps/common/test/lexical/ast_test.exs
+++ b/apps/common/test/lexical/ast_test.exs
@@ -307,6 +307,15 @@ defmodule Lexical.AstTest do
       assert %Analysis{} = analysis = analyze(code)
       assert {:defmodule, _, _} = analysis.ast
     end
+
+    test "handles incomplete imports" do
+      code = ~q[
+        defmodule Invalid do
+          import Other, only: :m
+        end
+      ]
+      assert %Analysis{} = analyze(code)
+    end
   end
 
   defp ast(s) do

--- a/apps/remote_control/test/lexical/remote_control/analyzer/imports_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/analyzer/imports_test.exs
@@ -29,6 +29,14 @@ defmodule WithStruct do
   defstruct [:field]
 end
 
+defmodule WithSigils do
+  def sigil_m(_) do
+  end
+
+  def sigil_n(_, _) do
+  end
+end
+
 defmodule Lexical.Ast.Analysis.ImportsTest do
   alias Lexical.Ast
   alias Lexical.RemoteControl.Analyzer
@@ -262,6 +270,18 @@ defmodule Lexical.Ast.Analysis.ImportsTest do
       refute_imported(imports, ImportedModule, :function, 0)
       refute_imported(imports, ImportedModule, :function, 1)
       refute_imported(imports, ImportedModule, :function, 2)
+    end
+
+    test "it is possible to select all sigils" do
+      imports =
+        ~q[
+          import WithSigils, only: :sigils
+          |
+      ]
+        |> imports_at_cursor()
+
+      assert_imported(imports, WithSigils, :sigil_m, 1)
+      assert_imported(imports, WithSigils, :sigil_n, 2)
     end
 
     test "it is possible to limit imports by name and arity with only" do


### PR DESCRIPTION
If you import `only: :macros`, or `only: :functions`, lexical would crash, because there was no case for `only: :f`. Adding a fallthrough case fixes the issue