### PR TITLE
Removed select_all() from backend in favor of a reduce function

### DIFF
--- a/apps/common/lib/lexical/identifier.ex
+++ b/apps/common/lib/lexical/identifier.ex
@@ -7,4 +7,21 @@ defmodule Lexical.Identifier do
     {:ok, next_id} = Snowflake.next_id()
     next_id
   end
+
+  def to_unix(id) do
+    Snowflake.Util.real_timestamp_of_id(id)
+  end
+
+  def to_datetime(id) do
+    id
+    |> to_unix()
+    |> DateTime.from_unix!(:millisecond)
+  end
+
+  def to_erl(id) do
+    %DateTime{year: year, month: month, day: day, hour: hour, minute: minute, second: second} =
+      to_datetime(id)
+
+    {{year, month, day}, {hour, minute, second}}
+  end
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/store.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store.ex
@@ -44,10 +44,6 @@ defmodule Lexical.RemoteControl.Search.Store do
     GenServer.stop(__MODULE__)
   end
 
-  def all do
-    GenServer.call(__MODULE__, :all)
-  end
-
   def loaded? do
     GenServer.call(__MODULE__, :loaded?)
   end
@@ -182,10 +178,6 @@ defmodule Lexical.RemoteControl.Search.Store do
 
   def handle_call({:fuzzy, subject, constraints}, _from, {ref, %State{} = state}) do
     {:reply, State.fuzzy(state, subject, constraints), {ref, state}}
-  end
-
-  def handle_call(:all, _from, {ref, %State{} = state}) do
-    {:reply, State.all(state), {ref, state}}
   end
 
   def handle_call({:update, path, entries}, _from, {ref, %State{} = state}) do

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backend.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backend.ex
@@ -22,6 +22,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backend do
   @type subtype_query :: Entry.entry_subtype() | wildcard()
   @type block_structure :: %{Entry.block_id() => block_structure()} | %{}
   @type path_structures :: %{Path.t() => block_structure()}
+  @type accumulator :: any()
+  @type reducer_fun :: (Entry.t(), accumulator() -> accumulator())
 
   @doc """
   Create a new backend.
@@ -57,9 +59,9 @@ defmodule Lexical.RemoteControl.Search.Store.Backend do
   @callback destroy(Project.t()) :: :ok
 
   @doc """
-  Returns all entries currently residing in the backend
+  Applies a reducer function to the backend's entries
   """
-  @callback select_all() :: [Entry.t()]
+  @callback reduce(accumulator(), reducer_fun()) :: accumulator()
 
   @doc """
   Replaces all the entries in the store with those passed in

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
@@ -45,8 +45,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
   end
 
   @impl Backend
-  def select_all do
-    GenServer.call(genserver_name(), {:select_all, []})
+  def reduce(acc, reducer_fun) do
+    GenServer.call(genserver_name(), {:reduce, [acc, reducer_fun]}, :infinity)
   end
 
   @impl Backend

--- a/apps/remote_control/lib/lexical/remote_control/search/store/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/state.ex
@@ -101,10 +101,6 @@ defmodule Lexical.RemoteControl.Search.Store.State do
     end
   end
 
-  def all(%__MODULE__{} = state) do
-    state.backend.select_all()
-  end
-
   def siblings(%__MODULE__{} = state, entry) do
     state.backend.siblings(entry)
   end
@@ -169,7 +165,7 @@ defmodule Lexical.RemoteControl.Search.Store.State do
 
           {:ok, :stale} ->
             Logger.info("backend reports stale")
-            {:update_index, state.update_index.(state.project, all(state))}
+            {:update_index, state.update_index.(state.project, state.backend)}
 
           {:error, :not_leader} ->
             :initialize_fuzzy

--- a/apps/remote_control/test/lexical/remote_control/search/store_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store_test.exs
@@ -35,6 +35,12 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
     {:ok, project: project}
   end
 
+  def all_entries(backend) do
+    []
+    |> backend.reduce(fn entry, acc -> [entry | acc] end)
+    |> Enum.reverse()
+  end
+
   for backend <- @backends,
       backend_name = backend |> Module.split() |> List.last() do
     describe "#{backend_name} :: replace/1" do
@@ -46,7 +52,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
         entries = [definition(subject: OtherModule)]
 
         Store.replace(entries)
-        assert entries == Store.all()
+        assert entries == all_entries(unquote(backend))
       end
     end
 
@@ -125,7 +131,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
 
         Store.update(path, updated)
 
-        assert_eventually [remaining] = Store.all()
+        assert_eventually [remaining] = all_entries(unquote(backend))
         refute remaining.id in [1, 2]
       end
 
@@ -144,7 +150,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
 
         Store.update(updated_path, updated)
 
-        assert_eventually [first, second] = Store.all()
+        assert_eventually [first, second] = all_entries(unquote(backend))
 
         assert first.id in [3, 4]
         assert second.id in [3, 4]


### PR DESCRIPTION
There are several places where we're pulling all the entries from the backend, processing them and throwing them out. This creates memory pressure on every process involved in handing the entries.

Instead of that, it makes more sense to expose a reduce function inside the backend that allows you to process the entries however you want, and only the data you care about is pulled through the processes.

This saves around 250mb running the lexical project on my laptop.