### PR TITLE
Detected module references using __MODULE__

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module.ex
@@ -151,7 +151,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Module do
   defp module_part?({:@, _, [{type, _, _} | _]}) when type in @protocol_module_attribue_names,
     do: true
 
-  defp module_part?({:__MODULE__, _, _}), do: true
+  defp module_part?({:__MODULE__, _, context}) when is_atom(context), do: true
 
   defp module_part?(_), do: false
 

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/module_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/module_test.exs
@@ -437,5 +437,19 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ModuleTest do
       assert child.type == :module
       assert child.subtype == :definition
     end
+
+    test "works with __MODULE__ alias concatenations" do
+      {:ok, [_, child], _} =
+        ~q[
+        defmodule Parent do
+          @child_module __MODULE__.Child
+        end
+        ]
+        |> index()
+
+      assert child.type == :module
+      assert child.subtype == :reference
+      assert child.subject == Parent.Child
+    end
   end
 end


### PR DESCRIPTION
We were not detecting a module reference if it used __MODULE__, as in `__MODULE__.Child`. This was due to not recognizing the AST for `__MODULE__` as being a constituent part of a module reference.

Fixes #602