### PR TITLE
Implemented find references for module attributes

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/analyzer.ex
+++ b/apps/remote_control/lib/lexical/remote_control/analyzer.ex
@@ -121,6 +121,13 @@ defmodule Lexical.RemoteControl.Analyzer do
     :error
   end
 
+  @doc """
+  Returns the current module at the given position in the analysis
+  """
+  def current_module(%Analysis{} = analysis, %Position{} = position) do
+    expand_alias([:__MODULE__], analysis, position)
+  end
+
   defp resolve_alias([first | _] = segments, aliases_mapping) when is_tuple(first) do
     with {:ok, current_module} <- Map.fetch(aliases_mapping, :__MODULE__) do
       Ast.reify_alias(current_module, segments)

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/entity.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/entity.ex
@@ -15,7 +15,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Entity do
           | {:struct, module()}
           | {:call, module(), fun_name :: atom(), arity :: non_neg_integer()}
           | {:type, module(), type_name :: atom(), arity :: non_neg_integer()}
-          | {:module_attribute, module, atom()}
+          | {:module_attribute, container_module :: module(), attribut_name :: atom()}
 
   defguardp is_call(form) when Sourceror.Identifier.is_call(form) and elem(form, 0) != :.
 
@@ -113,7 +113,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Entity do
       {:ok, {:call, module, fun, arity}, node_range}
     else
       _ ->
-        {:ok, module} = RemoteControl.Analyzer.expand_alias([:__MODULE__], analysis, position)
+        {:ok, module} = RemoteControl.Analyzer.current_module(analysis, position)
         {:ok, {:call, module, fun, 0}, node_range}
     end
   end
@@ -126,10 +126,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Entity do
   end
 
   defp resolve({:module_attribute, attr_name}, node_range, analysis, position) do
-    current_module =
-      analysis
-      |> RemoteControl.Analyzer.aliases_at(position)
-      |> Map.get(:__MODULE__)
+    {:ok, current_module} = RemoteControl.Analyzer.current_module(analysis, position)
 
     {:ok, {:module_attribute, current_module, List.to_atom(attr_name)}, node_range}
   end

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/entity.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/entity.ex
@@ -15,6 +15,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Entity do
           | {:struct, module()}
           | {:call, module(), fun_name :: atom(), arity :: non_neg_integer()}
           | {:type, module(), type_name :: atom(), arity :: non_neg_integer()}
+          | {:module_attribute, module, atom()}
 
   defguardp is_call(form) when Sourceror.Identifier.is_call(form) and elem(form, 0) != :.
 
@@ -122,6 +123,15 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Entity do
       {:ok, module} -> {:ok, {:module, module}, node_range}
       _ -> {:error, {:unsupported, context}}
     end
+  end
+
+  defp resolve({:module_attribute, attr_name}, node_range, analysis, position) do
+    current_module =
+      analysis
+      |> RemoteControl.Analyzer.aliases_at(position)
+      |> Map.get(:__MODULE__)
+
+    {:ok, {:module_attribute, current_module, List.to_atom(attr_name)}, node_range}
   end
 
   defp resolve(context, _node_range, _analysis, _position) do

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
@@ -52,6 +52,10 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
     new(path, Identifier.next_global!(), block.id, subject, type, :reference, range, application)
   end
 
+  def definition(path, %Block{} = block, subject, type, range, application) do
+    new(path, Identifier.next_global!(), block.id, subject, type, :definition, range, application)
+  end
+
   def block_definition(path, %Block{} = block, subject, type, range, application) do
     definition(
       path,

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_definition.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_definition.ex
@@ -2,12 +2,12 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinition do
   alias Lexical.Ast.Analysis
   alias Lexical.Document.Position
   alias Lexical.Document.Range
-  alias Lexical.Formats
   alias Lexical.RemoteControl
   alias Lexical.RemoteControl.Search.Indexer.Entry
   alias Lexical.RemoteControl.Search.Indexer.Metadata
   alias Lexical.RemoteControl.Search.Indexer.Source.Block
   alias Lexical.RemoteControl.Search.Indexer.Source.Reducer
+  alias Lexical.RemoteControl.Search.Subject
 
   @function_definitions [:def, :defp]
 
@@ -33,7 +33,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinition do
         :defp -> :private_function
       end
 
-    mfa = "#{Formats.module(module)}.#{fn_name}/#{arity}"
+    mfa = Subject.mfa(module, fn_name, arity)
     %Block{} = block = Reducer.current_block(reducer)
     path = reducer.analysis.document.path
 

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_definition.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_definition.ex
@@ -15,8 +15,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinition do
       when is_atom(fn_name) and definition in @function_definitions do
     range = get_definition_range(reducer.analysis, metadata, body)
 
-    {:ok, module} =
-      RemoteControl.Analyzer.expand_alias([:__MODULE__], reducer.analysis, range.start)
+    {:ok, module} = RemoteControl.Analyzer.current_module(reducer.analysis, range.start)
 
     arity =
       case args do

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_reference.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_reference.ex
@@ -1,11 +1,11 @@
 defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionReference do
   alias Lexical.Document.Position
   alias Lexical.Document.Range
-  alias Lexical.Formats
   alias Lexical.RemoteControl
   alias Lexical.RemoteControl.Search.Indexer.Entry
   alias Lexical.RemoteControl.Search.Indexer.Metadata
   alias Lexical.RemoteControl.Search.Indexer.Source.Reducer
+  alias Lexical.RemoteControl.Search.Subject
 
   require Logger
 
@@ -136,7 +136,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionReference do
 
     case RemoteControl.Analyzer.expand_alias(module, reducer.analysis, range.start) do
       {:ok, module} ->
-        mfa = Formats.mfa(module, function_name, arity)
+        mfa = Subject.mfa(module, function_name, arity)
 
         Entry.reference(
           reducer.analysis.document.path,

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module.ex
@@ -12,6 +12,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Module do
   alias Lexical.RemoteControl.Search.Indexer.Metadata
   alias Lexical.RemoteControl.Search.Indexer.Source.Block
   alias Lexical.RemoteControl.Search.Indexer.Source.Reducer
+  alias Lexical.RemoteControl.Search.Subject
 
   require Logger
 
@@ -32,7 +33,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Module do
           Entry.block_definition(
             reducer.analysis.document.path,
             block,
-            aliased_module,
+            Subject.module(aliased_module),
             :module,
             range,
             Application.get_application(aliased_module)
@@ -64,7 +65,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Module do
           Entry.reference(
             reducer.analysis.document.path,
             current_block,
-            module,
+            Subject.module(module),
             :module,
             range,
             Application.get_application(module)
@@ -90,7 +91,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Module do
           Entry.reference(
             reducer.analysis.document.path,
             current_block,
-            module,
+            Subject.module(module),
             :module,
             range,
             Application.get_application(module)

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module_attribute.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module_attribute.ex
@@ -5,7 +5,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ModuleAttribute do
 
   alias Lexical.Document.Position
   alias Lexical.Document.Range
-  alias Lexical.RemoteControl
+  alias Lexical.RemoteControl.Analyzer
   alias Lexical.RemoteControl.Search.Indexer.Entry
   alias Lexical.RemoteControl.Search.Indexer.Source.Reducer
   alias Lexical.RemoteControl.Search.Subject
@@ -16,10 +16,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ModuleAttribute do
   def extract({:@, _, [{attr_name, _, nil}]}, %Reducer{} = reducer) do
     block = Reducer.current_block(reducer)
 
-    current_module =
-      reducer.analysis
-      |> RemoteControl.Analyzer.Aliases.at(Reducer.position(reducer))
-      |> Map.get(:__MODULE__)
+    {:ok, current_module} = Analyzer.current_module(reducer.analysis, Reducer.position(reducer))
 
     reference =
       Entry.reference(
@@ -38,10 +35,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ModuleAttribute do
   def extract({:@, _, [{attr_name, _, _attr_value}]} = attr, %Reducer{} = reducer) do
     block = Reducer.current_block(reducer)
 
-    current_module =
-      reducer.analysis
-      |> RemoteControl.Analyzer.Aliases.at(Reducer.position(reducer))
-      |> Map.get(:__MODULE__)
+    {:ok, current_module} = Analyzer.current_module(reducer.analysis, Reducer.position(reducer))
 
     definition =
       Entry.definition(

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module_attribute.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module_attribute.ex
@@ -1,0 +1,97 @@
+defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ModuleAttribute do
+  @moduledoc """
+  Extracts module attribute definitions and references from AST
+  """
+
+  alias Lexical.Document.Position
+  alias Lexical.Document.Range
+  alias Lexical.RemoteControl
+  alias Lexical.RemoteControl.Search.Indexer.Entry
+  alias Lexical.RemoteControl.Search.Indexer.Source.Reducer
+  alias Lexical.RemoteControl.Search.Subject
+
+  require Logger
+
+  # Finds module attribute usages
+  def extract({:@, _, [{attr_name, _, nil}]}, %Reducer{} = reducer) do
+    block = Reducer.current_block(reducer)
+
+    current_module =
+      reducer.analysis
+      |> RemoteControl.Analyzer.Aliases.at(Reducer.position(reducer))
+      |> Map.get(:__MODULE__)
+
+    reference =
+      Entry.reference(
+        reducer.analysis.document.path,
+        block,
+        Subject.module_attribute(current_module, attr_name),
+        :module_attribute,
+        reference_range(reducer, attr_name),
+        Application.get_application(current_module)
+      )
+
+    {:ok, reference}
+  end
+
+  # Finds module attribute definitions @foo 3
+  def extract({:@, _, [{attr_name, _, _attr_value}]} = attr, %Reducer{} = reducer) do
+    block = Reducer.current_block(reducer)
+
+    current_module =
+      reducer.analysis
+      |> RemoteControl.Analyzer.Aliases.at(Reducer.position(reducer))
+      |> Map.get(:__MODULE__)
+
+    definition =
+      Entry.definition(
+        reducer.analysis.document.path,
+        block,
+        Subject.module_attribute(current_module, attr_name),
+        :module_attribute,
+        definition_range(reducer, attr),
+        Application.get_application(current_module)
+      )
+
+    {:ok, definition}
+  end
+
+  def extract(_, _) do
+    :ignored
+  end
+
+  defp reference_range(%Reducer{} = reducer, attr_name) do
+    document = reducer.analysis.document
+
+    name_length =
+      attr_name
+      |> Atom.to_string()
+      |> String.length()
+
+    {start_line, start_column} = reducer.position
+
+    # add 1 to include the @ character
+    end_column = start_column + name_length + 1
+
+    Range.new(
+      Position.new(document, start_line, start_column),
+      Position.new(document, start_line, end_column)
+    )
+  end
+
+  defp definition_range(%Reducer{} = reducer, attr_ast) do
+    document = reducer.analysis.document
+
+    [line: start_line, column: start_column] = Sourceror.get_start_position(attr_ast)
+
+    end_line = Sourceror.get_end_line(attr_ast)
+    {:ok, line_text} = Lexical.Document.fetch_text_at(document, end_line)
+    # add one because lsp positions are one-based
+    end_column = String.length(line_text) + 1
+
+    Range.new(
+      Position.new(document, start_line, start_column),
+      Position.new(document, end_line, end_column)
+    )
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/source/reducer.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/source/reducer.ex
@@ -15,7 +15,12 @@ defmodule Lexical.RemoteControl.Search.Indexer.Source.Reducer do
 
   defstruct [:analysis, :entries, :position, :ends_at, :blocks, :block_hierarchy]
 
-  @extractors [Extractors.Module, Extractors.FunctionDefinition, Extractors.FunctionReference]
+  @extractors [
+    Extractors.Module,
+    Extractors.ModuleAttribute,
+    Extractors.FunctionDefinition,
+    Extractors.FunctionReference
+  ]
 
   def new(%Analysis{} = analysis) do
     %__MODULE__{

--- a/apps/remote_control/lib/lexical/remote_control/search/subject.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/subject.ex
@@ -1,0 +1,18 @@
+defmodule Lexical.RemoteControl.Search.Subject do
+  @moduledoc """
+  Functions for converting to a search entry's subject field
+  """
+  alias Lexical.Formats
+
+  def module(module) do
+    module
+  end
+
+  def module_attribute(module, attribute_name) do
+    "#{module}@#{attribute_name}"
+  end
+
+  def mfa(module, function, arity) do
+    Formats.mfa(module, function, arity)
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/analyzer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/analyzer_test.exs
@@ -51,7 +51,7 @@ defmodule Lexical.RemoteControl.AnalyzerTest do
 
       assert %Analysis{valid?: false} = analysis = Ast.analyze(document)
       assert %Analysis{valid?: true} = analysis = Ast.reanalyze_to(analysis, position)
-      assert {:ok, Invalid} = Analyzer.expand_alias([:__MODULE__], analysis, position)
+      assert {:ok, Invalid} = Analyzer.current_module(analysis, position)
     end
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/module_attribute_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/module_attribute_test.exs
@@ -1,0 +1,181 @@
+defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ModuleAttributeTest do
+  alias Lexical.RemoteControl.Search.Subject
+  use Lexical.Test.ExtractorCase
+
+  def index(source) do
+    do_index(source, fn entry ->
+      entry.type == :module_attribute
+    end)
+  end
+
+  describe "indexing module attributes" do
+    test "finds definitions when defining scalars" do
+      {:ok, [attr], doc} =
+        ~q[
+        defmodule Root do
+         @attribute 32
+        end
+      ]
+        |> index()
+
+      assert attr.type == :module_attribute
+      assert attr.subtype == :definition
+      assert attr.subject == Subject.module_attribute(Root, :attribute)
+
+      assert decorate(doc, attr.range) =~ "«@attribute 32»"
+    end
+
+    test "finds multiple definitions of the same attribute" do
+      {:ok, [first, second, third], doc} =
+        ~q[
+          defmodule Parent do
+           @tag 1
+           def first,  do: 1
+
+           @tag 2
+           def second,  do: 1
+
+           @tag 3
+           def third,  do: 1
+          end
+        ]
+        |> index()
+
+      assert first.type == :module_attribute
+      assert first.subtype == :definition
+      assert first.subject == Subject.module_attribute(Parent, :tag)
+      assert decorate(doc, first.range) =~ "«@tag 1»"
+
+      assert second.type == :module_attribute
+      assert second.subtype == :definition
+      assert second.subject == Subject.module_attribute(Parent, :tag)
+      assert decorate(doc, second.range) =~ "«@tag 2»"
+
+      assert third.type == :module_attribute
+      assert third.subtype == :definition
+      assert third.subject == Subject.module_attribute(Parent, :tag)
+      assert decorate(doc, third.range) =~ "«@tag 3»"
+    end
+
+    test "finds definitions when the definition spans multiple lines" do
+      {:ok, [attr], doc} =
+        ~q[
+        defmodule Parent do
+          @number_strings 1..50
+            |> Enum.map(& &1 * 2)
+            |> Enum.map(&Integer.to_string/1)
+        end
+        ]
+        |> index()
+
+      assert attr.type == :module_attribute
+      assert attr.subtype == :definition
+      assert attr.subject == Subject.module_attribute(Parent, :number_strings)
+
+      expected =
+        """
+         «@number_strings 1..50
+            |> Enum.map(& &1 * 2)
+            |> Enum.map(&Integer.to_string/1)»
+        """
+        |> String.trim()
+
+      assert decorate(doc, attr.range) =~ expected
+    end
+
+    test "finds references in other definitions" do
+      {:ok, [_def1, def2, reference], doc} =
+        ~q[
+        defmodule Root do
+           @attr 23
+
+           @attr2 @attr + 1
+        end
+        ]
+        |> index()
+
+      assert def2.type == :module_attribute
+      assert def2.subtype == :definition
+      assert def2.subject == Subject.module_attribute(Root, :attr2)
+      assert decorate(doc, def2.range) =~ "«@attr2 @attr + 1»"
+
+      assert reference.type == :module_attribute
+      assert reference.subtype == :reference
+      assert reference.subject == Subject.module_attribute(Root, :attr)
+      assert decorate(doc, reference.range) =~ "@attr2 «@attr» + 1"
+    end
+
+    test "finds definitions in nested contexts" do
+      {:ok, [parent_def, child_def], doc} =
+        ~q[
+          defmodule Parent do
+            @in_parent true
+            defmodule Child do
+              @in_child true
+            end
+          end
+        ]
+        |> index()
+
+      assert parent_def.type == :module_attribute
+      assert parent_def.subtype == :definition
+      assert parent_def.subject == Subject.module_attribute(Parent, :in_parent)
+      assert decorate(doc, parent_def.range) =~ "«@in_parent true»"
+
+      assert child_def.type == :module_attribute
+      assert child_def.subtype == :definition
+      assert child_def.subject == Subject.module_attribute(Parent.Child, :in_child)
+      assert decorate(doc, child_def.range) =~ "«@in_child true»"
+    end
+
+    test "finds references in function arguments" do
+      {:ok, [_definition, reference], doc} =
+        ~q[
+          defmodule InArgs do
+            @age 95
+            def is_old?(@age), do: true
+          end
+        ]
+        |> index()
+
+      assert reference.type == :module_attribute
+      assert reference.subtype == :reference
+      assert reference.subject == Subject.module_attribute(InArgs, :age)
+      assert decorate(doc, reference.range) =~ "  def is_old?(«@age»)"
+    end
+
+    test "finds references in map keys" do
+      {:ok, [_, key], doc} =
+        ~q[
+          defmodule InMapKey do
+            @foo 3
+            def something(%{@foo => 3}) do
+            end
+          end
+        ]
+        |> index()
+
+      assert key.type == :module_attribute
+      assert key.subtype == :reference
+      assert key.subject == Subject.module_attribute(InMapKey, :foo)
+      assert decorate(doc, key.range) =~ "%{«@foo» => 3}"
+    end
+
+    test "finds references in map values" do
+      {:ok, [_, value], doc} =
+        ~q[
+          defmodule InMapValue do
+            @foo 3
+            def something(%{foo: @foo}) do
+            end
+          end
+        ]
+        |> index()
+
+      assert value.type == :module_attribute
+      assert value.subtype == :reference
+      assert value.subject == Subject.module_attribute(InMapValue, :foo)
+      assert decorate(doc, value.range) =~ "%{foo: «@foo»}"
+    end
+  end
+end

--- a/apps/server/lib/lexical/server/provider/handlers/hover.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/hover.ex
@@ -78,6 +78,10 @@ defmodule Lexical.Server.Provider.Handlers.Hover do
     end
   end
 
+  defp hover_content(type, _) do
+    {:error, {:unsupported, type}}
+  end
+
   defp module_header(:module, %Docs{module: module}) do
     Ast.Module.name(module)
   end


### PR DESCRIPTION
We now index references and usages of module attributes. Saving the module name with the attribute limits its scope to the contained module, which greatly simplifies indexing and search.

Fixes #472