### PR TITLE
Fixed unused variable code action

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build/error.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/error.ex
@@ -50,7 +50,7 @@ defmodule Lexical.RemoteControl.Build.Error do
 
   defp format_message("undefined" <> _ = message) do
     # All undefined function messages explain the *same* thing inside the parentheses
-    message |> String.replace(@undefined_function_pattern, "") |> format_token()
+    String.replace(message, @undefined_function_pattern, "")
   end
 
   defp format_message(message) when is_binary(message) do
@@ -61,15 +61,11 @@ defmodule Lexical.RemoteControl.Build.Error do
     # Same reason as the `undefined` message above, we can remove the things in parentheses
     case String.split(message, "is unused (", parts: 2) do
       [prefix, _] ->
-        format_token(prefix) <> "is unused"
+        prefix <> "is unused"
 
       _ ->
         message
     end
-  end
-
-  defp format_token(string_contains_token) do
-    String.replace(string_contains_token, "\"", "`")
   end
 
   @doc """

--- a/apps/remote_control/test/lexical/remote_control/build/document/compilers/eex_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/document/compilers/eex_test.exs
@@ -97,7 +97,7 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EExTest do
                |> document_with_content()
                |> compile()
 
-      assert result.message =~ ~s[`something` is unused]
+      assert result.message =~ ~s["something" is unused]
       assert result.position in [1, {1, 5}]
       assert result.severity == :warning
       assert result.source == "EEx"
@@ -115,7 +115,7 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EExTest do
 
       assert {:ok, [%Result{} = result]} = compile(document)
 
-      assert result.message == ~s[variable `something` is unused]
+      assert result.message == ~s[variable "something" is unused]
       assert decorate(document, result.position) == "<%= «something» = 6 %>"
       assert result.severity == :warning
       assert result.source == "EEx"
@@ -147,7 +147,7 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EExTest do
       assert {:error, [%Result{} = result]} = compile(document)
 
       if Features.with_diagnostics?() do
-        assert result.message =~ "undefined variable `thing`"
+        assert result.message =~ "undefined variable \"thing\""
       else
         assert result.message =~ "undefined function thing/0"
       end
@@ -167,7 +167,7 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EExTest do
 
       assert {:error, [%Result{} = result]} = compile(document)
 
-      assert result.message == "undefined variable `thing`"
+      assert result.message == "undefined variable \"thing\""
       assert decorate(document, result.position) == "<%= «thing» %>"
       assert result.severity == :error
       assert result.source == "EEx"

--- a/apps/remote_control/test/lexical/remote_control/build/document/compilers/heex_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/document/compilers/heex_test.exs
@@ -63,7 +63,7 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.HeexTest do
       assert {:error, [%Result{} = result]} = compile(document)
 
       if Features.with_diagnostics?() do
-        assert result.message =~ ~S[undefined variable `thing`]
+        assert result.message =~ ~S[undefined variable "thing"]
       else
         assert result.message =~ "undefined function thing/0"
         assert result.position in [1, {1, 10}]

--- a/apps/remote_control/test/lexical/remote_control/build/error_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/error_test.exs
@@ -67,8 +67,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     @feature_condition span_in_diagnostic?: false
     @tag execute_if(@feature_condition)
     test "handles undefined variable" do
-      document_text =
-        ~S[
+      document_text = ~S[
         defmodule Foo do
           def bar do
             a
@@ -81,15 +80,14 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
         |> compile()
         |> diagnostic()
 
-      assert diagnostic.message in [~s[undefined variable `a`], ~s[undefined function a/0]]
+      assert diagnostic.message in [~s[undefined variable "a"], ~s[undefined function a/0]]
       assert decorate(document_text, diagnostic.position) =~ "«a\n»"
     end
 
     @feature_condition span_in_diagnostic?: true
     @tag execute_if(@feature_condition)
     test "handles undefined variable when #{inspect(@feature_condition)}" do
-      document_text =
-        ~S[
+      document_text = ~S[
         defmodule Foo do
           def bar do
             a
@@ -102,15 +100,14 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
         |> compile()
         |> diagnostic()
 
-      assert diagnostic.message == ~s[undefined variable `a`]
+      assert diagnostic.message == ~s[undefined variable "a"]
       assert decorate(document_text, diagnostic.position) =~ "«a»"
     end
 
     @feature_condition span_in_diagnostic?: false
     @tag execute_if(@feature_condition)
     test "handles unsued variable warning" do
-      document_text =
-        ~S[
+      document_text = ~S[
         defmodule Foo do
           def bar do
             a = 1
@@ -123,15 +120,14 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
         |> compile()
         |> diagnostic()
 
-      assert diagnostic.message =~ ~s[variable `a` is unused]
+      assert diagnostic.message =~ ~s[variable "a" is unused]
       assert decorate(document_text, diagnostic.position) =~ "«a = 1\n»"
     end
 
     @feature_condition span_in_diagnostic?: true
     @tag execute_if(@feature_condition)
     test "handles unsued variable warning when #{inspect(@feature_condition)}" do
-      document_text =
-        ~S[
+      document_text = ~S[
         defmodule Foo do
           def bar do
             a = 1
@@ -144,15 +140,14 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
         |> compile()
         |> diagnostic()
 
-      assert diagnostic.message == ~s[variable `a` is unused]
+      assert diagnostic.message == ~s[variable "a" is unused]
       assert decorate(document_text, diagnostic.position) =~ "«a»"
     end
 
     @feature_condition span_in_diagnostic?: false
     @tag execute_if(@feature_condition)
     test "handles unused function warning" do
-      document_text =
-        ~S[
+      document_text = ~S[
         defmodule UnusedDefp do
           defp unused do
           end
@@ -173,8 +168,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     @feature_condition span_in_diagnostic?: true
     @tag execute_if(@feature_condition)
     test "handles unused function warning when #{inspect(@feature_condition)}" do
-      document_text =
-        ~S[
+      document_text = ~S[
         defmodule UnusedDefp do
           defp unused do
           end
@@ -193,8 +187,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     end
 
     test "handles FunctionClauseError" do
-      document_text =
-        ~S[
+      document_text = ~S[
         defmodule Foo do
           def add(a, b) when is_integer(a) and is_integer(b) do
             a + b
@@ -216,8 +209,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     end
 
     test "handles UndefinedError for erlang moudle" do
-      document_text =
-        ~S[
+      document_text = ~S[
         defmodule Foo do
          :slave.stop
         end
@@ -233,8 +225,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     end
 
     test "handles UndefinedError for erlang function without defined module" do
-      document_text =
-        ~S[
+      document_text = ~S[
 
          :slave.stop(:name, :name)
         ]
@@ -252,8 +243,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     @feature_condition span_in_diagnostic?: false
     @tag execute_if(@feature_condition)
     test "handles UndefinedError" do
-      document_text =
-        ~S[
+      document_text = ~S[
         defmodule Foo do
           def bar do
             print(:bar)
@@ -275,8 +265,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     @feature_condition span_in_diagnostic?: true
     @tag execute_if(@feature_condition)
     test "handles UndefinedError when #{inspect(@feature_condition)}" do
-      document_text =
-        ~S[
+      document_text = ~S[
         defmodule Foo do
           def bar do
             print(:bar)
@@ -298,8 +287,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     @feature_condition span_in_diagnostic?: false
     @tag execute_if(@feature_condition)
     test "handles multiple UndefinedError in one line" do
-      document_text =
-        ~S/
+      document_text = ~S/
         defmodule Foo do
           def bar do
             [print(:bar), a, b]
@@ -319,8 +307,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     @feature_condition span_in_diagnostic?: true
     @tag execute_if(@feature_condition)
     test "handles multiple UndefinedError in one line when #{inspect(@feature_condition)}" do
-      document_text =
-        ~S/
+      document_text = ~S/
         defmodule Foo do
           def bar do
             [print(:bar), a, b]
@@ -333,10 +320,10 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
         |> compile()
         |> diagnostics()
 
-      assert a.message == ~s[undefined variable `a`]
+      assert a.message == ~s[undefined variable "a"]
       assert decorate(document_text, a.position) =~ "«a»"
 
-      assert b.message == ~s[undefined variable `b`]
+      assert b.message == ~s[undefined variable "b"]
       assert decorate(document_text, b.position) =~ "«b»"
 
       assert func_diagnotic.message == ~s[undefined function print/1]
@@ -344,8 +331,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     end
 
     test "handles UndefinedError without moudle" do
-      document_text =
-        ~S[
+      document_text = ~S[
 
           IO.ins
         ]
@@ -387,8 +373,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     end
 
     test "handles ArgumentError when in module" do
-      document_text =
-        ~s[
+      document_text = ~s[
         defmodule Foo do
           :a |> {1, 2}
         end
@@ -406,8 +391,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     end
 
     test "handles ArgumentError when in function" do
-      document_text =
-        ~s[
+      document_text = ~s[
         defmodule Foo do
           def foo do
             :a |> {1, 2}
@@ -444,8 +428,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     end
 
     test "handles Protocol.UndefinedError for comprehension" do
-      document_text =
-        ~S[
+      document_text = ~S[
         defmodule Foo do
           for i <- 1, do: i
         end]
@@ -460,8 +443,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     end
 
     test "handles Protocol.UndefinedError for comprehension when no module" do
-      document_text =
-        ~S[
+      document_text = ~S[
           for i <- 1, do: i
         ]
 
@@ -475,8 +457,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     end
 
     test "handles RuntimeError" do
-      document_text =
-        ~S[defmodule Foo do
+      document_text = ~S[defmodule Foo do
         raise RuntimeError.exception("This is a runtime error")
       end
       ]
@@ -493,8 +474,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     end
 
     test "handles ExUnit.DuplicateTestError" do
-      document_text =
-        ~s[
+      document_text = ~s[
         defmodule FooTest do
           use ExUnit.Case, async: true
 
@@ -518,8 +498,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     end
 
     test "handles ExUnit.DuplicateDescribeError" do
-      document_text =
-        ~s[
+      document_text = ~s[
 
         defmodule FooTest do
           use ExUnit.Case, async: true
@@ -548,8 +527,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     end
 
     test "handles struct `KeyError` when is in a function block" do
-      document_text =
-        ~s(
+      document_text = ~s(
         defmodule Foo do
           defstruct [:a, :b]
         end
@@ -573,8 +551,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     @feature_condition span_in_diagnostic?: false
     @tag execute_if(@feature_condition)
     test "handles struct `CompileError` when is in a function params" do
-      document_text =
-        ~S/
+      document_text = ~S/
         defmodule Foo do
           defstruct [:a, :b]
         end
@@ -603,8 +580,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     @feature_condition span_in_diagnostic?: true
     @tag execute_if(@feature_condition)
     test "handles struct `CompileError` when is in a function params and #{inspect(@feature_condition)}" do
-      document_text =
-        ~S/
+      document_text = ~S/
         defmodule Foo do
           defstruct [:a, :b]
         end
@@ -623,13 +599,12 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
       assert unknown.message == "unknown key :c for struct Foo"
       assert decorate(document_text, unknown.position) =~ "def bar(«%Foo{c: c}) do\n»"
 
-      assert undefined.message == "variable `c` is unused"
+      assert undefined.message == "variable \"c\" is unused"
       assert decorate(document_text, undefined.position) =~ "def bar(%Foo{c: «c»}) do"
     end
 
     test "handles struct enforce key error" do
-      document_text =
-        ~s(
+      document_text = ~s(
         defmodule Foo do
           @enforce_keys [:a, :b]
           defstruct [:a, :b]
@@ -654,8 +629,7 @@ defmodule Lexical.RemoteControl.Build.ErrorTest do
     end
 
     test "handles record missing key's error" do
-      document_text =
-        ~s[
+      document_text = ~s[
         defmodule Bar do
           import Record
           defrecord :user, name: nil, age: nil

--- a/apps/remote_control/test/lexical/remote_control/build_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build_test.exs
@@ -288,7 +288,7 @@ defmodule Lexical.BuildTest do
 
       assert diagnostic.uri
       assert diagnostic.severity == :warning
-      assert diagnostic.message =~ ~S[variable `unused` is unused]
+      assert diagnostic.message =~ ~S[variable "unused" is unused]
 
       if Features.with_diagnostics?() do
         assert diagnostic.position == {4, 13}
@@ -321,7 +321,7 @@ defmodule Lexical.BuildTest do
         assert diagnostic.severity == :error
 
         assert diagnostic.message =~
-                 ~s[undefined variable `calc`]
+                 ~s[undefined variable "calc"]
 
         assert diagnostic.position == {4, 13}
       else


### PR DESCRIPTION
The quote character around the variable name was changed, this broke the code action for replace unused variables.