### PR TITLE
Handled module attributes in defimpl

### DIFF
--- a/apps/common/lib/lexical/ast.ex
+++ b/apps/common/lib/lexical/ast.ex
@@ -407,6 +407,10 @@ defmodule Lexical.Ast do
     end
   end
 
+  def reify_alias(current_module, []) do
+    {:ok, List.wrap(current_module)}
+  end
+
   # private
 
   defp do_string_to_quoted(string) when is_binary(string) do

--- a/apps/remote_control/lib/lexical/remote_control/analyzer.ex
+++ b/apps/remote_control/lib/lexical/remote_control/analyzer.ex
@@ -128,6 +128,32 @@ defmodule Lexical.RemoteControl.Analyzer do
     expand_alias([:__MODULE__], analysis, position)
   end
 
+  defp resolve_alias([{:@, _, [{:protocol, _, _}]} | rest], alias_mapping) do
+    with {:ok, protocol} <- Map.fetch(alias_mapping, :"@protocol") do
+      Ast.reify_alias(protocol, rest)
+    end
+  end
+
+  defp resolve_alias(
+         [{:__aliases__, _, [{:@, _, [{:protocol, _, _}]} | _] = protocol}],
+         alias_mapping
+       ) do
+    resolve_alias(protocol, alias_mapping)
+  end
+
+  defp resolve_alias([{:@, _, [{:for, _, _} | _]} | rest], alias_mapping) do
+    with {:ok, protocol_for} <- Map.fetch(alias_mapping, :"@for") do
+      Ast.reify_alias(protocol_for, rest)
+    end
+  end
+
+  defp resolve_alias(
+         [{:__aliases__, _, [{:@, _, [{:for, _, _}]} | _] = protocol_for}],
+         alias_mapping
+       ) do
+    resolve_alias(protocol_for, alias_mapping)
+  end
+
   defp resolve_alias([first | _] = segments, aliases_mapping) when is_tuple(first) do
     with {:ok, current_module} <- Map.fetch(aliases_mapping, :__MODULE__) do
       Ast.reify_alias(current_module, segments)

--- a/apps/remote_control/test/lexical/remote_control/analyzer/aliases_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/analyzer/aliases_test.exs
@@ -232,6 +232,19 @@ defmodule Lexical.RemoteControl.Analyzer.AliasesTest do
 
       assert aliases[:Else] == Something.Else
     end
+
+    test "in a protocol implementation" do
+      aliases =
+        ~q[
+      defimpl MyProtocol, for: Atom do
+        |
+      end
+      ]
+        |> aliases_at_cursor()
+
+      assert aliases[:"@protocol"] == MyProtocol
+      assert aliases[:"@for"] == Atom
+    end
   end
 
   describe "nested modules" do


### PR DESCRIPTION
Apparently, defimpls define two module attributes, `@protocol` and `@for`, which we completely missed during analysis.

Fixes #556