### PR TITLE
Removed updated_at from the entry struct

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
@@ -14,8 +14,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
     :range,
     :subject,
     :subtype,
-    :type,
-    :updated_at
+    :type
   ]
 
   @type t :: %__MODULE__{
@@ -25,9 +24,10 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
           path: Path.t(),
           range: Lexical.Document.Range.t(),
           subtype: entry_subtype(),
-          type: entry_type(),
-          updated_at: :calendar.datetime()
+          type: entry_type()
         }
+  @type datetime_format :: :erl | :unix | :datetime
+  @type date_type :: :calendar.datetime() | integer() | DateTime.t()
 
   alias Lexical.Identifier
   alias Lexical.RemoteControl.Search.Indexer.Source.Block
@@ -43,8 +43,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
       path: path,
       subject: structure,
       type: :metadata,
-      subtype: :block_structure,
-      updated_at: timestamp()
+      subtype: :block_structure
     }
   end
 
@@ -81,8 +80,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
       range: range,
       subject: subject,
       subtype: subtype,
-      type: type,
-      updated_at: timestamp()
+      type: type
     }
   end
 
@@ -90,7 +88,19 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
     is_block(entry)
   end
 
-  defp timestamp do
-    :calendar.universal_time()
+  @spec updated_at(t()) :: date_type()
+  @spec updated_at(t(), datetime_format) :: date_type()
+  def updated_at(entry, format \\ :erl)
+
+  def updated_at(%__MODULE__{id: id} = entry, format) when is_integer(id) do
+    case format do
+      :erl -> Identifier.to_erl(entry.id)
+      :unix -> Identifier.to_unix(id)
+      :datetime -> Identifier.to_datetime(id)
+    end
+  end
+
+  def updated_at(%__MODULE__{}, _format) do
+    nil
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/search/indexer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer_test.exs
@@ -1,6 +1,7 @@
 defmodule Lexical.RemoteControl.Search.IndexerTest do
   alias Lexical.Project
   alias Lexical.RemoteControl.Search.Indexer
+  alias Lexical.RemoteControl.Search.Indexer.Entry
 
   use ExUnit.Case
   use Patch
@@ -96,9 +97,11 @@ defmodule Lexical.RemoteControl.Search.IndexerTest do
       entries: entries,
       file_path: file_path
     } do
-      path_to_mtime = Map.new(entries, & &1.updated_at)
+      entries = Enum.reject(entries, &is_nil(&1.id))
+      path_to_mtime = Map.new(entries, fn entry -> {entry.path, Entry.updated_at(entry)} end)
+
       [entry | _] = entries
-      {{year, month, day}, hms} = entry.updated_at
+      {{year, month, day}, hms} = Entry.updated_at(entry)
       old_mtime = {{year - 1, month, day}, hms}
 
       patch(Indexer, :stat, fn path ->


### PR DESCRIPTION
The id on the entry struct can be used to calculate the updated at, since it's a snowflake.

This saves around 10mb on-disk, and around as much in-memory.