### PR TITLE
ETS backend write-ahead log

### DIFF
--- a/apps/remote_control/.formatter.exs
+++ b/apps/remote_control/.formatter.exs
@@ -20,7 +20,7 @@ impossible_to_format = [
   Path.join([current_directory, "test", "fixtures", "parse_errors", "lib", "parse_errors.ex"])
 ]
 
-locals_without_parens = [with_progress: 2, with_progress: 3, defkey: 2, defkey: 3]
+locals_without_parens = [with_progress: 2, with_progress: 3, defkey: 2, defkey: 3, with_wal: 2]
 
 [
   locals_without_parens: locals_without_parens,

--- a/apps/remote_control/lib/lexical/remote_control/application.ex
+++ b/apps/remote_control/lib/lexical/remote_control/application.ex
@@ -26,6 +26,8 @@ defmodule Lexical.RemoteControl.Application do
           RemoteControl.Plugin.Runner.Coordinator,
           maybe_search_store()
         ]
+        |> Enum.reject(&is_nil/1)
+        |> List.flatten()
       else
         []
       end
@@ -39,16 +41,19 @@ defmodule Lexical.RemoteControl.Application do
 
   defp maybe_search_store do
     if Features.indexing_enabled?() do
-      {RemoteControl.Search.Store,
-       [
-         &RemoteControl.Search.Indexer.create_index/1,
-         &RemoteControl.Search.Indexer.update_index/2
-       ]}
+      [
+        RemoteControl.Search.Store.Backends.Ets,
+        {RemoteControl.Search.Store,
+         [
+           &RemoteControl.Search.Indexer.create_index/1,
+           &RemoteControl.Search.Indexer.update_index/2
+         ]}
+      ]
     end
   end
 
   defp maybe_reindex do
-    if Features.indexing_enabled? do
+    if Features.indexing_enabled?() do
       {RemoteControl.Commands.Reindex, nil}
     end
   end

--- a/apps/remote_control/lib/lexical/remote_control/application.ex
+++ b/apps/remote_control/lib/lexical/remote_control/application.ex
@@ -26,8 +26,8 @@ defmodule Lexical.RemoteControl.Application do
           RemoteControl.Plugin.Runner.Coordinator,
           maybe_search_store()
         ]
-        |> Enum.reject(&is_nil/1)
         |> List.flatten()
+        |> Enum.reject(&is_nil/1)
       else
         []
       end

--- a/apps/remote_control/lib/lexical/remote_control/search/store.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store.ex
@@ -228,7 +228,6 @@ defmodule Lexical.RemoteControl.Search.Store do
   @impl GenServer
   def terminate(_reason, {_, state}) do
     {:ok, state} = State.flush_buffered_updates(state)
-    State.drop(state)
     {:noreply, state}
   end
 

--- a/apps/remote_control/lib/lexical/remote_control/search/store.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store.ex
@@ -215,10 +215,9 @@ defmodule Lexical.RemoteControl.Search.Store do
     {:reply, loaded?, {ref, state}}
   end
 
-  def handle_call(:loaded?, _, %State{} = state) do
+  def handle_call(:loaded?, _, %State{loaded?: loaded?} = state) do
     # We're not enabled yet, but we can still reply to the query
-    # if we're loaded, because if we're not enabled, we're not loaded.
-    {:reply, false, state}
+    {:reply, loaded?, state}
   end
 
   def handle_call(:destroy, _, {ref, %State{} = state}) do

--- a/apps/remote_control/lib/lexical/remote_control/search/store.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store.ex
@@ -215,6 +215,12 @@ defmodule Lexical.RemoteControl.Search.Store do
     {:reply, loaded?, {ref, state}}
   end
 
+  def handle_call(:loaded?, _, %State{} = state) do
+    # We're not enabled yet, but we can still reply to the query
+    # if we're loaded, because if we're not enabled, we're not loaded.
+    {:reply, false, state}
+  end
+
   def handle_call(:destroy, _, {ref, %State{} = state}) do
     new_state = State.destroy(state)
     {:reply, :ok, {ref, new_state}}

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
@@ -20,11 +20,6 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
   end
 
   @impl Backend
-  def sync(%Project{}) do
-    GenServer.call(genserver_name(), :sync)
-  end
-
-  @impl Backend
   def insert(entries) do
     GenServer.call(genserver_name(), {:insert, [entries]}, :infinity)
   end
@@ -43,7 +38,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
         GenServer.call(name, {:destroy, []})
 
       _ ->
-        State.destroy(project)
+        :ok
     end
 
     :ok
@@ -123,11 +118,6 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
     end
   end
 
-  def handle_call(:sync, _from, %State{} = state) do
-    state = State.sync(state)
-    {:reply, :ok, state}
-  end
-
   def handle_call({function_name, arguments}, _from, %State{} = state) do
     arguments = [state | arguments]
     reply = apply(State, function_name, arguments)
@@ -150,6 +140,12 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
     # :global.random_notify_name. We've been selected to be the leader!
     new_state = become_leader(state.project)
     {:noreply, new_state}
+  end
+
+  @impl GenServer
+  def terminate(_reason, %State{} = state) do
+    State.terminate(state)
+    state
   end
 
   # Private

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
@@ -33,15 +33,15 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
   def destroy(%Project{} = project) do
     name = genserver_name(project)
 
-    case :global.whereis_name(name) do
-      pid when is_pid(pid) ->
-        GenServer.call(name, {:destroy, []})
-
-      _ ->
-        :ok
+    if pid = GenServer.whereis(name) do
+      GenServer.call(pid, {:destroy, []})
     end
 
     :ok
+  end
+
+  def destroy_all(%Project{} = project) do
+    State.destroy_all(project)
   end
 
   @impl Backend

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
@@ -10,8 +10,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
   @behaviour Backend
 
   @impl Backend
-  def new(%Project{} = project) do
-    start_link(project)
+  def new(%Project{}) do
+    {:ok, Process.whereis(__MODULE__)}
   end
 
   @impl Backend
@@ -85,7 +85,19 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
   end
 
   def start_link(%Project{} = project) do
-    GenServer.start_link(__MODULE__, [project])
+    GenServer.start_link(__MODULE__, [project], name: __MODULE__)
+  end
+
+  def start_link do
+    start_link(RemoteControl.get_project())
+  end
+
+  def child_spec([%Project{}] = init_args) do
+    %{id: __MODULE__, start: {__MODULE__, :start_link, init_args}}
+  end
+
+  def child_spec(_) do
+    child_spec([RemoteControl.get_project()])
   end
 
   @impl GenServer

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
@@ -16,7 +16,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
     Schemas.V1,
     Schemas.V2
   ]
-  use Wal
+
+  import Wal, only: :macros
   import Entry, only: :macros
 
   import Schemas.V2,
@@ -147,10 +148,9 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
 
     {:ok, _, result} =
       with_wal state.wal_state do
-        with true <- :ets.delete_all_objects(state.table_name),
-             true <- :ets.insert(state.table_name, rows) do
-          :ok
-        end
+        true = :ets.delete_all_objects(state.table_name)
+        true = :ets.insert(state.table_name, rows)
+        :ok
       end
 
     # When we replace everything, the old checkpoint is invalidated

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
@@ -52,9 +52,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
   end
 
   def drop(%__MODULE__{leader?: true} = state) do
-    with_wal state.wal_state do
-      :ets.delete_all_objects(state.table_name)
-    end
+    Wal.truncate(state.wal_state)
+    :ets.delete_all_objects(state.table_name)
   end
 
   def insert(%__MODULE__{leader?: true} = state, entries) do

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
@@ -9,13 +9,14 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
   alias Lexical.RemoteControl.Search.Indexer.Entry
   alias Lexical.RemoteControl.Search.Store.Backends.Ets.Schema
   alias Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas
+  alias Lexical.RemoteControl.Search.Store.Backends.Ets.Wal
 
   @schema_order [
     Schemas.LegacyV0,
     Schemas.V1,
     Schemas.V2
   ]
-
+  use Wal
   import Entry, only: :macros
 
   import Schemas.V2,
@@ -29,7 +30,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
       structure: 1
     ]
 
-  defstruct [:project, :table_name, :leader?, :leader_pid]
+  defstruct [:project, :table_name, :leader?, :leader_pid, :wal_state]
 
   def new_leader(%Project{} = project) do
     %__MODULE__{project: project, leader?: true, leader_pid: self()}
@@ -40,9 +41,9 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
   end
 
   def prepare(%__MODULE__{leader?: true} = state) do
-    {:ok, table_name, result} = Schema.load(state.project, @schema_order)
-    :ets.info(table_name)
-    {{:ok, result}, %__MODULE__{state | table_name: table_name}}
+    {:ok, wal, table_name, result} = Schema.load(state.project, @schema_order)
+
+    {{:ok, result}, %__MODULE__{state | table_name: table_name, wal_state: wal}}
   end
 
   def prepare(%__MODULE__{leader?: false}) do
@@ -50,12 +51,18 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
   end
 
   def drop(%__MODULE__{leader?: true} = state) do
-    :ets.delete_all_objects(state.table_name)
+    with_wal state.wal_state do
+      :ets.delete_all_objects(state.table_name)
+    end
   end
 
   def insert(%__MODULE__{leader?: true} = state, entries) do
     rows = Schema.entries_to_rows(entries, current_schema())
-    true = :ets.insert(state.table_name, rows)
+
+    with_wal state.wal_state do
+      true = :ets.insert(state.table_name, rows)
+    end
+
     :ok
   end
 
@@ -138,10 +145,18 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
   def replace_all(%__MODULE__{leader?: true} = state, entries) do
     rows = Schema.entries_to_rows(entries, current_schema())
 
-    with true <- :ets.delete_all_objects(state.table_name),
-         true <- :ets.insert(state.table_name, rows) do
-      :ok
-    end
+    {:ok, _, result} =
+      with_wal state.wal_state do
+        with true <- :ets.delete_all_objects(state.table_name),
+             true <- :ets.insert(state.table_name, rows) do
+          :ok
+        end
+      end
+
+    # When we replace everything, the old checkpoint is invalidated
+    # so it makes sense to force a new one.
+    Wal.checkpoint(state.wal_state)
+    result
   end
 
   def delete_by_path(%__MODULE__{leader?: true} = state, path) do
@@ -150,36 +165,27 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
       |> :ets.match({query_by_path(path: path), :"$0"})
       |> List.flatten()
 
-    :ets.match_delete(state.table_name, {query_by_subject(path: path), :_})
-    :ets.match_delete(state.table_name, {query_by_path(path: path), :_})
-    :ets.match_delete(state.table_name, {query_structure(path: path), :_})
+    with_wal state.wal_state do
+      :ets.match_delete(state.table_name, {query_by_subject(path: path), :_})
+      :ets.match_delete(state.table_name, {query_by_path(path: path), :_})
+      :ets.match_delete(state.table_name, {query_structure(path: path), :_})
+    end
 
-    Enum.each(ids_to_delete, &:ets.delete(state.table_name, &1))
+    Enum.each(ids_to_delete, fn id ->
+      with_wal state.wal_state do
+        :ets.delete(state.table_name, id)
+      end
+    end)
+
     {:ok, ids_to_delete}
   end
 
   def destroy(%__MODULE__{leader?: true} = state) do
-    destroy(state.project)
+    Wal.destroy(state.wal_state)
   end
 
-  def destroy(%Project{} = project) do
-    project
-    |> Schema.index_root()
-    |> File.rm_rf()
-  end
-
-  def sync(%__MODULE__{leader?: true} = state) do
-    file_path_charlist =
-      state.project
-      |> Schema.index_file_path(current_schema())
-      |> String.to_charlist()
-
-    :ets.tab2file(state.table_name, file_path_charlist)
-    state
-  end
-
-  def sync(%__MODULE__{leader?: false} = state) do
-    state
+  def terminate(%__MODULE__{} = state) do
+    Wal.close(state.wal_state)
   end
 
   defp child_path(structure, child_id) do

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
@@ -180,12 +180,24 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
     {:ok, ids_to_delete}
   end
 
-  def destroy(%__MODULE__{leader?: true} = state) do
+  def destroy_all(%Project{} = project) do
+    Wal.destroy_all(project)
+  end
+
+  def destroy(%__MODULE__{leader?: true, wal_state: %Wal{}} = state) do
     Wal.destroy(state.wal_state)
   end
 
-  def terminate(%__MODULE__{} = state) do
+  def destroy(%__MODULE__{leader?: true}) do
+    :ok
+  end
+
+  def terminate(%__MODULE__{wal_state: %Wal{}} = state) do
     Wal.close(state.wal_state)
+  end
+
+  def terminate(%__MODULE__{}) do
+    :ok
   end
 
   defp child_path(structure, child_id) do

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/wal.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/wal.ex
@@ -1,0 +1,424 @@
+defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Wal do
+  @moduledoc """
+  A (hopefully) simple write-ahead log
+
+
+  """
+  alias Lexical.Identifier
+  alias Lexical.Project
+  alias Lexical.VM.Versions
+
+  import Record
+
+  defrecord :operation, id: nil, function: nil, args: nil
+
+  defstruct [
+    :checkpoint_version,
+    :ets_table,
+    :max_wal_operations,
+    :project,
+    :schema_version,
+    :update_log,
+    :update_log_name
+  ]
+
+  defmacro __using__(_) do
+    quote do
+      alias Lexical.Identifier
+      import unquote(__MODULE__), only: [with_wal: 2, operation: 1]
+    end
+  end
+
+  @write_functions [
+    :delete,
+    :delete_all_objects,
+    :delete_object,
+    :insert,
+    :insert_new,
+    :match_delete,
+    :select_delete,
+    :select_replace,
+    :update_counter,
+    :update_element
+  ]
+
+  @no_checkpoint_id 0
+  @chunk_size 10_000
+  @checkpoint_int_length 20
+  @default_max_operations 50_000
+
+  defmacro with_wal(wal_state, do: block) do
+    {_, write_calls} =
+      Macro.prewalk(block, [], fn ast, acc ->
+        {ast, collect_ets_writes(ast, acc)}
+      end)
+
+    operations =
+      write_calls
+      |> Enum.reverse()
+      |> Enum.map(&to_operation/1)
+
+    quote do
+      case unquote(__MODULE__).append(unquote(wal_state), unquote(operations)) do
+        {:ok, wal_state} ->
+          result = unquote(block)
+          {:ok, wal_state, result}
+
+        error ->
+          error
+      end
+    end
+  end
+
+  def new(%Project{} = project, schema_version, ets_table, options \\ []) do
+    max_wal_operations = Keyword.get(options, :max_wal_operations, @default_max_operations)
+
+    %__MODULE__{
+      ets_table: ets_table,
+      max_wal_operations: max_wal_operations,
+      project: project,
+      schema_version: to_string(schema_version)
+    }
+  end
+
+  def exists?(%__MODULE__{} = wal) do
+    exists?(wal.project, wal.schema_version)
+  end
+
+  def exists?(%Project{} = project, schema_vesion) do
+    case File.ls(wal_directory(project, schema_vesion)) do
+      {:ok, [_]} -> true
+      {:ok, [_ | _]} -> true
+      _ -> false
+    end
+  end
+
+  def load(%__MODULE__{} = wal) do
+    ensure_wal_directory_exists(wal)
+
+    with {:ok, checkpoint_id} <- load_latest_checkpoint(wal),
+         {:ok, new_wal} <- open_update_wal(wal, checkpoint_id),
+         :ok <- apply_updates(new_wal) do
+      {:ok, new_wal}
+    end
+  end
+
+  def append(%__MODULE__{} = wal, operations) do
+    case :disk_log.log_terms(wal.update_log, operations) do
+      :ok ->
+        maybe_checkpoint(wal)
+
+      error ->
+        error
+    end
+  end
+
+  def close(%__MODULE__{} = wal) do
+    case wal.update_log do
+      nil ->
+        :ok
+
+      log ->
+        :disk_log.sync(log)
+        :disk_log.close(log)
+    end
+  end
+
+  def destroy(%__MODULE__{} = wal) do
+    close(wal)
+    destroy(wal.project, wal.schema_version)
+  end
+
+  def destroy(%Project{} = project, schema_version) do
+    project
+    |> wal_directory(schema_version)
+    |> File.rm_rf!()
+  end
+
+  def checkpoint(%__MODULE__{} = wal) do
+    case :ets.info(wal.ets_table) do
+      :undefined ->
+        {:error, :no_table}
+
+      _ ->
+        do_checkpoint(wal)
+    end
+  end
+
+  def size(%__MODULE__{update_log: nil}) do
+    {:error, :not_loaded}
+  end
+
+  def size(%__MODULE__{update_log: update_log}) do
+    with info when is_list(info) <- :disk_log.info(update_log),
+         {:ok, size} <- Keyword.fetch(info, :items) do
+      {:ok, size}
+    else
+      _ ->
+        {:error, :not_loaded}
+    end
+  end
+
+  def root_path(%Project{} = project) do
+    Project.workspace_path(project, ["indexes", "ets"])
+  end
+
+  # Private
+
+  defp collect_ets_writes({{:., _, [:ets, function_name]}, _, args}, acc)
+       when function_name in @write_functions do
+    [{:ets, function_name, args} | acc]
+  end
+
+  defp collect_ets_writes(_, acc), do: acc
+
+  defp to_operation({:ets, call_name, args}) do
+    quote do
+      operation(id: Identifier.next_global!(), function: unquote(call_name), args: unquote(args))
+    end
+  end
+
+  defp ensure_wal_directory_exists(%__MODULE__{} = wal) do
+    wal |> wal_directory() |> File.mkdir_p!()
+  end
+
+  defp wal_directory(%__MODULE__{} = wal) do
+    wal_directory(wal.project, wal.schema_version)
+  end
+
+  defp wal_directory(%Project{} = project, schema_version) do
+    versions = Versions.current()
+    Path.join([root_path(project), versions.erlang, versions.elixir, to_string(schema_version)])
+  end
+
+  defp open_update_wal(%__MODULE__{} = wal, checkpoint_version) do
+    wal_path = update_wal_path(wal)
+    wal_name = update_wal_name(wal)
+
+    case :disk_log.open(name: wal_name, file: String.to_charlist(wal_path)) do
+      {:ok, log} ->
+        new_wal = %__MODULE__{
+          wal
+          | update_log: log,
+            update_log_name: wal_name,
+            checkpoint_version: checkpoint_version
+        }
+
+        {:ok, new_wal}
+
+      {:repaired, log, {:recovered, _}, _bad} ->
+        new_wal = %__MODULE__{
+          wal
+          | update_log: log,
+            update_log_name: wal_name,
+            checkpoint_version: checkpoint_version
+        }
+
+        {:ok, new_wal}
+
+      error ->
+        error
+    end
+  end
+
+  defp update_wal_name(%__MODULE__{} = wal) do
+    :"updates_for_#{Project.name(wal.project)}_v#{wal.schema_version}"
+  end
+
+  # Updates
+  defp apply_updates(%__MODULE__{} = wal) do
+    stream_updates(wal, wal.update_log, :start)
+  end
+
+  defp stream_updates(%__MODULE__{} = wal, log, continuation) do
+    case :disk_log.chunk(log, continuation, @chunk_size) do
+      {continuation, items} when is_list(items) ->
+        apply_relevant_items(wal, items)
+        stream_updates(wal, log, continuation)
+
+      {continuation, items, _bad_bytes} ->
+        apply_relevant_items(wal, items)
+        stream_updates(wal, log, continuation)
+
+      :eof ->
+        :ok
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp apply_relevant_items(%__MODULE__{} = wal, items) do
+    checkpoint_version = wal.checkpoint_version
+
+    items
+    |> Stream.filter(fn operation(id: id) -> id >= checkpoint_version end)
+    |> Enum.each(fn operation(function: function, args: args) ->
+      apply(:ets, function, args)
+    end)
+  end
+
+  defp get_wal_operations(%__MODULE__{} = wal) do
+    stats = :disk_log.info(wal.update_log)
+    Keyword.get(stats, :items, 0)
+  end
+
+  # Checkpoints
+  defp needs_checkpoint?(%__MODULE__{} = wal) do
+    get_wal_operations(wal) >= wal.max_wal_operations
+  end
+
+  defp maybe_checkpoint(%__MODULE__{} = wal) do
+    with true <- needs_checkpoint?(wal),
+         {:ok, new_wal} <- checkpoint(wal) do
+      {:ok, new_wal}
+    else
+      _ ->
+        {:ok, wal}
+    end
+  end
+
+  defp do_checkpoint(%__MODULE__{} = wal) do
+    checkpoint_version = Identifier.next_global!()
+    checkpoint_file_name = checkpoint_file_name(checkpoint_version)
+
+    log_path = wal |> wal_directory() |> Path.join(checkpoint_file_name)
+    log_name = checkpoint_log_name(wal.project)
+
+    with {:ok, log} <- :disk_log.open(name: log_name, file: String.to_charlist(log_path)),
+         :ok <- checkpoint_ets_table(wal, log),
+         :ok <- :disk_log.close(log),
+         :ok <- :disk_log.truncate(wal.update_log) do
+      new_wal = %__MODULE__{wal | checkpoint_version: checkpoint_version}
+      delete_old_checkpoints(new_wal)
+      {:ok, new_wal}
+    else
+      error ->
+        # Checkpoint loading failed. Give up and start over
+        delete_old_checkpoints(wal)
+        error
+    end
+  end
+
+  defp checkpoint_ets_table(%__MODULE__{} = wal, log) do
+    log_chunks = fn
+      item, {@chunk_size, items} ->
+        :disk_log.log_terms(log, Enum.reverse(items))
+        {1, [item]}
+
+      item, {count, items} ->
+        {count + 1, [item | items]}
+    end
+
+    {_count, items} = :ets.foldl(log_chunks, {0, []}, wal.ets_table)
+    :disk_log.log_terms(log, items)
+  end
+
+  defp load_latest_checkpoint(%__MODULE__{} = wal) do
+    with {:ok, checkpoint_file} <- find_latest_checkpoint(wal),
+         {:ok, checkpoint_version} <- extract_checkpoint_version(checkpoint_file),
+         :ok <- load_checkpoint(wal, checkpoint_file) do
+      {:ok, checkpoint_version}
+    else
+      _ ->
+        # There's no checkpoint, or our checkpoint is invalid. Start from scratch.
+        {:ok, @no_checkpoint_id}
+    end
+  end
+
+  defp load_checkpoint(%__MODULE__{} = wal, checkpoint_file) do
+    log_name = checkpoint_log_name(wal.project)
+
+    case :disk_log.open(name: log_name, file: String.to_charlist(checkpoint_file)) do
+      {:ok, log} ->
+        stream_checkpoint(wal, log, :start)
+
+      {:repaired, log, _recovered, _bad_bytes} ->
+        stream_checkpoint(wal, log, :start)
+
+      error ->
+        error
+    end
+  end
+
+  defp delete_old_checkpoints(%__MODULE__{} = wal) do
+    current_checkpoint_file_name = checkpoint_file_name(wal.checkpoint_version)
+
+    [wal_directory(wal), "*.checkpoint"]
+    |> Path.join()
+    |> Path.wildcard()
+    |> Enum.each(fn checkpoint ->
+      if Path.basename(checkpoint) != current_checkpoint_file_name do
+        File.rm(checkpoint)
+      end
+    end)
+  end
+
+  defp checkpoint_file_name(checkpoint_id) when is_integer(checkpoint_id) do
+    checkpoint_id
+    |> Integer.to_string(10)
+    |> checkpoint_file_name()
+  end
+
+  defp checkpoint_file_name(checkpoint_id) when is_binary(checkpoint_id) do
+    String.pad_leading(checkpoint_id, @checkpoint_int_length, "0") <> ".checkpoint"
+  end
+
+  defp checkpoint_log_name(%Project{} = project) do
+    :"checkpoint_log_#{Project.name(project)}"
+  end
+
+  defp stream_checkpoint(%__MODULE__{} = wal, log, continuation) do
+    case :disk_log.chunk(log, continuation, @chunk_size) do
+      {continuation, items} when is_list(items) ->
+        :ets.insert(wal.ets_table, items)
+        stream_checkpoint(wal, log, continuation)
+
+      {continuation, items, _bad_bytes} ->
+        :ets.insert(wal.ets_table, items)
+        stream_checkpoint(wal, log, continuation)
+
+      :eof ->
+        :disk_log.close(log)
+        :ok
+
+      {:error, _} = error ->
+        :disk_log.close(log)
+        error
+    end
+  end
+
+  defp find_latest_checkpoint(%__MODULE__{} = wal) do
+    checkpoints =
+      [wal_directory(wal), "*.checkpoint"]
+      |> Path.join()
+      |> Path.wildcard()
+      |> Enum.sort(:desc)
+
+    case checkpoints do
+      [checkpoint | _] ->
+        {:ok, checkpoint}
+
+      _ ->
+        {:error, :no_checkpoint}
+    end
+  end
+
+  defp extract_checkpoint_version(checkpoint_path) do
+    file_name = Path.basename(checkpoint_path)
+
+    with [id_string, _] <- String.split(file_name, "."),
+         {id, ""} <- Integer.parse(id_string, 10) do
+      {:ok, id}
+    else
+      _ ->
+        :error
+    end
+  end
+
+  defp update_wal_path(%__MODULE__{} = wal) do
+    wal
+    |> wal_directory()
+    |> Path.join("updates.wal")
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/wal.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/wal.ex
@@ -124,6 +124,12 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Wal do
     |> File.rm_rf!()
   end
 
+  def destroy_all(%Project{} = project) do
+    project
+    |> root_path()
+    |> File.rm_rf!()
+  end
+
   def checkpoint(%__MODULE__{} = wal) do
     case :ets.info(wal.ets_table) do
       :undefined ->

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/wal.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/wal.ex
@@ -113,6 +113,10 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Wal do
     end
   end
 
+  def truncate(%__MODULE__{} = wal) do
+    :disk_log.truncate(wal.update_log)
+  end
+
   def destroy(%__MODULE__{} = wal) do
     close(wal)
     destroy(wal.project, wal.schema_version)

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/references_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/references_test.exs
@@ -22,6 +22,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.ReferencesTest do
 
     start_supervised!(Document.Store)
     start_supervised!(RemoteControl.Dispatch)
+    start_supervised!(Backends.Ets)
 
     start_supervised!(
       {Search.Store, [project, fn _ -> {:ok, []} end, fn _, _ -> {:ok, [], []} end, Backends.Ets]}

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/references_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/references_test.exs
@@ -21,16 +21,11 @@ defmodule Lexical.RemoteControl.CodeIntelligence.ReferencesTest do
 
     start_supervised!(
       {Search.Store,
-       [
-         project,
-         fn _ -> {:ok, []} end,
-         fn _, _ -> {:ok, [], []} end,
-         Search.Store.Backends.Ets
-       ]}
+       [project, fn _ -> {:ok, []} end, fn _, _ -> {:ok, [], []} end, Search.Store.Backends.Ets]}
     )
 
     Search.Store.enable()
-    assert_eventually Search.Store.loaded?()
+    assert_eventually Search.Store.loaded?(), 1500
     {:ok, project: project}
   end
 

--- a/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
@@ -23,7 +23,7 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
     start_supervised!(RemoteControl.Dispatch)
     start_supervised!(Commands.Reindex)
     start_supervised!({Search.Store, [project, create_index, update_index]})
-    start_supervised!(Lexical.Server.Application.document_store_child_spec())
+    start_supervised!({Document.Store, derive: [analysis: &Lexical.Ast.analyze/1]})
 
     Search.Store.enable()
     assert_eventually(Search.Store.loaded?(), 1500)

--- a/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
@@ -22,6 +22,7 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
 
     start_supervised!(RemoteControl.Dispatch)
     start_supervised!(Commands.Reindex)
+    start_supervised!(Search.Store.Backends.Ets)
     start_supervised!({Search.Store, [project, create_index, update_index]})
     start_supervised!({Document.Store, derive: [analysis: &Lexical.Ast.analyze/1]})
 

--- a/apps/remote_control/test/lexical/remote_control/search/store/backends/ets/schema_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store/backends/ets/schema_test.exs
@@ -4,9 +4,9 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.SchemaTest do
   alias Lexical.RemoteControl.Search.Store.Backends.Ets.Wal
 
   import Lexical.Test.Fixtures
+  import Wal, only: :macros
 
   use ExUnit.Case
-  use Wal
 
   setup do
     project = project()
@@ -168,8 +168,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.SchemaTest do
   def write_entries(project, schema_module, entries) do
     table_name = schema_module.table_name()
     :ets.new(table_name, schema_module.table_options())
-    wal = Wal.new(project, schema_module.version(), table_name)
-    {:ok, wal} = Wal.load(wal)
+    {:ok, wal} = Wal.load(project, schema_module.version(), table_name)
 
     with_wal wal do
       :ets.insert(table_name, entries)

--- a/apps/remote_control/test/lexical/remote_control/search/store/backends/ets/wal_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store/backends/ets/wal_test.exs
@@ -5,24 +5,26 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.WalTest do
 
   use ExUnit.Case
   use Patch
-  use Wal
+
+  import Wal, only: :macros
 
   @table_name :wal_test
+  @schema_version 1
+
   setup do
     project = project()
     new_table()
-    wal_state = Wal.new(project, 1, @table_name)
 
     on_exit(fn ->
-      Wal.destroy(wal_state)
+      Wal.destroy(project, @schema_version)
     end)
 
-    {:ok, project: project, wal: wal_state}
+    {:ok, project: project}
   end
 
   describe "with_wal/1" do
-    test "returns the wal state and the ets operation", %{wal: wal_state} do
-      {:ok, wal_state} = Wal.load(wal_state)
+    test "returns the wal state and the ets operation", %{project: project} do
+      {:ok, wal_state} = Wal.load(project, @schema_version, @table_name)
 
       {:ok, new_state, result} =
         with_wal wal_state do
@@ -33,21 +35,25 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.WalTest do
       assert result == :worked
       assert %Wal{} = new_state
     end
+  end
 
-    test "returns an error if the wal isn't open", %{wal: wal_state} do
-      result =
+  describe "non-write operations are ignored" do
+    setup [:with_a_loaded_wal]
+
+    test "ignores lookups", %{wal: wal_state} do
+      {:ok, new_wal, _} =
         with_wal wal_state do
-          :ets.insert(@table_name, {:first, 1})
+          :ets.lookup(@table_name, :first)
         end
 
-      assert result == {:error, :no_such_log}
+      assert {:ok, 0} = Wal.size(new_wal)
     end
   end
 
   describe "operations" do
     setup [:with_a_loaded_wal]
 
-    test "the wal captures deletes operations", %{wal: wal_state} do
+    test "the wal captures deletes operations", %{wal: wal_state, project: project} do
       with_wal wal_state do
         :ets.insert(@table_name, [{:first, {1, 1}}, {:second, {2, 2}}])
         :ets.delete(@table_name, :second)
@@ -55,60 +61,60 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.WalTest do
 
       entries = dump_and_close_table()
 
-      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+      assert {:ok, _new_wal, ^entries} = load_from_project(project)
     end
 
-    test "the wal captures delete_all_items operations", %{wal: wal_state} do
+    test "the wal captures delete_all_items operations", %{wal: wal_state, project: project} do
       with_wal wal_state do
         :ets.insert(@table_name, [{:first, 1}, {:second, 2}])
         :ets.delete_all_objects(@table_name)
       end
 
       dump_and_close_table()
-      assert {:ok, _new_wal, []} = load_from_wal(wal_state)
+      assert {:ok, _new_wal, []} = load_from_project(project)
     end
 
-    test "the wal captures delete_object operations calls", %{wal: wal_state} do
+    test "the wal captures delete_object operations calls", %{wal: wal_state, project: project} do
       with_wal wal_state do
         :ets.insert(@table_name, [{:first, 1}, {:second, 2}])
         :ets.delete_object(@table_name, {:first, 1})
       end
 
       entries = dump_and_close_table()
-      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+      assert {:ok, _new_wal, ^entries} = load_from_project(project)
     end
 
-    test "the wal captures inserts operations", %{wal: wal_state} do
+    test "the wal captures inserts operations", %{wal: wal_state, project: project} do
       with_wal wal_state do
         :ets.insert(@table_name, [{:first, {3, 6}}])
       end
 
       entries = dump_and_close_table()
 
-      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+      assert {:ok, _new_wal, ^entries} = load_from_project(project)
     end
 
-    test "the wal captures insert_new operations", %{wal: wal_state} do
+    test "the wal captures insert_new operations", %{wal: wal_state, project: project} do
       with_wal wal_state do
         :ets.insert_new(@table_name, [{:first, 1}, {:second, 2}])
       end
 
       entries = dump_and_close_table()
 
-      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+      assert {:ok, _new_wal, ^entries} = load_from_project(project)
     end
 
-    test "the wal captures match_delete operations", %{wal: wal_state} do
+    test "the wal captures match_delete operations", %{wal: wal_state, project: project} do
       with_wal wal_state do
         :ets.insert(@table_name, [{:first, 1}, {:second, 2}, {:third, 1}])
         :ets.match_delete(@table_name, {:_, 1})
       end
 
       entries = dump_and_close_table()
-      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+      assert {:ok, _new_wal, ^entries} = load_from_project(project)
     end
 
-    test "the wal captures select_delete operations", %{wal: wal_state} do
+    test "the wal captures select_delete operations", %{wal: wal_state, project: project} do
       with_wal wal_state do
         :ets.insert(@table_name, [{:first, 1}, {:second, 1}, {:third, 3}])
         :ets.select_delete(@table_name, [{{:_, 1}, [], [true]}])
@@ -116,37 +122,37 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.WalTest do
 
       entries = dump_and_close_table()
 
-      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+      assert {:ok, _new_wal, ^entries} = load_from_project(project)
     end
 
-    test "the wal captures select_replace operations", %{wal: wal_state} do
+    test "the wal captures select_replace operations", %{wal: wal_state, project: project} do
       with_wal wal_state do
         :ets.insert(@table_name, [{:first, 1}, {:second, 2}, {:third, 1}])
         :ets.select_replace(@table_name, [{{:third, :_}, [], [{{:third, 3}}]}])
       end
 
       entries = dump_and_close_table()
-      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+      assert {:ok, _new_wal, ^entries} = load_from_project(project)
     end
 
-    test "the wal captures update_counter operations", %{wal: wal_state} do
+    test "the wal captures update_counter operations", %{wal: wal_state, project: project} do
       with_wal wal_state do
         :ets.insert(@table_name, [{:first, 1}, {:second, 2}, {:third, 3}])
         :ets.update_counter(@table_name, :first, {2, 1})
       end
 
       entries = dump_and_close_table()
-      assert {:ok, _new_val, ^entries} = load_from_wal(wal_state)
+      assert {:ok, _new_val, ^entries} = load_from_project(project)
     end
 
-    test "the wal captures update_element operations", %{wal: wal_state} do
+    test "the wal captures update_element operations", %{wal: wal_state, project: project} do
       with_wal wal_state do
         :ets.insert(@table_name, [{:first, 1}, {:second, 2}, {:third, 3}])
         :ets.update_element(@table_name, :first, {2, :oops})
       end
 
       entries = dump_and_close_table()
-      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+      assert {:ok, _new_wal, ^entries} = load_from_project(project)
     end
   end
 
@@ -154,11 +160,11 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.WalTest do
     setup [:with_a_loaded_wal]
 
     test "fails if the ets table doesn't exist" do
-      wal_state = Wal.new(project(), 1, :does_not_exist)
+      {:ok, wal_state} = Wal.load(project(), @schema_version, :does_not_exist)
       assert {:error, :no_table} = Wal.checkpoint(wal_state)
     end
 
-    test "gracefully handles an invalid checkpoint", %{wal: wal_state} do
+    test "gracefully handles an invalid checkpoint", %{wal: wal_state, project: project} do
       :ok = Patch.expose(Wal, find_latest_checkpoint: 1)
 
       with_wal wal_state do
@@ -171,16 +177,13 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.WalTest do
       # write junk over it
       File.write!(checkpoint_path, "this is not data")
 
-      {:ok, new_wal} =
-        wal_state.project
-        |> Wal.new(1, @table_name)
-        |> Wal.load()
+      {:ok, new_wal} = Wal.load(project, @schema_version, @table_name)
 
       assert Wal.size(new_wal) == {:ok, 0}
       assert new_wal.checkpoint_version == 0
     end
 
-    test "can load a checkpoint", %{wal: wal_state} do
+    test "can load a checkpoint", %{wal: wal_state, project: project} do
       with_wal wal_state do
         :ets.insert(@table_name, [{:first, 1}, {:second, 2}])
       end
@@ -199,11 +202,11 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.WalTest do
       assert {:ok, 0} = Wal.size(new_wal)
 
       items = dump_and_close_table()
-      {:ok, loaded_wal, ^items} = load_from_wal(new_wal)
+      {:ok, loaded_wal, ^items} = load_from_project(project)
       assert loaded_wal.checkpoint_version == checkpoint_version
     end
 
-    test "can handle lots of data", %{wal: wal_state} do
+    test "can handle lots of data", %{wal: wal_state, project: project} do
       stream =
         1..500_000
         |> Stream.cycle()
@@ -219,19 +222,13 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.WalTest do
       :ok = Wal.close(new_state)
       data = dump_and_close_table()
 
-      assert {:ok, _wal_state, entries} =
-               new_state.project
-               |> Wal.new(1, @table_name)
-               |> load_from_wal()
+      assert {:ok, _wal_state, entries} = load_from_project(project)
 
       assert Enum.sort(entries) == Enum.sort(data)
     end
 
     test "checkpoints after a certain number of operations", %{project: project} do
-      {:ok, wal_state} =
-        project
-        |> Wal.new(1, @table_name, max_wal_operations: 5)
-        |> Wal.load()
+      {:ok, wal_state} = Wal.load(project, @schema_version, @table_name, max_wal_operations: 5)
 
       with_wal wal_state do
         :ets.insert(@table_name, {:first, 1})
@@ -250,8 +247,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.WalTest do
     end
   end
 
-  defp with_a_loaded_wal(%{wal: wal_state}) do
-    {:ok, wal_state} = Wal.load(wal_state)
+  defp with_a_loaded_wal(%{project: project}) do
+    {:ok, wal_state} = Wal.load(project, @schema_version, @table_name)
     {:ok, wal: wal_state}
   end
 
@@ -261,16 +258,16 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.WalTest do
     items
   end
 
-  defp load_from_wal(wal_state) do
+  defp load_from_project(project) do
     new_table()
-    {:ok, new_wal} = Wal.load(wal_state)
+    {:ok, new_wal} = Wal.load(project, @schema_version, @table_name)
     entries = :ets.tab2list(@table_name)
     {:ok, new_wal, entries}
   end
 
   defp new_table do
     if :ets.info(@table_name) == :undefined do
-      :ets.new(@table_name, [:named_table, :set])
+      :ets.new(@table_name, [:named_table, :ordered_set])
     end
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/search/store/backends/ets/wal_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store/backends/ets/wal_test.exs
@@ -1,0 +1,276 @@
+defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.WalTest do
+  alias Lexical.RemoteControl.Search.Store.Backends.Ets.Wal
+
+  import Lexical.Test.Fixtures
+
+  use ExUnit.Case
+  use Patch
+  use Wal
+
+  @table_name :wal_test
+  setup do
+    project = project()
+    new_table()
+    wal_state = Wal.new(project, 1, @table_name)
+
+    on_exit(fn ->
+      Wal.destroy(wal_state)
+    end)
+
+    {:ok, project: project, wal: wal_state}
+  end
+
+  describe "with_wal/1" do
+    test "returns the wal state and the ets operation", %{wal: wal_state} do
+      {:ok, wal_state} = Wal.load(wal_state)
+
+      {:ok, new_state, result} =
+        with_wal wal_state do
+          :ets.insert(@table_name, {:first, 1})
+          :worked
+        end
+
+      assert result == :worked
+      assert %Wal{} = new_state
+    end
+
+    test "returns an error if the wal isn't open", %{wal: wal_state} do
+      result =
+        with_wal wal_state do
+          :ets.insert(@table_name, {:first, 1})
+        end
+
+      assert result == {:error, :no_such_log}
+    end
+  end
+
+  describe "operations" do
+    setup [:with_a_loaded_wal]
+
+    test "the wal captures deletes operations", %{wal: wal_state} do
+      with_wal wal_state do
+        :ets.insert(@table_name, [{:first, {1, 1}}, {:second, {2, 2}}])
+        :ets.delete(@table_name, :second)
+      end
+
+      entries = dump_and_close_table()
+
+      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+    end
+
+    test "the wal captures delete_all_items operations", %{wal: wal_state} do
+      with_wal wal_state do
+        :ets.insert(@table_name, [{:first, 1}, {:second, 2}])
+        :ets.delete_all_objects(@table_name)
+      end
+
+      dump_and_close_table()
+      assert {:ok, _new_wal, []} = load_from_wal(wal_state)
+    end
+
+    test "the wal captures delete_object operations calls", %{wal: wal_state} do
+      with_wal wal_state do
+        :ets.insert(@table_name, [{:first, 1}, {:second, 2}])
+        :ets.delete_object(@table_name, {:first, 1})
+      end
+
+      entries = dump_and_close_table()
+      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+    end
+
+    test "the wal captures inserts operations", %{wal: wal_state} do
+      with_wal wal_state do
+        :ets.insert(@table_name, [{:first, {3, 6}}])
+      end
+
+      entries = dump_and_close_table()
+
+      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+    end
+
+    test "the wal captures insert_new operations", %{wal: wal_state} do
+      with_wal wal_state do
+        :ets.insert_new(@table_name, [{:first, 1}, {:second, 2}])
+      end
+
+      entries = dump_and_close_table()
+
+      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+    end
+
+    test "the wal captures match_delete operations", %{wal: wal_state} do
+      with_wal wal_state do
+        :ets.insert(@table_name, [{:first, 1}, {:second, 2}, {:third, 1}])
+        :ets.match_delete(@table_name, {:_, 1})
+      end
+
+      entries = dump_and_close_table()
+      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+    end
+
+    test "the wal captures select_delete operations", %{wal: wal_state} do
+      with_wal wal_state do
+        :ets.insert(@table_name, [{:first, 1}, {:second, 1}, {:third, 3}])
+        :ets.select_delete(@table_name, [{{:_, 1}, [], [true]}])
+      end
+
+      entries = dump_and_close_table()
+
+      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+    end
+
+    test "the wal captures select_replace operations", %{wal: wal_state} do
+      with_wal wal_state do
+        :ets.insert(@table_name, [{:first, 1}, {:second, 2}, {:third, 1}])
+        :ets.select_replace(@table_name, [{{:third, :_}, [], [{{:third, 3}}]}])
+      end
+
+      entries = dump_and_close_table()
+      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+    end
+
+    test "the wal captures update_counter operations", %{wal: wal_state} do
+      with_wal wal_state do
+        :ets.insert(@table_name, [{:first, 1}, {:second, 2}, {:third, 3}])
+        :ets.update_counter(@table_name, :first, {2, 1})
+      end
+
+      entries = dump_and_close_table()
+      assert {:ok, _new_val, ^entries} = load_from_wal(wal_state)
+    end
+
+    test "the wal captures update_element operations", %{wal: wal_state} do
+      with_wal wal_state do
+        :ets.insert(@table_name, [{:first, 1}, {:second, 2}, {:third, 3}])
+        :ets.update_element(@table_name, :first, {2, :oops})
+      end
+
+      entries = dump_and_close_table()
+      assert {:ok, _new_wal, ^entries} = load_from_wal(wal_state)
+    end
+  end
+
+  describe "checkpoints" do
+    setup [:with_a_loaded_wal]
+
+    test "fails if the ets table doesn't exist" do
+      wal_state = Wal.new(project(), 1, :does_not_exist)
+      assert {:error, :no_table} = Wal.checkpoint(wal_state)
+    end
+
+    test "gracefully handles an invalid checkpoint", %{wal: wal_state} do
+      :ok = Patch.expose(Wal, find_latest_checkpoint: 1)
+
+      with_wal wal_state do
+        :ets.insert(@table_name, [{:first, 1}])
+      end
+
+      assert {:ok, new_wal} = Wal.checkpoint(wal_state)
+      {:ok, checkpoint_path} = private(Wal.find_latest_checkpoint(new_wal))
+      Wal.close(new_wal)
+      # write junk over it
+      File.write!(checkpoint_path, "this is not data")
+
+      {:ok, new_wal} =
+        wal_state.project
+        |> Wal.new(1, @table_name)
+        |> Wal.load()
+
+      assert Wal.size(new_wal) == {:ok, 0}
+      assert new_wal.checkpoint_version == 0
+    end
+
+    test "can load a checkpoint", %{wal: wal_state} do
+      with_wal wal_state do
+        :ets.insert(@table_name, [{:first, 1}, {:second, 2}])
+      end
+
+      assert wal_state.checkpoint_version == 0
+
+      # prior, we had no checkpoint and one item in the update
+      # log. Checkpointing clears out the updates log and
+      # creates a checkpoint file, which can be restored
+      assert {:ok, 1} = Wal.size(wal_state)
+      assert {:ok, new_wal} = Wal.checkpoint(wal_state)
+
+      checkpoint_version = new_wal.checkpoint_version
+
+      assert checkpoint_version > 0
+      assert {:ok, 0} = Wal.size(new_wal)
+
+      items = dump_and_close_table()
+      {:ok, loaded_wal, ^items} = load_from_wal(new_wal)
+      assert loaded_wal.checkpoint_version == checkpoint_version
+    end
+
+    test "can handle lots of data", %{wal: wal_state} do
+      stream =
+        1..500_000
+        |> Stream.cycle()
+        |> Stream.map(fn count -> {{:item, count}, count} end)
+
+      for item <- Enum.take(stream, 20_000) do
+        with_wal wal_state do
+          :ets.insert(@table_name, item)
+        end
+      end
+
+      {:ok, new_state} = Wal.checkpoint(wal_state)
+      :ok = Wal.close(new_state)
+      data = dump_and_close_table()
+
+      assert {:ok, _wal_state, entries} =
+               new_state.project
+               |> Wal.new(1, @table_name)
+               |> load_from_wal()
+
+      assert Enum.sort(entries) == Enum.sort(data)
+    end
+
+    test "checkpoints after a certain number of operations", %{project: project} do
+      {:ok, wal_state} =
+        project
+        |> Wal.new(1, @table_name, max_wal_operations: 5)
+        |> Wal.load()
+
+      with_wal wal_state do
+        :ets.insert(@table_name, {:first, 1})
+        :ets.insert(@table_name, {:first, 2})
+        :ets.insert(@table_name, {:first, 3})
+        :ets.insert(@table_name, {:first, 4})
+      end
+
+      assert Wal.size(wal_state) == {:ok, 4}
+
+      with_wal wal_state do
+        :ets.insert(@table_name, {:first, 5})
+      end
+
+      assert Wal.size(wal_state) == {:ok, 0}
+    end
+  end
+
+  defp with_a_loaded_wal(%{wal: wal_state}) do
+    {:ok, wal_state} = Wal.load(wal_state)
+    {:ok, wal: wal_state}
+  end
+
+  defp dump_and_close_table do
+    items = :ets.tab2list(@table_name)
+    :ets.delete(@table_name)
+    items
+  end
+
+  defp load_from_wal(wal_state) do
+    new_table()
+    {:ok, new_wal} = Wal.load(wal_state)
+    entries = :ets.tab2list(@table_name)
+    {:ok, new_wal, entries}
+  end
+
+  defp new_table do
+    if :ets.info(@table_name) == :undefined do
+      :ets.new(@table_name, [:named_table, :set])
+    end
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/search/store/backends/ets_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store/backends/ets_test.exs
@@ -3,7 +3,6 @@ defmodule Lexical.RemoteControl.Search.Store.Backend.EtsTest do
   alias Lexical.RemoteControl.Dispatch
   alias Lexical.RemoteControl.Search.Store
   alias Lexical.RemoteControl.Search.Store.Backends
-  alias Lexical.RemoteControl.Search.Store.Backends.Ets.Wal
   alias Lexical.Test.Entry
   alias Lexical.Test.EventualAssertions
   alias Lexical.Test.Fixtures
@@ -33,8 +32,11 @@ defmodule Lexical.RemoteControl.Search.Store.Backend.EtsTest do
     {:ok, backend: backend, project: project}
   end
 
+  def delete_indexes(project, Backends.Ets) do
+    Backends.Ets.destroy_all(project)
+  end
+
   def delete_indexes(project, backend) do
-    project() |> Wal.root_path() |> File.rm_rf()
     backend.destroy(project)
   end
 

--- a/apps/remote_control/test/lexical/remote_control/search/store/backends/ets_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store/backends/ets_test.exs
@@ -7,7 +7,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backend.EtsTest do
   alias Lexical.Test.EventualAssertions
   alias Lexical.Test.Fixtures
 
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
   import EventualAssertions
   import Entry.Builder
@@ -258,7 +258,6 @@ defmodule Lexical.RemoteControl.Search.Store.Backend.EtsTest do
       |> Process.monitor()
 
     Store.stop()
-    refute_eventually ready?(project)
 
     receive do
       {:DOWN, ^ref, _, _, _} ->

--- a/apps/remote_control/test/lexical/remote_control/search/store/backends/ets_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store/backends/ets_test.exs
@@ -228,9 +228,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backend.EtsTest do
 
       assert :ok = Store.replace(entries)
 
-      Store.stop()
-
-      ensure_restarted(project)
+      restart_store(project)
 
       assert_eventually entries == Store.all()
     end
@@ -247,19 +245,10 @@ defmodule Lexical.RemoteControl.Search.Store.Backend.EtsTest do
         reference(id: 2, subject: Present, path: path)
       ])
 
-      Store.stop()
-
-      ensure_restarted(project)
+      restart_store(project)
 
       assert_eventually [%{id: 2}] = Store.all()
     end
-  end
-
-  defp ensure_restarted(%Project{} = project) do
-    refute_eventually ready?(project)
-    assert_eventually Store |> Process.whereis() |> is_pid()
-    Store.enable()
-    assert_eventually ready?(project), 1500
   end
 
   def restart_store(%Project{} = project) do
@@ -275,7 +264,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backend.EtsTest do
       {:DOWN, ^ref, _, _, _} ->
         assert_eventually Store |> Process.whereis() |> is_pid()
         Store.enable()
-        assert_eventually ready?(project)
+        assert_eventually ready?(project), 1500
     after
       1000 ->
         raise "Could not stop store"

--- a/apps/remote_control/test/lexical/remote_control/search/store/backends/ets_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store/backends/ets_test.exs
@@ -51,6 +51,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backend.EtsTest do
 
   defp start_supervised_store(%Project{} = project, create_fn, update_fn, backend) do
     start_supervised!(Dispatch)
+    start_supervised!(Backends.Ets)
     start_supervised!({Store, [project, create_fn, update_fn, backend]})
     assert_eventually alive?(), 1500
     Store.enable()

--- a/apps/remote_control/test/lexical/remote_control/search/store/backends/ets_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store/backends/ets_test.exs
@@ -259,19 +259,20 @@ defmodule Lexical.RemoteControl.Search.Store.Backend.EtsTest do
     refute_eventually ready?(project)
     assert_eventually Store |> Process.whereis() |> is_pid()
     Store.enable()
-    assert_eventually ready?(project)
+    assert_eventually ready?(project), 1500
   end
 
   def restart_store(%Project{} = project) do
-    Store
-    |> Process.whereis()
-    |> Process.monitor()
+    ref =
+      Store
+      |> Process.whereis()
+      |> Process.monitor()
 
     Store.stop()
     refute_eventually ready?(project)
 
     receive do
-      {:DOWN, _, _, _, _} ->
+      {:DOWN, ^ref, _, _, _} ->
         assert_eventually Store |> Process.whereis() |> is_pid()
         Store.enable()
         assert_eventually ready?(project)

--- a/apps/remote_control/test/lexical/remote_control/search/store/backends/ets_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store/backends/ets_test.exs
@@ -23,6 +23,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backend.EtsTest do
     # start with a clean slate.
 
     Lexical.RemoteControl.set_project(project)
+
     delete_indexes(project, backend)
 
     on_exit(fn ->
@@ -51,16 +52,13 @@ defmodule Lexical.RemoteControl.Search.Store.Backend.EtsTest do
   defp start_supervised_store(%Project{} = project, create_fn, update_fn, backend) do
     start_supervised!(Dispatch)
     start_supervised!({Store, [project, create_fn, update_fn, backend]})
+    assert_eventually alive?(), 1500
     Store.enable()
-    assert_eventually ready?(project)
+    assert_eventually ready?(project), 1500
   end
 
   def with_a_started_store(%{project: project, backend: backend}) do
     start_supervised_store(project, &default_create/1, &default_update/2, backend)
-
-    on_exit(fn ->
-      delete_indexes(project, backend)
-    end)
 
     :ok
   end

--- a/apps/remote_control/test/lexical/remote_control/search/store_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store_test.exs
@@ -316,8 +316,8 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
     entries
   end
 
-  defp after_each_test(_, _) do
-    :ok
+  defp after_each_test(backend, project) do
+    destroy_backend(backend, project)
   end
 
   defp destroy_backends(project) do
@@ -325,7 +325,11 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
   end
 
   defp destroy_backend(Ets, project) do
-    Ets.destroy(project)
+    Ets.destroy_all(project)
+  end
+
+  defp destroy_backend(_, _) do
+    :ok
   end
 
   defp default_create(_project) do
@@ -339,7 +343,11 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
   defp with_a_started_store(project, backend) do
     start_supervised!(Dispatch)
     start_supervised!({Store, [project, &default_create/1, &default_update/2, backend]})
+
+    assert_eventually alive?()
+
     Store.enable()
+
     assert_eventually ready?(), 1500
 
     on_exit(fn ->

--- a/apps/remote_control/test/lexical/remote_control/search/store_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store_test.exs
@@ -8,7 +8,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
   alias Lexical.Test.EventualAssertions
   alias Lexical.Test.Fixtures
 
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
   import Entry.Builder
   import EventualAssertions

--- a/apps/remote_control/test/lexical/remote_control/search/store_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store_test.exs
@@ -344,6 +344,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
     destroy_backend(backend, project)
 
     start_supervised!(Dispatch)
+    start_supervised!(backend)
     start_supervised!({Store, [project, &default_create/1, &default_update/2, backend]})
 
     assert_eventually alive?()

--- a/apps/remote_control/test/lexical/remote_control/search/store_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store_test.exs
@@ -341,6 +341,8 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
   end
 
   defp with_a_started_store(project, backend) do
+    destroy_backend(backend, project)
+
     start_supervised!(Dispatch)
     start_supervised!({Store, [project, &default_create/1, &default_update/2, backend]})
 


### PR DESCRIPTION
Our store was using `:ets.tab2file` to write its entries to the filesystem, which would require writing the entire index every time it was called. This is problematic, as updates to the index come in whenever code is added or removed. This would also cause a lot of contention during startup because of the amount of data being read off the filesystem.

This branch introduces a write ahead log, using erlang's built in `disk_logger` module. The idea is that the WAL writes operations to disk before they're applied to ETS, so that when we start up, we first read a checkpoint, then apply the operations one-by-one to get to the prior state.

Note that this approach is in contrast to using Khepri. Khepri is very nice, but it's significantly slower than this approach, and it uses a lot more memory. It's also worth noting that the WAL based approach can have its memory efficiency improved by removing the need to shuffle all of the entries around between processes, but that's future work.