### PR TITLE
Add prefix search functionality to the search store

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/store.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store.ex
@@ -56,6 +56,10 @@ defmodule Lexical.RemoteControl.Search.Store do
     GenServer.call(__MODULE__, {:exact, subject, constraints})
   end
 
+  def prefix(prefix, constraints) do
+    GenServer.call(__MODULE__, {:prefix, prefix, constraints})
+  end
+
   def parent(%Entry{} = entry) do
     GenServer.call(__MODULE__, {:parent, entry})
   end
@@ -182,6 +186,10 @@ defmodule Lexical.RemoteControl.Search.Store do
 
   def handle_call({:exact, subject, constraints}, _from, {ref, %State{} = state}) do
     {:reply, State.exact(state, subject, constraints), {ref, state}}
+  end
+
+  def handle_call({:prefix, prefix, constraints}, _from, {ref, %State{} = state}) do
+    {:reply, State.prefix(state, prefix, constraints), {ref, state}}
   end
 
   def handle_call({:fuzzy, subject, constraints}, _from, {ref, %State{} = state}) do

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backend.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backend.ex
@@ -84,6 +84,11 @@ defmodule Lexical.RemoteControl.Search.Store.Backend do
   @callback find_by_subject(subject_query(), type_query(), subtype_query()) :: [Entry.t()]
 
   @doc """
+  Finds all entries by prefix
+  """
+  @callback find_by_prefix(subject_query(), type_query(), subtype_query()) :: [Entry.t()]
+
+  @doc """
   Finds entries whose ref attribute is in the given list
   """
   @callback find_by_ids([Entry.entry_id()], type_query(), subtype_query()) :: [Entry.t()]

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets.ex
@@ -65,6 +65,11 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets do
   end
 
   @impl Backend
+  def find_by_prefix(prefix, type, subtype) do
+    GenServer.call(genserver_name(), {:find_by_prefix, [prefix, type, subtype]})
+  end
+
+  @impl Backend
   def find_by_ids(ids, type, subtype) do
     GenServer.call(genserver_name(), {:find_by_ids, [ids, type, subtype]})
   end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v2.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v2.ex
@@ -30,7 +30,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V2 do
   def to_rows(%Entry{} = entry) do
     subject_key =
       by_subject(
-        subject: to_subject(entry.subject),
+        subject: to_subject_charlist(entry.subject),
         type: entry.type,
         subtype: entry.subtype,
         path: entry.path
@@ -62,8 +62,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V2 do
     [:named_table, :ordered_set, :compressed]
   end
 
-  defp to_subject(binary) when is_binary(binary), do: binary
-  defp to_subject(:_), do: :_
-  defp to_subject(atom) when is_atom(atom), do: inspect(atom)
-  defp to_subject(other), do: to_string(other)
+  def to_subject_charlist(charlist) when is_list(charlist), do: charlist
+  def to_subject_charlist(:_), do: :_
+  def to_subject_charlist(atom) when is_atom(atom), do: atom |> inspect() |> to_charlist()
+  def to_subject_charlist(other), do: to_charlist(other)
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v2.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v2.ex
@@ -30,7 +30,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V2 do
   def to_rows(%Entry{} = entry) do
     subject_key =
       by_subject(
-        subject: to_subject_charlist(entry.subject),
+        subject: to_subject(entry.subject),
         type: entry.type,
         subtype: entry.subtype,
         path: entry.path
@@ -62,8 +62,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V2 do
     [:named_table, :ordered_set, :compressed]
   end
 
-  def to_subject_charlist(charlist) when is_list(charlist), do: charlist
-  def to_subject_charlist(:_), do: :_
-  def to_subject_charlist(atom) when is_atom(atom), do: atom |> inspect() |> to_charlist()
-  def to_subject_charlist(other), do: to_charlist(other)
+  def to_subject(charlist) when is_list(charlist), do: charlist
+  def to_subject(:_), do: :_
+  def to_subject(atom) when is_atom(atom), do: atom |> inspect() |> to_charlist()
+  def to_subject(other), do: to_charlist(other)
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
@@ -14,13 +14,14 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
   @schema_order [
     Schemas.LegacyV0,
     Schemas.V1,
-    Schemas.V2
+    Schemas.V2,
+    Schemas.V3
   ]
 
   import Wal, only: :macros
   import Entry, only: :macros
 
-  import Schemas.V2,
+  import Schemas.V3,
     only: [
       by_block_id: 1,
       query_by_id: 1,

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
@@ -116,6 +116,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
   @dialyzer {:nowarn_function, to_prefix: 1}
 
   defp to_prefix(prefix) when is_binary(prefix) do
+    # what we really want to do here is convert the prefix to a improper list
+    # like this: `'abc' -> [97, 98, 99 | :_]`, it's different from `'abc' ++ [:_]`
     [last_char | others] = prefix |> String.to_charlist() |> Enum.reverse()
     others |> Enum.reverse() |> Enum.concat([last_char | :_])
   end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
@@ -109,8 +109,8 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
 
     state.table_name
     |> :ets.select([{{match_pattern, :_}, [], [:"$_"]}])
-    |> Enum.flat_map(fn {_, id_keys} -> id_keys end)
-    |> MapSet.new()
+    |> Stream.flat_map(fn {_, id_keys} -> id_keys end)
+    |> Stream.uniq()
     |> Enum.flat_map(&:ets.lookup_element(state.table_name, &1, 2))
   end
 

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
@@ -118,8 +118,9 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
   defp to_prefix(prefix) when is_binary(prefix) do
     # what we really want to do here is convert the prefix to a improper list
     # like this: `'abc' -> [97, 98, 99 | :_]`, it's different from `'abc' ++ [:_]`
-    [last_char | others] = prefix |> String.to_charlist() |> Enum.reverse()
-    others |> Enum.reverse() |> Enum.concat([last_char | :_])
+    # this is the required format for the `:ets.select` function.
+    {last_char, others} = prefix |> String.to_charlist() |> List.pop_at(-1)
+    others ++ [last_char | :_]
   end
 
   def siblings(%__MODULE__{} = state, %Entry{} = entry) do

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/state.ex
@@ -28,7 +28,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
       query_structure: 1,
       query_by_subject: 1,
       structure: 1,
-      to_subject_charlist: 1
+      to_subject: 1
     ]
 
   defstruct [:project, :table_name, :leader?, :leader_pid, :wal_state]
@@ -84,7 +84,7 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.State do
   def find_by_subject(%__MODULE__{} = state, subject, type, subtype) do
     match_pattern =
       query_by_subject(
-        subject: to_subject_charlist(subject),
+        subject: to_subject(subject),
         type: type,
         subtype: subtype
       )

--- a/apps/remote_control/lib/lexical/remote_control/search/store/state.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/state.ex
@@ -88,6 +88,12 @@ defmodule Lexical.RemoteControl.Search.Store.State do
     state.backend.find_by_subject(subject, type, subtype)
   end
 
+  def prefix(%__MODULE__{} = state, prefix, constraints) do
+    type = Keyword.get(constraints, :type, :_)
+    subtype = Keyword.get(constraints, :subtype, :_)
+    state.backend.find_by_prefix(prefix, type, subtype)
+  end
+
   def fuzzy(%__MODULE__{} = state, subject, constraints) do
     case Fuzzy.match(state.fuzzy, subject) do
       [] ->

--- a/apps/remote_control/test/lexical/remote_control/search/store_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store_test.exs
@@ -97,6 +97,23 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
         assert entry.id == 1
       end
 
+      test "matching prefix tokens should work" do
+        Store.replace([
+          definition(id: 1, subject: Foo.Bar),
+          definition(id: 2, subject: Foo.Baa.Baa),
+          definition(id: 3, subject: Foo.Bar.Baz)
+        ])
+
+        assert [entry1, entry3] =
+                 Store.prefix("Foo.Bar", type: :module, subtype: :definition)
+
+        assert entry1.subject == Foo.Bar
+        assert entry3.subject == Foo.Bar.Baz
+
+        assert entry1.id == 1
+        assert entry3.id == 3
+      end
+
       test "matching fuzzy tokens works" do
         Store.replace([
           definition(id: 1, subject: Foo.Bar.Baz),


### PR DESCRIPTION
***Description:*** 

This commit adds the `prefix` function to the `Lexical.RemoteControl.Search.Store` module, allowing for searching entries by prefix. It also implements the `find_by_prefix` callback in the `Lexical.RemoteControl.Search.Store.Backends.Ets` module.

***Changes:***

- Added `prefix` function to `Lexical.RemoteControl.Search.Store`
- Implemented `find_by_prefix` callback in `Lexical.RemoteControl.Search.Store.Backends.Ets`