### PR TITLE
Made indexer return streams rather than lists

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/progress.ex
+++ b/apps/remote_control/lib/lexical/remote_control/progress.ex
@@ -2,33 +2,66 @@ defmodule Lexical.RemoteControl.Progress do
   alias Lexical.RemoteControl.Dispatch
   import Lexical.RemoteControl.Api.Messages
 
+  @type label :: String.t()
+  @type message :: String.t()
+
+  @type delta :: pos_integer()
+  @type on_complete_callback :: (() -> any())
+  @type report_progress_callback :: (delta(), message() -> any())
+
   defmacro __using__(_) do
     quote do
       import unquote(__MODULE__), only: [with_progress: 2]
     end
   end
 
+  @spec with_progress(label(), (() -> any())) :: any()
   def with_progress(label, func) when is_function(func, 0) do
+    on_complete = begin_progress(label)
+
     try do
-      Dispatch.broadcast(project_progress(label: label, stage: :begin))
       func.()
     after
+      on_complete.()
+    end
+  end
+
+  @spec with_percent_progress(label(), pos_integer(), (report_progress_callback() -> any())) ::
+          any()
+  def with_percent_progress(label, max, func) when is_function(func, 1) do
+    {report_progress, on_complete} = begin_percent(label, max)
+
+    try do
+      func.(report_progress)
+    after
+      on_complete.()
+    end
+  end
+
+  @spec begin_progress(label :: label()) :: on_complete_callback()
+  def begin_progress(label) do
+    Dispatch.broadcast(project_progress(label: label, stage: :begin))
+
+    fn ->
       Dispatch.broadcast(project_progress(label: label, stage: :complete))
     end
   end
 
-  def with_percent_progress(label, max, func) when is_function(func, 1) do
+  @spec begin_percent(label(), pos_integer()) ::
+          {report_progress_callback(), on_complete_callback()}
+  def begin_percent(label, max) do
+    Dispatch.broadcast(percent_progress(label: label, max: max, stage: :begin))
+
     report_progress = fn delta, message ->
       Dispatch.broadcast(
         percent_progress(label: label, message: message, delta: delta, stage: :report)
       )
     end
 
-    try do
-      Dispatch.broadcast(percent_progress(label: label, max: max, stage: :begin))
-      func.(report_progress)
-    after
+    complete = fn ->
       Dispatch.broadcast(percent_progress(label: label, stage: :complete))
     end
+
+    {report_progress, complete}
   end
 end

--- a/apps/server/lib/lexical/server/project/progress/state.ex
+++ b/apps/server/lib/lexical/server/project/progress/state.ex
@@ -63,7 +63,14 @@ defmodule Lexical.Server.Project.Progress.State do
     {progress, progress_by_label} =
       Map.get_and_update(state.progress_by_label, label, fn _ -> :pop end)
 
-    progress |> Value.complete(message) |> write()
+    case progress do
+      %Value{} = progress ->
+        progress |> Value.complete(message) |> write
+
+      _ ->
+        :ok
+    end
+
     %__MODULE__{state | progress_by_label: progress_by_label}
   end
 
@@ -71,7 +78,13 @@ defmodule Lexical.Server.Project.Progress.State do
     {progress, progress_by_label} =
       Map.get_and_update(state.progress_by_label, label, fn _ -> :pop end)
 
-    progress |> Percentage.complete(message) |> write()
+    case progress do
+      %Percentage{} = progress ->
+        progress |> Percentage.complete(message) |> write()
+
+      nil ->
+        :ok
+    end
 
     %__MODULE__{state | progress_by_label: progress_by_label}
   end


### PR DESCRIPTION
The indexer would return a list of entries, and these entries were sent across process boundaries regularly (in the store, and in the reindex action), which would cause their memory usage to swell.

Returning a stream alleviates this pressure, and reduces the memory used by on the lexical project from 425Mb to 290Mb, a fairly significant savings.

Fixes #597