### PR TITLE
Added missing else for with block

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/struct_reference.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/struct_reference.ex
@@ -32,6 +32,9 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.StructReference do
     with {:ok, Kernel} <- expand_alias(kernel_alias, reducer),
          {:ok, struct_module} <- expand_alias(struct_alias, reducer) do
       {:ok, entry(reducer, struct_module, reference)}
+    else
+      _ ->
+        :ignored
     end
   end
 

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/struct_reference_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/struct_reference_test.exs
@@ -331,4 +331,62 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.StructReferenceTest do
       assert decorate(doc, struct.range) == ~S[  struct = «struct!(__MODULE__, foo: 3)»]
     end
   end
+
+  describe "when aliases can't be expanded" do
+    test "a fully qualified call to Kernel.struct/1 is ignored" do
+      assert {:ok, [], _} = ~q[
+         defmodule Parent do
+           struct = Kernel.struct(unquote(__MODULE__))
+         end
+        ] |> index()
+    end
+
+    test "a fully qualified call to Kernel.struct/2 is ignored" do
+      assert {:ok, [], _} = ~q[
+         defmodule Parent do
+           struct = Kernel.struct(unquote(__MODULE__), foo: 3)
+         end
+        ] |> index()
+    end
+
+    test "a call to struct!/2 is ignored" do
+      assert {:ok, [], _} = ~q[
+         defmodule Parent do
+           struct = struct!(unquote(__MODULE__), foo: 3)
+         end
+        ] |> index()
+    end
+
+    test "a call to struct!/1 is ignored" do
+      assert {:ok, [], _} = ~q[
+         defmodule Parent do
+           struct = struct!(unquote(__MODULE__))
+         end
+        ] |> index()
+    end
+
+    test "a call to struct/1 is ignored" do
+      assert {:ok, [], _} = ~q[
+         defmodule Parent do
+           struct = struct(unquote(__MODULE__))
+         end
+        ] |> index()
+    end
+
+    test "a call to struct/2 is ignored" do
+      assert {:ok, [], _} = ~q[
+         defmodule Parent do
+           struct = struct(unquote(__MODULE__), foo: 3)
+         end
+        ] |> index()
+    end
+
+    test "a reference ignored" do
+      assert {:ok, [], _} = ~q[
+         defmodule Parent do
+           struct = %unquote(__MODULE__){}
+         end
+        ] |> index()
+    end
+  end
 end


### PR DESCRIPTION
Got a report of an indexer crash due to a case clause error in the reducer. It was caused by one of the struct clauses missing an else.

Fixes #573