### PR TITLE
Fixed bug due to elixir_sense upgrade

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
@@ -184,6 +184,10 @@ defmodule Lexical.RemoteControl.Completion.Candidate do
     Module.new(elixir_sense_map)
   end
 
+  def from_elixir_sense(%{type: :module, subtype: :alias} = elixir_sense_map) do
+    Module.new(elixir_sense_map)
+  end
+
   def from_elixir_sense(%{type: :module, subtype: :behaviour} = elixir_sense_map) do
     Behaviour.new(elixir_sense_map)
   end


### PR DESCRIPTION
When elixir_sense was upgraded, it added an :alias subtype for module completions, which we didn't handle, so all aliases failed to complete.