### PR TITLE
Moved entity resolution to remote control

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -122,4 +122,8 @@ defmodule Lexical.RemoteControl.Api do
   def index_running?(%Project{} = project) do
     RemoteControl.call(project, Commands.Reindex, :running?, [])
   end
+
+  def resolve_entity(%Project{} = project, %Analysis{} = analysis, %Position{} = position) do
+    RemoteControl.call(project, CodeIntelligence.Entity, :resolve, [analysis, position])
+  end
 end


### PR DESCRIPTION
When performing a hover request, we called Entity.resolve, but this is not safe to call from the server project, because the entity cache is not available on the server node, so it will fail (and crash the provider queue). Moveing entity resolution to remote_control fixes the issue

Fixes #572