### PR TITLE
Removed -e option

### DIFF
--- a/bin/start_lexical.sh
+++ b/bin/start_lexical.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -o pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 


### PR DESCRIPTION
The -e option exits immediately on an error, which will cause the command to exit if no version manager is detected. This means we won't try to invoke elixir from the path.

From my limited knowledge of bash, it looks like this command was added in error.

Fixes #615