### PR TITLE
Bumped garbage collection for some of our more intensive processes

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/commands/reindex.ex
+++ b/apps/remote_control/lib/lexical/remote_control/commands/reindex.ex
@@ -101,6 +101,7 @@ defmodule Lexical.RemoteControl.Commands.Reindex do
 
   @impl GenServer
   def init(reindex_fun) do
+    Process.flag(:fullsweep_after, 5)
     {:ok, State.new(reindex_fun)}
   end
 

--- a/apps/remote_control/lib/lexical/remote_control/search/store.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store.ex
@@ -113,6 +113,7 @@ defmodule Lexical.RemoteControl.Search.Store do
 
   @impl GenServer
   def init([%Project{} = project, create_index, update_index, backend]) do
+    Process.flag(:fullsweep_after, 5)
     # I've found that if indexing happens before the first compile, for some reason
     # the compilation is 4x slower than if indexing happens after it. I was
     # unable to figure out why this is the case, and I looked extensively, so instead

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
@@ -102,6 +102,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
 
   @impl GenServer
   def init([%Project{} = project]) do
+    Process.flag(:fullsweep_after, 5)
     :ok = connect_to_project_nodes(project)
     {:ok, project, {:continue, :try_for_leader}}
   end


### PR DESCRIPTION
These processes weren't getting GC'd very often, because they're not _that_ busy. Tuning the GC interval makes them take up less memory without having to manually trigger GC on a schedule.

Fixes #599