### PR TITLE
Struct discovery now uses the index

### DIFF
--- a/apps/common/lib/lexical/features.ex
+++ b/apps/common/lib/lexical/features.ex
@@ -1,2 +1,0 @@
-defmodule Lexical.Features do
-end

--- a/apps/common/lib/lexical/features.ex
+++ b/apps/common/lib/lexical/features.ex
@@ -1,7 +1,2 @@
 defmodule Lexical.Features do
-  @indexing_enabled "INDEXING_ENABLED" |> System.get_env("") |> String.trim() |> String.downcase()
-
-  def indexing_enabled? do
-    @indexing_enabled in ~w(1 true)
-  end
 end

--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -126,4 +126,8 @@ defmodule Lexical.RemoteControl.Api do
   def resolve_entity(%Project{} = project, %Analysis{} = analysis, %Position{} = position) do
     RemoteControl.call(project, CodeIntelligence.Entity, :resolve, [analysis, position])
   end
+
+  def struct_definitions(%Project{} = project) do
+    RemoteControl.call(project, CodeIntelligence.Structs, :for_project, [])
+  end
 end

--- a/apps/remote_control/lib/lexical/remote_control/api/messages.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api/messages.ex
@@ -39,6 +39,8 @@ defmodule Lexical.RemoteControl.Api.Messages do
 
   defrecord :struct_discovered, module: nil, fields: []
 
+  defrecord :project_index_ready, project: nil
+
   defrecord :project_reindex_requested, project: nil
 
   defrecord :project_reindexed, project: nil, elapsed_ms: 0, status: :success
@@ -122,6 +124,8 @@ defmodule Lexical.RemoteControl.Api.Messages do
           )
 
   @type struct_discovered :: record(:struct_discovered, module: module(), fields: field_list())
+
+  @type project_index_ready :: record(:project_index_ready, project: Lexical.Project.t())
 
   @type project_reindex_requested ::
           record(:project_reindex_requested, project: Lexical.Project.t())

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/structs.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/structs.ex
@@ -1,6 +1,5 @@
 defmodule Lexical.RemoteControl.CodeIntelligence.Structs do
   alias Lexical.RemoteControl
-
   alias Lexical.RemoteControl.Module.Loader
   alias Lexical.RemoteControl.Search.Indexer.Entry
   alias Lexical.RemoteControl.Search.Store
@@ -24,10 +23,8 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Structs do
       end
 
     for %Entry{subject: struct_module} <- entries,
-        Loader.ensure_loaded?(struct_module),
-        fields = struct_module.__info__(:struct),
-        is_list(fields) do
-      {struct_module, fields}
+        Loader.ensure_loaded?(struct_module) do
+      struct_module
     end
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/structs.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/structs.ex
@@ -13,9 +13,6 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Structs do
   end
 
   defp structs_from_index do
-    # This might be a performance / memory issue on larger projects. It
-    # iterates through all modules, loading each as necessary and then removing them
-    # if they're not already loaded to try and claw back some memory
     entries =
       case Store.exact(type: :struct, subtype: :definition) do
         {:ok, entries} -> entries

--- a/apps/remote_control/test/lexical/remote_control/build_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build_test.exs
@@ -37,6 +37,10 @@ defmodule Lexical.BuildTest do
     fixture_dir = Path.join(fixtures_path(), project_name)
     project = Project.new("file://#{fixture_dir}")
 
+    project
+    |> Project.workspace_path()
+    |> File.rm_rf()
+
     {:ok, _} = start_supervised({ProjectNodeSupervisor, project})
     {:ok, _, _} = RemoteControl.start_link(project)
     RemoteControl.Api.register_listener(project, self(), [:all])

--- a/apps/server/lib/lexical/server/project/intelligence.ex
+++ b/apps/server/lib/lexical/server/project/intelligence.ex
@@ -216,7 +216,7 @@ defmodule Lexical.Server.Project.Intelligence do
     {:ok, struct_definitions} = Api.struct_definitions(state.project)
 
     state =
-      Enum.reduce(struct_definitions, State.new(state.project), fn {module, _}, state ->
+      Enum.reduce(struct_definitions, State.new(state.project), fn module, state ->
         State.add_struct_module(state, module)
       end)
 

--- a/apps/server/lib/lexical/server/project/intelligence.ex
+++ b/apps/server/lib/lexical/server/project/intelligence.ex
@@ -167,7 +167,12 @@ defmodule Lexical.Server.Project.Intelligence do
 
   @impl GenServer
   def init([%Project{} = project]) do
-    Api.register_listener(project, self(), [module_updated(), struct_discovered()])
+    Api.register_listener(project, self(), [
+      project_index_ready(),
+      module_updated(),
+      struct_discovered()
+    ])
+
     state = State.new(project)
     {:ok, state}
   end
@@ -201,6 +206,20 @@ defmodule Lexical.Server.Project.Intelligence do
   @impl GenServer
   def handle_info(struct_discovered(module: module_name), %State{} = state) do
     state = State.add_struct_module(state, module_name)
+    {:noreply, state}
+  end
+
+  require Logger
+
+  @impl GenServer
+  def handle_info(project_index_ready(), %State{} = state) do
+    {:ok, struct_definitions} = Api.struct_definitions(state.project)
+
+    state =
+      Enum.reduce(struct_definitions, State.new(state.project), fn {module, _}, state ->
+        State.add_struct_module(state, module)
+      end)
+
     {:noreply, state}
   end
 

--- a/apps/server/lib/lexical/server/provider/handlers/code_lens.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/code_lens.ex
@@ -2,7 +2,6 @@ defmodule Lexical.Server.Provider.Handlers.CodeLens do
   alias Lexical.Document
   alias Lexical.Document.Position
   alias Lexical.Document.Range
-  alias Lexical.Features
   alias Lexical.Project
   alias Lexical.Protocol.Requests
   alias Lexical.Protocol.Responses
@@ -53,7 +52,7 @@ defmodule Lexical.Server.Provider.Handlers.CodeLens do
   defp show_reindex_lens?(%Project{} = project, %Document{} = document) do
     document_path = Path.expand(document.path)
 
-    Features.indexing_enabled?() and document_path == Project.mix_exs_path(project) and
+    document_path == Project.mix_exs_path(project) and
       not RemoteControl.Api.index_running?(project)
   end
 end

--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -1,6 +1,5 @@
 defmodule Lexical.Server.State do
   alias Lexical.Document
-  alias Lexical.Features
   alias Lexical.Protocol.Id
   alias Lexical.Protocol.Notifications
   alias Lexical.Protocol.Notifications.DidChange
@@ -288,7 +287,7 @@ defmodule Lexical.Server.State do
         document_formatting_provider: true,
         execute_command_provider: command_options,
         hover_provider: true,
-        references_provider: Features.indexing_enabled?(),
+        references_provider: true,
         text_document_sync: sync_options
       )
 

--- a/apps/server/test/lexical/server/provider/handlers/code_lens_test.exs
+++ b/apps/server/test/lexical/server/provider/handlers/code_lens_test.exs
@@ -33,7 +33,6 @@ defmodule Lexical.Server.Provider.Handlers.CodeLensTest do
   end
 
   defp with_indexing_enabled(_) do
-    patch(Lexical.Features, :indexing_enabled?, true)
     patch(Lexical.RemoteControl.Api, :index_running?, false)
     :ok
   end

--- a/apps/server/test/support/lexical/test/completion_case.ex
+++ b/apps/server/test/support/lexical/test/completion_case.ex
@@ -21,9 +21,14 @@ defmodule Lexical.Test.Server.CompletionCase do
     start_supervised!({DynamicSupervisor, Server.Project.Supervisor.options()})
     start_supervised!({Server.Project.Supervisor, project})
 
-    RemoteControl.Api.register_listener(project, self(), [project_compiled()])
+    RemoteControl.Api.register_listener(project, self(), [
+      project_compiled(),
+      project_index_ready()
+    ])
+
     RemoteControl.Api.schedule_compile(project, true)
     assert_receive project_compiled(), 5000
+    assert_receive project_index_ready(), 5000
     {:ok, project: project}
   end
 

--- a/pages/installation.md
+++ b/pages/installation.md
@@ -67,15 +67,6 @@ bug.
 For the following examples, assume the absolute path to your Lexical
 source code is `/my/home/projects/lexical`.
 
-### Enabling indexing
-
-We've recently added indexing support to lexical. This powers features like `find references` and will go on to power a host of other features. While we're continuting to 
-develop indexing, we've disabled it by default. If you want to enable indexing (and find references), build lexical like this:
-
-```shell
-INDEXING_ENABLED=true mix package
-```
-
 ## Editor-specific setup
 1. [Vanilla Emacs with lsp-mode](#vanilla-emacs-with-lsp-mode)
 2. [Vanilla Emacs with eglot](#vanilla-emacs-with-eglot)


### PR DESCRIPTION
Thehe last thing that used the forced build was struct discovery. Now that we index struct definitions, we can instead leverage the already built index, and not have to force compile projects when they start.

This has a tremendous impact on startup time. Lexical would take 11 seconds to compile on my system, and now it compiles in 1.9 seconds. The index is ready nearly instantly after that.

This does mean that this is a bit of a rubicon commit, after this, we rely on the index for core functionality, and we can't disable it. As such, I've removed the environment variable, and the feature flag.