### PR TITLE
Namespacing: Apply to config scripts 

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/bootstrap.ex
+++ b/apps/remote_control/lib/lexical/remote_control/bootstrap.ex
@@ -10,10 +10,12 @@ defmodule Lexical.RemoteControl.Bootstrap do
   alias Lexical.RemoteControl
   require Logger
 
-  def init(%Project{} = project, document_store_entropy, remote_control_config) do
+  def init(%Project{} = project, document_store_entropy, app_configs) do
     Lexical.Document.Store.set_entropy(document_store_entropy)
+
+    Application.put_all_env(app_configs)
+
     maybe_append_hex_path()
-    Application.put_all_env(remote_control: remote_control_config)
 
     project_root = Project.root_path(project)
 

--- a/apps/remote_control/lib/lexical/remote_control/project_node.ex
+++ b/apps/remote_control/lib/lexical/remote_control/project_node.ex
@@ -228,9 +228,9 @@ defmodule Lexical.RemoteControl.ProjectNode do
     :"#{Project.name(project)}::node_process"
   end
 
+  @deps_apps Mix.Project.deps_apps()
   defp all_app_configs do
-    Application.started_applications()
-    |> Enum.map(fn {app_name, _, _} ->
+    Enum.map(@deps_apps, fn app_name ->
       {app_name, Application.get_all_env(app_name)}
     end)
   end

--- a/apps/remote_control/lib/lexical/remote_control/project_node.ex
+++ b/apps/remote_control/lib/lexical/remote_control/project_node.ex
@@ -103,8 +103,7 @@ defmodule Lexical.RemoteControl.ProjectNode do
 
   def start(project, paths) do
     node_name = Project.node_name(project)
-    remote_control_config = Application.get_all_env(:remote_control)
-    bootstrap_args = [project, Document.Store.entropy(), remote_control_config]
+    bootstrap_args = [project, Document.Store.entropy(), all_app_configs()]
 
     with {:ok, node_pid} <- ProjectNodeSupervisor.start_project_node(project),
          :ok <- start_node(project, paths),
@@ -227,5 +226,12 @@ defmodule Lexical.RemoteControl.ProjectNode do
 
   def name(%Project{} = project) do
     :"#{Project.name(project)}::node_process"
+  end
+
+  defp all_app_configs do
+    Application.started_applications()
+    |> Enum.map(fn {app_name, _, _} ->
+      {app_name, Application.get_all_env(app_name)}
+    end)
   end
 end

--- a/apps/remote_control/lib/mix/tasks/namespace/transform/configs.ex
+++ b/apps/remote_control/lib/mix/tasks/namespace/transform/configs.ex
@@ -1,0 +1,28 @@
+defmodule Mix.Tasks.Namespace.Transform.Configs do
+  alias Mix.Tasks.Namespace
+
+  def apply_to_all(base_directory) do
+    base_directory
+    |> Path.join("**")
+    |> Path.wildcard()
+    |> Enum.map(&Path.absname/1)
+    |> Enum.each(&apply/1)
+  end
+
+  def apply(path) do
+    namespaced =
+      path
+      |> File.read!()
+      |> Code.string_to_quoted!()
+      |> Macro.postwalk(fn
+        atom when is_atom(atom) ->
+          Namespace.Module.apply(atom)
+
+        ast ->
+          ast
+      end)
+      |> Macro.to_string()
+
+    File.write!(path, namespaced)
+  end
+end

--- a/apps/remote_control/lib/mix/tasks/namespace/transform/configs.ex
+++ b/apps/remote_control/lib/mix/tasks/namespace/transform/configs.ex
@@ -6,6 +6,9 @@ defmodule Mix.Tasks.Namespace.Transform.Configs do
     |> Path.join("**")
     |> Path.wildcard()
     |> Enum.map(&Path.absname/1)
+    |> tap(fn paths ->
+      Mix.Shell.IO.info("Rewriting #{length(paths)} config scripts.")
+    end)
     |> Enum.each(&apply/1)
   end
 
@@ -15,6 +18,16 @@ defmodule Mix.Tasks.Namespace.Transform.Configs do
       |> File.read!()
       |> Code.string_to_quoted!()
       |> Macro.postwalk(fn
+        {:__aliases__, meta, alias} ->
+          namespaced_alias =
+            alias
+            |> Module.concat()
+            |> Namespace.Module.apply()
+            |> Module.split()
+            |> Enum.map(&String.to_atom/1)
+
+          {:__aliases__, meta, namespaced_alias}
+
         atom when is_atom(atom) ->
           Namespace.Module.apply(atom)
 

--- a/apps/remote_control/mix.exs
+++ b/apps/remote_control/mix.exs
@@ -51,6 +51,7 @@ defmodule Lexical.RemoteControl.MixProject do
       {:patch, "~> 0.12", only: [:dev, :test], optional: true, runtime: false},
       {:path_glob, "~> 0.2", optional: true},
       {:phoenix_live_view, "~> 0.19.5", only: [:test], optional: true, runtime: false},
+      {:snowflake, "~> 1.0"},
       {:sourceror, "~> 1.0"}
     ]
   end

--- a/apps/remote_control/test/lexical/remote_control/code_mod/format_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_mod/format_test.exs
@@ -134,7 +134,7 @@ defmodule Lexical.RemoteControl.CodeMod.FormatTest do
       end
       ] |> modify(project: project)
 
-      assert_receive file_diagnostics(diagnostics: [diagnostic]), 250
+      assert_receive file_diagnostics(diagnostics: [diagnostic]), 500
       assert diagnostic.message =~ "syntax error"
     end
   end

--- a/apps/server/lib/mix/tasks/package.ex
+++ b/apps/server/lib/mix/tasks/package.ex
@@ -258,6 +258,8 @@ defmodule Mix.Tasks.Package do
     config_dest = Path.join(package_root, "config")
     File.mkdir_p!(config_dest)
     File.cp_r!(config_source, config_dest)
+
+    Namespace.Transform.Configs.apply_to_all(config_dest)
   end
 
   @priv_apps [:remote_control]


### PR DESCRIPTION
Had an interesting bug with indexing; The snowflakes generated by remote_control were not compatible with our epoch. This is because we weren't namepsacing the configuration files, and were configuring snowflake rather than lx_snowflake.

This PR adds that namespacing.