### PR TITLE
Indexing struct definitions and references

### DIFF
--- a/apps/common/lib/lexical/ast/range.ex
+++ b/apps/common/lib/lexical/ast/range.ex
@@ -1,0 +1,40 @@
+defmodule Lexical.Ast.Range do
+  @moduledoc """
+  Utilities for extracting ranges from ast nodes
+  """
+  alias Lexical.Document
+  alias Lexical.Document.Position
+  alias Lexical.Document.Range
+
+  @spec fetch(Macro.t(), Document.t()) :: {:ok, Range.t()} | :error
+  def fetch(ast, %Document{} = document) do
+    case Sourceror.get_range(ast) do
+      %{start: start_pos, end: end_pos} ->
+        [line: start_line, column: start_column] = start_pos
+        [line: end_line, column: end_column] = end_pos
+
+        range =
+          Range.new(
+            Position.new(document, start_line, start_column),
+            Position.new(document, end_line, end_column)
+          )
+
+        {:ok, range}
+
+      _ ->
+        :error
+    end
+  end
+
+  @spec fetch!(Macro.t(), Document.t()) :: Range.t()
+  def fetch!(ast, %Document{} = document) do
+    case fetch(ast, document) do
+      {:ok, range} ->
+        range
+
+      :error ->
+        raise ArgumentError,
+          message: "Could not get a range for #{inspect(ast)} in #{document.path}"
+    end
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/references.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/references.ex
@@ -17,34 +17,36 @@ defmodule Lexical.RemoteControl.CodeIntelligence.References do
   end
 
   defp find_references({:module, module}, include_definitions?) do
-    module_references(module, include_definitions?)
+    subject = Subject.module(module)
+    subtype = subtype(include_definitions?)
+
+    query(subject, type: :module, subtype: subtype)
   end
 
   defp find_references({:struct, struct_module}, include_definitions?) do
-    module_references(struct_module, include_definitions?)
+    subject = Subject.module(struct_module)
+    subtype = subtype(include_definitions?)
+
+    query(subject, type: :struct, subtype: subtype)
   end
 
   defp find_references({:call, module, function_name, arity}, include_definitions?) do
     subject = Subject.mfa(module, function_name, arity)
     subtype = subtype(include_definitions?)
+
     query(subject, type: :function, subtype: subtype)
   end
 
   defp find_references({:module_attribute, module, attribute_name}, include_definitions?) do
     subject = Subject.module_attribute(module, attribute_name)
     subtype = subtype(include_definitions?)
+
     query(subject, type: :module_attribute, subtype: subtype)
   end
 
   defp find_references(resolved, _include_definitions?) do
     Logger.info("Not attempting to find references for unhandled type: #{inspect(resolved)}")
     []
-  end
-
-  defp module_references(module, include_definitions?) do
-    subject = Subject.module(module)
-    subtype = subtype(include_definitions?)
-    query(subject, type: :module, subtype: subtype)
   end
 
   defp to_location(%Entry{} = entry) do

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/struct_definition.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/struct_definition.ex
@@ -1,6 +1,5 @@
 defmodule Lexical.RemoteControl.Search.Indexer.Extractors.StructDefinition do
-  alias Lexical.Document.Position
-  alias Lexical.Document.Range
+  alias Lexical.Ast
   alias Lexical.RemoteControl.Analyzer
   alias Lexical.RemoteControl.Search.Indexer.Entry
   alias Lexical.RemoteControl.Search.Indexer.Source.Reducer
@@ -9,7 +8,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.StructDefinition do
     document = reducer.analysis.document
     block = Reducer.current_block(reducer)
     {:ok, current_module} = Analyzer.current_module(reducer.analysis, Reducer.position(reducer))
-    range = range(document, definition)
+    range = Ast.Range.fetch!(definition, document)
 
     entry =
       Entry.definition(
@@ -26,16 +25,5 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.StructDefinition do
 
   def extract(_, _) do
     :ignored
-  end
-
-  defp range(document, definition) do
-    %{start: start_pos, end: end_pos} = Sourceror.get_range(definition)
-    [line: start_line, column: start_column] = start_pos
-    [line: end_line, column: end_column] = end_pos
-
-    Range.new(
-      Position.new(document, start_line, start_column),
-      Position.new(document, end_line, end_column)
-    )
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/struct_definition.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/struct_definition.ex
@@ -1,0 +1,41 @@
+defmodule Lexical.RemoteControl.Search.Indexer.Extractors.StructDefinition do
+  alias Lexical.Document.Position
+  alias Lexical.Document.Range
+  alias Lexical.RemoteControl.Analyzer
+  alias Lexical.RemoteControl.Search.Indexer.Entry
+  alias Lexical.RemoteControl.Search.Indexer.Source.Reducer
+
+  def extract({:defstruct, _, [_fields]} = definition, %Reducer{} = reducer) do
+    document = reducer.analysis.document
+    block = Reducer.current_block(reducer)
+    {:ok, current_module} = Analyzer.current_module(reducer.analysis, Reducer.position(reducer))
+    range = range(document, definition)
+
+    entry =
+      Entry.definition(
+        document.path,
+        block,
+        current_module,
+        :struct,
+        range,
+        Application.get_application(current_module)
+      )
+
+    {:ok, entry}
+  end
+
+  def extract(_, _) do
+    :ignored
+  end
+
+  defp range(document, definition) do
+    %{start: start_pos, end: end_pos} = Sourceror.get_range(definition)
+    [line: start_line, column: start_column] = start_pos
+    [line: end_line, column: end_column] = end_pos
+
+    Range.new(
+      Position.new(document, start_line, start_column),
+      Position.new(document, end_line, end_column)
+    )
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/struct_reference.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/struct_reference.ex
@@ -1,0 +1,103 @@
+defmodule Lexical.RemoteControl.Search.Indexer.Extractors.StructReference do
+  alias Lexical.Document
+  alias Lexical.Document.Position
+  alias Lexical.Document.Range
+  alias Lexical.RemoteControl.Analyzer
+  alias Lexical.RemoteControl.Search.Indexer.Entry
+  alias Lexical.RemoteControl.Search.Indexer.Source.Reducer
+  alias Lexical.RemoteControl.Search.Subject
+
+  require Logger
+
+  @struct_fn_names [:struct, :struct!]
+
+  # Handles usages via an alias, e.g. x = %MyStruct{...} or %__MODULE__{...}
+  def extract(
+        {:%, _, [struct_alias, {:%{}, _, _struct_args}]} = reference,
+        %Reducer{} = reducer
+      ) do
+    case expand_alias(struct_alias, reducer) do
+      {:ok, struct_module} ->
+        {:ok, entry(reducer, struct_module, reference)}
+
+      _ ->
+        :ignored
+    end
+  end
+
+  # Call to Kernel.struct with a fully qualified module e.g. Kernel.struct(MyStruct, ...)
+  def extract(
+        {{:., _, [kernel_alias, struct_fn_name]}, _, [struct_alias]} = reference,
+        %Reducer{} = reducer
+      )
+      when struct_fn_name in @struct_fn_names do
+    with {:ok, Kernel} <- expand_alias(kernel_alias, reducer),
+         {:ok, struct_module} <- expand_alias(struct_alias, reducer) do
+      {:ok, entry(reducer, struct_module, reference)}
+    end
+  end
+
+  # handles calls to Kernel.struct e.g. struct(MyModule) or struct(MyModule, foo: 3)
+  def extract({struct_fn_name, _, [struct_alias | _] = args} = reference, %Reducer{} = reducer)
+      when struct_fn_name in @struct_fn_names do
+    reducer_position = Reducer.position(reducer)
+    imports = Analyzer.imports_at(reducer.analysis, reducer_position)
+    arity = length(args)
+
+    with true <- Enum.member?(imports, {Kernel, :struct, arity}),
+         {:ok, struct_module} <- expand_alias(struct_alias, reducer) do
+      {:ok, entry(reducer, struct_module, reference)}
+    else
+      _ ->
+        :ignored
+    end
+  end
+
+  def extract(_, _) do
+    :ignored
+  end
+
+  defp entry(%Reducer{} = reducer, struct_module, reference) do
+    document = reducer.analysis.document
+    block = Reducer.current_block(reducer)
+    subject = Subject.module(struct_module)
+
+    Entry.reference(
+      document.path,
+      block,
+      subject,
+      :struct,
+      range(document, reference),
+      Application.get_application(struct_module)
+    )
+  end
+
+  defp range(%Document{} = document, ast) do
+    %{start: start_pos, end: end_pos} = Sourceror.get_range(ast)
+    [line: start_line, column: start_column] = start_pos
+    [line: end_line, column: end_column] = end_pos
+
+    Range.new(
+      Position.new(document, start_line, start_column),
+      Position.new(document, end_line, end_column)
+    )
+  end
+
+  defp expand_alias({:__aliases__, _, struct_alias}, %Reducer{} = reducer) do
+    Analyzer.expand_alias(struct_alias, reducer.analysis, Reducer.position(reducer))
+  end
+
+  defp expand_alias({:__MODULE__, _, _}, %Reducer{} = reducer) do
+    Analyzer.current_module(reducer.analysis, Reducer.position(reducer))
+  end
+
+  defp expand_alias(alias, %Reducer{} = reducer) do
+    {line, column} = reducer.position
+
+    Logger.error(
+      "Could not expand alias: #{inspect(alias)} at #{reducer.analysis.document.path} #{line}:#{column}"
+    )
+
+    :error
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/source/reducer.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/source/reducer.ex
@@ -19,7 +19,9 @@ defmodule Lexical.RemoteControl.Search.Indexer.Source.Reducer do
     Extractors.Module,
     Extractors.ModuleAttribute,
     Extractors.FunctionDefinition,
-    Extractors.FunctionReference
+    Extractors.FunctionReference,
+    Extractors.StructDefinition,
+    Extractors.StructReference
   ]
 
   def new(%Analysis{} = analysis) do

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/references_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/references_test.exs
@@ -100,15 +100,6 @@ defmodule Lexical.RemoteControl.CodeIntelligence.ReferencesTest do
       assert decorate(code, location.range) =~ ~s[%«ReferencedModule»{} = something_else]
     end
 
-    test "includes modules when a struct is requested", %{project: project} do
-      code = ~q[
-        ReferencedModule = something_else
-      ]
-
-      assert {:ok, [%Location{} = location]} = references(project, "%ReferencedModule|{}", code)
-      assert decorate(code, location.range) =~ ~s[«ReferencedModule» = something_else]
-    end
-
     test "includes definitions if the parameter is true", %{project: project} do
       code = ~q[
         defmodule DefinedModule do
@@ -122,6 +113,29 @@ defmodule Lexical.RemoteControl.CodeIntelligence.ReferencesTest do
       assert {:ok, [location_1, location_2]} = references(project, "DefinedModule|", code, true)
       assert decorate(code, location_1.range) =~ ~s[defmodule «DefinedModule» do]
       assert decorate(code, location_2.range) =~ ~s[@attr «DefinedModule»]
+    end
+  end
+
+  describe "struct references" do
+    test "includes their definition if the parameter is true", %{project: project} do
+      code = ~q(
+      defmodule Struct do
+        defstruct [:field]
+      end
+      )
+
+      assert {:ok, [location]} = references(project, "%Struct|{}", code, true)
+      assert decorate(code, location.range) =~ "«defstruct [:field]»"
+    end
+
+    test "excludes their definition", %{project: project} do
+      code = ~q(
+      defmodule Struct do
+        defstruct [:field]
+      end
+      )
+
+      assert {:ok, []} = references(project, "%Struct|{}", code)
     end
   end
 

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/struct_definition_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/struct_definition_test.exs
@@ -24,6 +24,32 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.StructDefinitionTest d
     assert decorate(doc, struct.range) =~ "«defstruct [:name, :value]»"
   end
 
+  test "it highlights multiple line definitions" do
+    {:ok, [struct], doc} =
+      ~q(
+        defmodule Root do
+         defstruct [
+          :name,
+          :value,
+          :other
+         ]
+        end
+        )
+      |> index()
+
+    expected =
+      """
+      «defstruct [
+        :name,
+        :value,
+        :other
+       ]»
+      """
+      |> String.trim()
+
+    assert decorate(doc, struct.range) =~ expected
+  end
+
   test "it should find a module that defines a struct via a keyword list" do
     {:ok, [struct], doc} =
       ~q(

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/struct_definition_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/struct_definition_test.exs
@@ -1,0 +1,65 @@
+defmodule Lexical.RemoteControl.Search.Indexer.Extractors.StructDefinitionTest do
+  alias Lexical.RemoteControl.Search.Subject
+  use Lexical.Test.ExtractorCase
+
+  def index(source) do
+    do_index(source, fn entry ->
+      entry.type == :struct and entry.subtype == :definition
+    end)
+  end
+
+  test "it should find a module that defines a struct via a list of atoms" do
+    {:ok, [struct], doc} =
+      ~q(
+        defmodule Root do
+         defstruct [:name, :value]
+        end
+        )
+      |> index()
+
+    assert struct.type == :struct
+    assert struct.subtype == :definition
+    assert struct.subject == Subject.module(Root)
+
+    assert decorate(doc, struct.range) =~ "«defstruct [:name, :value]»"
+  end
+
+  test "it should find a module that defines a struct via a keyword list" do
+    {:ok, [struct], doc} =
+      ~q(
+        defmodule Root do
+         defstruct [name: nil, cost: 0]
+        end
+        )
+      |> index()
+
+    assert struct.type == :struct
+    assert struct.subtype == :definition
+    assert struct.subject == Subject.module(Root)
+
+    assert decorate(doc, struct.range) =~ "«defstruct [name: nil, cost: 0]»"
+  end
+
+  test "it finds struct definitions in nested modules" do
+    {:ok, [child, parent], doc} =
+      ~q(
+        defmodule Parent do
+          defmodule Child do
+            defstruct [:parent, :height]
+          end
+          defstruct [name: nil, cost: 0]
+        end
+        )
+      |> index()
+
+    assert child.type == :struct
+    assert child.subtype == :definition
+    assert child.subject == Subject.module(Parent.Child)
+    assert decorate(doc, child.range) =~ "«defstruct [:parent, :height]"
+
+    assert parent.type == :struct
+    assert parent.subtype == :definition
+    assert parent.subject == Subject.module(Parent)
+    assert decorate(doc, parent.range) =~ "«defstruct [name: nil, cost: 0]"
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/struct_reference_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/struct_reference_test.exs
@@ -219,6 +219,15 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.StructReferenceTest do
       assert decorate(doc, struct.range) == ~S[struct = «Kernel.struct(MyStruct)»]
     end
 
+    test "in a fully qualified call to Kernel.struct/2" do
+      {:ok, [struct], doc} = ~q[struct = Kernel.struct(MyStruct, foo: 3)] |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyStruct)
+      assert decorate(doc, struct.range) == ~S[struct = «Kernel.struct(MyStruct, foo: 3)»]
+    end
+
     test "other functions named struct are not counted" do
       {:ok, [], _} = ~q[struct = Macro.struct(MyStruct)] |> index()
     end

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/struct_reference_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/struct_reference_test.exs
@@ -1,0 +1,325 @@
+defmodule Lexical.RemoteControl.Search.Indexer.Extractors.StructReferenceTest do
+  alias Lexical.RemoteControl.Search.Subject
+  use Lexical.Test.ExtractorCase
+
+  def index(source) do
+    do_index(source, fn entry ->
+      entry.type == :struct and entry.subtype == :reference
+    end)
+  end
+
+  describe "recognizing structs" do
+    test "in a naked reference" do
+      {:ok, [struct], doc} =
+        ~q[%MyStruct{}]
+        |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyStruct)
+      assert decorate(doc, struct.range) == "«%MyStruct{}»"
+    end
+
+    test "in a naked reference with fields" do
+      {:ok, [struct], doc} =
+        ~q[
+        %MyStruct{name: "stinky", height: 184}
+      ]
+        |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyStruct)
+      assert decorate(doc, struct.range) == ~S(«%MyStruct{name: "stinky", height: 184}»)
+    end
+
+    test "in a struct on the left side of a match" do
+      {:ok, [struct], doc} =
+        ~q[%MyStruct{} = variable]
+        |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyStruct)
+      assert decorate(doc, struct.range) == "«%MyStruct{}» = variable"
+    end
+
+    test "in a struct on the right side of a match" do
+      {:ok, [struct], doc} =
+        ~q[variable = %MyStruct{}]
+        |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyStruct)
+      assert decorate(doc, struct.range) == "variable = «%MyStruct{}»"
+    end
+
+    test "in a struct reference in params" do
+      {:ok, [struct], doc} =
+        ~q[
+        def my_fn(%MyStruct{} = first) do
+        end
+        ]
+        |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyStruct)
+      assert decorate(doc, struct.range) == ~S[def my_fn(«%MyStruct{}» = first) do]
+    end
+
+    test "in nested struct references" do
+      {:ok, [outer, inner], doc} =
+        ~q[
+        %OuterStruct{inner: %InnerStruct{}}
+        ]
+        |> index()
+
+      assert outer.type == :struct
+      assert outer.subtype == :reference
+      assert outer.subject == Subject.module(OuterStruct)
+      assert decorate(doc, outer.range) == ~S[«%OuterStruct{inner: %InnerStruct{}}»]
+
+      assert inner.type == :struct
+      assert inner.subtype == :reference
+      assert inner.subject == Subject.module(InnerStruct)
+      assert decorate(doc, inner.range) == ~S[%OuterStruct{inner: «%InnerStruct{}»}]
+    end
+
+    test "in map keys" do
+      {:ok, [struct], doc} =
+        ~q[%{%MyStruct{} => 3}]
+        |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyStruct)
+      assert decorate(doc, struct.range) == ~S[%{«%MyStruct{}» => 3}]
+    end
+
+    test "in map values" do
+      {:ok, [struct], doc} =
+        ~q[%{cool_struct: %MyStruct{}}]
+        |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyStruct)
+      assert decorate(doc, struct.range) == ~S[%{cool_struct: «%MyStruct{}»}]
+    end
+
+    test "in list elements" do
+      {:ok, [struct], doc} =
+        ~q([1, 2, %MyStruct{}])
+        |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyStruct)
+      assert decorate(doc, struct.range) == ~S([1, 2, «%MyStruct{}»])
+    end
+
+    test "in a imported call to struct/1 with an alias" do
+      {:ok, [struct], doc} = ~q[
+        defmodule Parent do
+          struct = struct(MyStruct)
+        end
+      ] |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyStruct)
+      assert decorate(doc, struct.range) == ~S[  struct = «struct(MyStruct)»]
+    end
+
+    test "in a imported call to struct/1 with __MODULE__" do
+      {:ok, [struct], doc} = ~q[
+        defmodule Parent do
+          struct = struct(__MODULE__)
+        end
+      ] |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(Parent)
+      assert decorate(doc, struct.range) == ~S[  struct = «struct(__MODULE__)»]
+    end
+
+    test "in a imported call to struct!/1 with __MODULE__" do
+      {:ok, [struct], doc} = ~q[
+        defmodule Parent do
+          struct = struct!(__MODULE__)
+        end
+      ] |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(Parent)
+      assert decorate(doc, struct.range) == ~S[  struct = «struct!(__MODULE__)»]
+    end
+
+    test "in a imported call to struct/2 with an alias" do
+      {:ok, [struct], doc} = ~q[
+        defmodule Parent do
+          struct = struct(MyStruct, foo: 3)
+        end
+      ] |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyStruct)
+      assert decorate(doc, struct.range) == ~S[  struct = «struct(MyStruct, foo: 3)»]
+    end
+
+    test "in a imported call to struct!/2 with an alias" do
+      {:ok, [struct], doc} = ~q[
+        defmodule Parent do
+          struct = struct!(MyStruct, foo: 3)
+        end
+      ] |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyStruct)
+      assert decorate(doc, struct.range) == ~S[  struct = «struct!(MyStruct, foo: 3)»]
+    end
+
+    test "in a imported call to struct/2 with __MODULE__" do
+      {:ok, [struct], doc} = ~q[
+        defmodule Parent do
+          struct = struct(__MODULE__, foo: 3)
+        end
+      ] |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(Parent)
+      assert decorate(doc, struct.range) == ~S[  struct = «struct(__MODULE__, foo: 3)»]
+    end
+
+    test "is ignored if struct isn't imported" do
+      assert {:ok, _, _} =
+               ~q{
+        defmodule Parent do
+
+          import Kernel, except: [struct: 1]
+          struct = struct(MyStruct)
+               end
+       }
+               |> index()
+    end
+
+    test "in a fully qualified call to Kernel.struct/1" do
+      {:ok, [struct], doc} = ~q[struct = Kernel.struct(MyStruct)] |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyStruct)
+      assert decorate(doc, struct.range) == ~S[struct = «Kernel.struct(MyStruct)»]
+    end
+
+    test "other functions named struct are not counted" do
+      {:ok, [], _} = ~q[struct = Macro.struct(MyStruct)] |> index()
+    end
+  end
+
+  describe "handling __MODULE__" do
+    test "in a module attribute" do
+      {:ok, [struct], doc} =
+        ~q[
+          defmodule MyModule do
+            @attr %__MODULE__{}
+          end
+        ]
+        |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyModule)
+      assert decorate(doc, struct.range) == ~S(  @attr «%__MODULE__{}»)
+    end
+
+    test "in handling a submodule" do
+      {:ok, [struct], doc} =
+        ~q[
+          defmodule MyModule do
+            @attr %__MODULE__.Submodule{}
+          end
+        ]
+        |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyModule.Submodule)
+      assert decorate(doc, struct.range) == ~S(  @attr «%__MODULE__.Submodule{}»)
+    end
+
+    test "in a function definition" do
+      {:ok, [struct], doc} =
+        ~q[
+          defmodule MyModule do
+            def my_fn(%__MODULE__{}), do: :ok
+          end
+        ]
+        |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(MyModule)
+      assert decorate(doc, struct.range) == ~S[  def my_fn(«%__MODULE__{}»), do: :ok]
+    end
+
+    test "in a call to Kernel.struct/1" do
+      {:ok, [struct], doc} = ~q[
+         defmodule Parent do
+           struct = struct(__MODULE__)
+         end
+        ] |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(Parent)
+      assert decorate(doc, struct.range) == ~S[  struct = «struct(__MODULE__)»]
+    end
+
+    test "in a call to Kernel.struct!/1" do
+      {:ok, [struct], doc} = ~q[
+         defmodule Parent do
+           struct = struct!(__MODULE__)
+         end
+        ] |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(Parent)
+      assert decorate(doc, struct.range) == ~S[  struct = «struct!(__MODULE__)»]
+    end
+
+    test "in a call to Kernel.struct/2" do
+      {:ok, [struct], doc} = ~q[
+         defmodule Parent do
+           struct = struct(__MODULE__, foo: 3)
+         end
+        ] |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(Parent)
+      assert decorate(doc, struct.range) == ~S[  struct = «struct(__MODULE__, foo: 3)»]
+    end
+
+    test "in a call to Kernel.struct!/2" do
+      {:ok, [struct], doc} = ~q[
+         defmodule Parent do
+           struct = struct!(__MODULE__, foo: 3)
+         end
+        ] |> index()
+
+      assert struct.type == :struct
+      assert struct.subtype == :reference
+      assert struct.subject == Subject.module(Parent)
+      assert decorate(doc, struct.range) == ~S[  struct = «struct!(__MODULE__, foo: 3)»]
+    end
+  end
+end


### PR DESCRIPTION
We now index struct definitions and references, including structs created with the various implementations of Kernel.struct

Fixes #560 