### PR TITLE
Refactor search store queries `exact/2` and `fuzzy/2` for simplicity

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/references.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/references.ex
@@ -15,9 +15,12 @@ defmodule Lexical.RemoteControl.CodeIntelligence.References do
     with {:ok, resolved, _range} <- Entity.resolve(analysis, position) do
       resolved = maybe_rewrite_resolution(resolved, analysis, position)
 
-      resolved
-      |> maybe_rewrite_resolution(analysis, position)
-      |> find_references(include_definitions?)
+      references =
+        resolved
+        |> maybe_rewrite_resolution(analysis, position)
+        |> find_references(include_definitions?)
+
+      {:ok, references}
     end
   end
 
@@ -71,10 +74,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.References do
   end
 
   defp query(subject, opts) do
-    with {:ok, entities} <- Store.exact(subject, opts) do
-      locations = Enum.map(entities, &to_location/1)
-      {:ok, locations}
-    end
+    subject |> Store.exact(opts) |> Enum.map(&to_location/1)
   end
 
   defp subtype(true = _include_definitions?), do: :_

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/structs.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/structs.ex
@@ -13,13 +13,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Structs do
   end
 
   defp structs_from_index do
-    entries =
-      case Store.exact(type: :struct, subtype: :definition) do
-        {:ok, entries} -> entries
-        _ -> []
-      end
-
-    for %Entry{subject: struct_module} <- entries,
+    for %Entry{subject: struct_module} <- Store.exact(type: :struct, subtype: :definition),
         Loader.ensure_loaded?(struct_module) do
       struct_module
     end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/state.ex
@@ -85,19 +85,18 @@ defmodule Lexical.RemoteControl.Search.Store.State do
   def exact(%__MODULE__{} = state, subject, constraints) do
     type = Keyword.get(constraints, :type, :_)
     subtype = Keyword.get(constraints, :subtype, :_)
-    results = state.backend.find_by_subject(subject, type, subtype)
-    {:ok, results}
+    state.backend.find_by_subject(subject, type, subtype)
   end
 
   def fuzzy(%__MODULE__{} = state, subject, constraints) do
     case Fuzzy.match(state.fuzzy, subject) do
       [] ->
-        {:ok, []}
+        []
 
       ids ->
         type = Keyword.get(constraints, :type, :_)
         subtype = Keyword.get(constraints, :subtype, :_)
-        {:ok, state.backend.find_by_ids(ids, type, subtype)}
+        state.backend.find_by_ids(ids, type, subtype)
     end
   end
 

--- a/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
@@ -62,7 +62,7 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
 
       assert {:ok, _} = Indexing.on_event(file_compile_requested(uri: uri), state)
 
-      assert_eventually {:ok, [entry]} = Search.Store.exact("NewModule", [])
+      assert_eventually [entry] = Search.Store.exact("NewModule", [])
 
       assert entry.subject == NewModule
     end
@@ -86,9 +86,9 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
 
       assert {:ok, _} = Indexing.on_event(file_compile_requested(uri: uri), state)
 
-      assert_eventually {:ok, [entry]} = Search.Store.exact("UpdatedModule", [])
+      assert_eventually [entry] = Search.Store.exact("UpdatedModule", [])
       assert entry.subject == UpdatedModule
-      assert {:ok, []} = Search.Store.exact("OldModule", [])
+      assert [] = Search.Store.exact("OldModule", [])
     end
 
     test "only updates entries if the version of the document is the same as the version in the document store",
@@ -103,7 +103,7 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
         |> set_document!()
 
       assert {:ok, _} = Indexing.on_event(file_compile_requested(uri: uri), state)
-      assert {:ok, []} = Search.Store.exact("Stale", [])
+      assert [] = Search.Store.exact("Stale", [])
     end
   end
 
@@ -119,14 +119,14 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
       {:ok, entries} = Search.Indexer.Source.index(uri, source)
       Search.Store.update(uri, entries)
 
-      assert_eventually {:ok, [_]} = Search.Store.exact("ToDelete", [])
+      assert_eventually [_] = Search.Store.exact("ToDelete", [])
 
       Indexing.on_event(
         filesystem_event(project: project, uri: uri, event_type: :deleted),
         state
       )
 
-      assert_eventually {:ok, []} = Search.Store.exact("ToDelete", [])
+      assert_eventually [] = Search.Store.exact("ToDelete", [])
     end
   end
 

--- a/apps/remote_control/test/lexical/remote_control/search/store_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store_test.exs
@@ -67,7 +67,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           reference(id: 3)
         ])
 
-        assert {:ok, [ref]} = Store.exact(subtype: :reference)
+        assert [ref] = Store.exact(subtype: :reference)
         assert ref.subtype == :reference
       end
 
@@ -78,7 +78,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           definition(subject: Foo.Bar.Baz)
         ])
 
-        assert {:ok, [ref]} = Store.exact("Foo.Bar.Baz", subtype: :reference)
+        assert [ref] = Store.exact("Foo.Bar.Baz", subtype: :reference)
 
         assert ref.subject == Foo.Bar.Baz
         assert ref.type == :module
@@ -91,7 +91,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           definition(id: 2, subject: Foo.Bar.Bak)
         ])
 
-        assert {:ok, [entry]} = Store.exact("Foo.Bar.Baz", type: :module, subtype: :definition)
+        assert [entry] = Store.exact("Foo.Bar.Baz", type: :module, subtype: :definition)
 
         assert entry.subject == Foo.Bar.Baz
         assert entry.id == 1
@@ -104,7 +104,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           definition(id: 3, subject: Bad.Times.Now)
         ])
 
-        assert {:ok, [entry_1, entry_2]} =
+        assert [entry_1, entry_2] =
                  Store.fuzzy("Foo.Bar.B", type: :module, subtype: :definition)
 
         assert entry_1.subject in [Foo.Bar.Baz, Foo.Bar.Bak]
@@ -167,7 +167,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           reference(id: 2, subject: Present, path: path)
         ])
 
-        assert_eventually {:ok, [found]} = Store.fuzzy("Pres", type: :module, subtype: :reference)
+        assert_eventually [found] = Store.fuzzy("Pres", type: :module, subtype: :reference)
         assert found.id == 2
         assert found.subject == Present
       end


### PR DESCRIPTION
Eliminated `{:ok, entries}` tuple wrappers for search outcomes and references, directly returning `entries`