### PR TITLE
Improved import resilience

### DIFF
--- a/apps/common/lib/lexical/ast/analysis/import.ex
+++ b/apps/common/lib/lexical/ast/analysis/import.ex
@@ -38,10 +38,9 @@ defmodule Lexical.Ast.Analysis.Import do
                 :sigils
 
               keyword when is_list(keyword) ->
-                Enum.map(keyword, fn
-                  {{:__block__, _, [function_name]}, {:__block__, _, [arity]}} ->
-                    {function_name, arity}
-                end)
+                keyword
+                |> Enum.reduce([], &expand_function_keywords/2)
+                |> Enum.reverse()
 
               _ ->
                 # they're likely in the middle of typing in something, and have produced an
@@ -66,4 +65,15 @@ defmodule Lexical.Ast.Analysis.Import do
   defp expand_selector(_) do
     :all
   end
+
+  defp expand_function_keywords(
+         {{:__block__, _, [function_name]}, {:__block__, _, [arity]}},
+         acc
+       )
+       when is_atom(function_name) and is_number(arity) do
+    [{function_name, arity} | acc]
+  end
+
+  defp expand_function_keywords(_ignored, acc),
+    do: acc
 end

--- a/apps/remote_control/test/lexical/remote_control/analyzer/imports_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/analyzer/imports_test.exs
@@ -340,9 +340,20 @@ defmodule Lexical.Ast.Analysis.ImportsTest do
       assert_imported(imports, ImportedModule, :macro, 1)
 
       assert_imported(imports, ImportedModule, :function, 0)
-      assert_imported(imports, ImportedModule, :function, 0)
       assert_imported(imports, ImportedModule, :function, 1)
       assert_imported(imports, ImportedModule, :function, 2)
+    end
+
+    test "imports nothing when the only part is incomplete" do
+      imports =
+        ~q(
+        defmodule New do
+          import Parent.Child.ImportedModule, only: [wi|]
+        end
+        )
+        |> imports_at_cursor()
+
+      refute_imported(imports, ImportedModule)
     end
   end
 


### PR DESCRIPTION
While importing, it was possible to crash lexical analysis by producing invalid import syntax as you were typing. This change improves resilience by handling and ignoring invalid syntax inside the list of imported functions.

Fixes #559