### PR TITLE
chore: prepare scripts for updating Nix hash by non-Nix users

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: DeterminateSystems/nix-installer-action@main
     - uses: DeterminateSystems/magic-nix-cache-action@main
     - run: |
-        nix build --no-link .#__fodHashGen 2>&1 | awk '/gen:/ { print $2 }' > nix/hash
+        nix run .#update-hash
         git config user.email ""
         git config user.name "GitHub Action Bot"
         git commit -m 'Update Nix hash of Mix deps' nix/hash && git push || true

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,22 @@
       in {
         formatter = pkgs.alejandra;
 
+        apps.update-hash = let
+          script = pkgs.writeShellApplication {
+            name = "update-hash";
+
+            runtimeInputs = [ pkgs.nixFlakes pkgs.gawk ];
+
+            text = ''
+              nix --extra-experimental-features 'nix-command flakes' \
+                build --no-link "${self}#__fodHashGen" 2>&1 | gawk '/got:/ { print $2 }'
+            '';
+          };
+        in {
+          type = "app";
+          program = "${script}/bin/update-hash";
+        };
+
         packages = {
           inherit lexical;
           default = lexical;

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,17 @@ defmodule Lexical.LanguageServer.MixProject do
     [
       compile: "compile --docs --debug-info",
       docs: "docs --html",
-      test: "test --no-start"
+      test: "test --no-start",
+      "nix.hash": &nix_hash/1
     ]
+  end
+
+  defp nix_hash(_args) do
+    docker = System.get_env("DOCKER_CMD", "docker")
+
+    Mix.shell().cmd(
+      "#{docker} run --rm -v '#{File.cwd!()}:/data' nixos/nix nix --extra-experimental-features 'nix-command flakes' run ./data#update-hash",
+      stderr_to_stdout: false
+    )
   end
 end

--- a/nix/hash
+++ b/nix/hash
@@ -1,1 +1,1 @@
-sha256-kPJh27e82QdAq5vxKZyv9brOkB82crLmEtYLwXEkOsM=
+sha256-G0mT+rvXZWLJIMfrhxq3TXt26wDImayu44wGEYJ+3CE=


### PR DESCRIPTION
This adds `mix nix.hash` command meant to be used by non-Nix users to generate new Nix hash by running build script in Docker. This commands prints out new hash that need to be pasted into `nix/hash` file. It uses Docker and accepts `DOCKER_CMD` environment variable to direct to alternative Docker-compatible executable (like Podman or Nerdctl).