### PR TITLE
Calling find references on a `defstruct` call finds defined structs

### DIFF
--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/references_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/references_test.exs
@@ -132,6 +132,23 @@ defmodule Lexical.RemoteControl.CodeIntelligence.ReferencesTest do
       assert decorate(code, location.range) =~ "«defstruct [:field]»"
     end
 
+    test "includes references if defstruct is selected", %{project: project} do
+      code = ~q[
+        defmodule UsesStruct do
+          def something(%Struct{}) do
+          end
+        end
+      ]
+
+      selector = ~q(
+      defmodule Struct do
+        defstruc|t [:name, :value]
+      end
+      )
+      assert {:ok, [location]} = references(project, selector, code)
+      assert decorate(code, location.range) =~ "def something(«%Struct{}») do"
+    end
+
     test "excludes their definition", %{project: project} do
       code = ~q(
       defmodule Struct do


### PR DESCRIPTION
When you call find references while hovering over `defstruct` calls, it finds references to the struct that the current module defines. Prior, it would result in no results because we don't index defstruct calls.

Fixes #570