### PR TITLE
Disabled fuzzy matcher

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/store/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/state.ex
@@ -230,10 +230,7 @@ defmodule Lexical.RemoteControl.Search.Store.State do
   end
 
   defp initialize_fuzzy(%__MODULE__{} = state) do
-    fuzzy =
-      state
-      |> all()
-      |> Fuzzy.from_entries()
+    fuzzy = Fuzzy.from_entries([])
 
     %__MODULE__{state | fuzzy: fuzzy}
   end


### PR DESCRIPTION
We're not presently using the fuzzy matcher, and it takes up quite a bit of memory in its current incarnation (hundreds of megs).

We'll need it when we do document and workspace symbols, and we'll need to tune it then.