### PR TITLE
Implement callback completions

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
@@ -37,7 +37,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callback do
     end
 
     # add tab stops and join with ", "
-    defp arg_text(args) do
+    defp arg_text(args) when is_list(args) do
       args
       |> Enum.with_index(fn arg, i ->
         "${#{i + 1}:#{arg}}"
@@ -61,12 +61,12 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callback do
       "supervision specification"
     end
 
-    defp detail(%{origin: origin, metadata: %{optional: true}}) do
-      "#{origin} callback"
-    end
-
     defp detail(%{origin: origin, metadata: %{optional: false}}) do
       "#{origin} callback (required)"
+    end
+
+    defp detail(%{origin: origin}) do
+      "#{origin} callback"
     end
 
     # cribbed from the callable translation for now.

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
@@ -32,7 +32,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callback do
         sort_text: sort_text(callback),
         filter_text: "def #{name}",
         documentation: summary
-      ) |> Completion.Builder.boost(local_boost, 8)
+      )
+      |> Completion.Builder.boost(local_boost, 8)
     end
 
     # add tab stops and join with ", "

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
@@ -9,8 +9,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callback do
       %Callback{
         name: name,
         argument_names: arg_names,
-        summary: summary,
-        metadata: metadata
+        summary: summary
       } = callback
 
       %Env{line: line} = env
@@ -26,7 +25,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callback do
         filter_text: "def #{name}",
         documentation: summary
       )
-      |> Completion.Builder.boost(local_boost(metadata), 8)
+      |> Completion.Builder.boost(5)
     end
 
     defp insert_text(name, arg_names)
@@ -91,9 +90,5 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callback do
 
       "#{name}:#{normalized_arity}"
     end
-
-    defp local_boost(%{optional: false}), do: 9
-
-    defp local_boost(_), do: 1
   end
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
@@ -1,43 +1,43 @@
 defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callback do
   alias Lexical.Ast.Env
   alias Lexical.Completion.Translatable
-  alias Lexical.RemoteControl.Completion.Candidate
+  alias Lexical.RemoteControl.Completion.Candidate.Callback
   alias Lexical.Server.CodeIntelligence.Completion
 
-  defimpl Translatable, for: Candidate.Callback do
+  defimpl Translatable, for: Callback do
     def translate(callback, _builder, %Env{} = env) do
-      %Candidate.Callback{
+      %Callback{
         name: name,
         argument_names: arg_names,
         summary: summary,
         metadata: metadata
       } = callback
 
-      insert_text =
-        impl_line(callback, env) <>
-          "def #{name}(#{arg_text(arg_names)}) do" <>
-          "\n\t$0\nend"
-
-      local_boost =
-        case metadata do
-          %{optional: false} -> 9
-          _ -> 1
-        end
+      %Env{line: line} = env
 
       env
-      |> Completion.Builder.snippet(insert_text,
-        label: "#{name}(#{Enum.join(arg_names, ", ")})",
+      |> Completion.Builder.text_edit_snippet(
+        insert_text(name, arg_names),
+        line_range(line),
+        label: label(name, arg_names),
         kind: :interface,
         detail: detail(callback),
         sort_text: sort_text(callback),
         filter_text: "def #{name}",
         documentation: summary
       )
-      |> Completion.Builder.boost(local_boost, 8)
+      |> Completion.Builder.boost(local_boost(metadata), 8)
+    end
+
+    defp insert_text(name, arg_names)
+         when is_binary(name) and is_list(arg_names) do
+      impl_line(name) <>
+        "def #{name}(#{arg_text(arg_names)}) do" <>
+        "\n\t$0\nend"
     end
 
     # add tab stops and join with ", "
-    defp arg_text(args) when is_list(args) do
+    defp arg_text(args) do
       args
       |> Enum.with_index(fn arg, i ->
         "${#{i + 1}:#{arg}}"
@@ -47,30 +47,43 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callback do
 
     # elixir_sense suggests child_spec/1 as a callback as it's a common idiom,
     # but not an actual callback of behaviours like GenServer.
-    defp impl_line(%{name: "child_spec"}, _env) do
-      ""
-    end
+    defp impl_line("child_spec"), do: ""
 
     # It's generally safe adding `@impl true` to callbacks as Elixir warns
     # of conflicting behaviours, and they're virtually non-existent anyway.
-    defp impl_line(%{}, _env) do
-      "@impl true\n"
+    defp impl_line(_), do: "@impl true\n"
+
+    defp line_range(line) when is_binary(line) do
+      start_char =
+        case String.split(line, "def", parts: 2) do
+          [i, _] -> String.length(i) + 1
+          [_] -> 0
+        end
+
+      end_char = String.length(line) + 1
+
+      {start_char, end_char}
     end
 
-    defp detail(%{name: "child_spec"}) do
+    defp label(name, arg_names)
+         when is_binary(name) and is_list(arg_names) do
+      "#{name}(#{Enum.join(arg_names, ", ")})"
+    end
+
+    defp detail(%Callback{name: "child_spec"}) do
       "supervision specification"
     end
 
-    defp detail(%{origin: origin, metadata: %{optional: false}}) do
+    defp detail(%Callback{origin: origin, metadata: %{optional: false}}) do
       "#{origin} callback (required)"
     end
 
-    defp detail(%{origin: origin}) do
+    defp detail(%Callback{origin: origin}) do
       "#{origin} callback"
     end
 
-    # cribbed from the callable translation for now.
-    defp sort_text(%{name: name, arity: arity}) do
+    # cribbed from the Callable translation for now.
+    defp sort_text(%Callback{name: name, arity: arity}) do
       normalized_arity =
         arity
         |> Integer.to_string()
@@ -78,5 +91,9 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callback do
 
       "#{name}:#{normalized_arity}"
     end
+
+    defp local_boost(%{optional: false}), do: 9
+
+    defp local_boost(_), do: 1
   end
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
@@ -2,11 +2,72 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callback do
   alias Lexical.Ast.Env
   alias Lexical.Completion.Translatable
   alias Lexical.RemoteControl.Completion.Candidate
-  alias Lexical.Server.CodeIntelligence.Completion.Translations
+  alias Lexical.Server.CodeIntelligence.Completion
 
   defimpl Translatable, for: Candidate.Callback do
     def translate(callback, _builder, %Env{} = env) do
-      Translations.Callable.completion(callback, env)
+      %Candidate.Callback{
+        name: name,
+        argument_names: arg_names,
+        summary: summary
+      } = callback
+
+      insert_text =
+        impl_line(callback, env) <>
+          "def #{name}(#{arg_text(arg_names)}) do" <>
+          "\n\t$0\nend"
+
+      Completion.Builder.snippet(env, insert_text,
+        label: "#{name}(#{Enum.join(arg_names, ", ")})",
+        kind: :interface,
+        detail: detail(callback),
+        sort_text: sort_text(callback),
+        filter_text: "def #{name}",
+        documentation: summary
+      )
+    end
+
+    # add tab stops and join with ", "
+    defp arg_text(args) do
+      args
+      |> Enum.with_index(fn arg, i ->
+        "${#{i + 1}:#{arg}}"
+      end)
+      |> Enum.join(", ")
+    end
+
+    # elixir_sense suggests child_spec/1 as a callback as it's a common idiom,
+    # but not an actual callback of behaviours like GenServer.
+    defp impl_line(%{name: "child_spec"}, _env) do
+      ""
+    end
+
+    # It's generally safe adding `@impl true` to callbacks as Elixir warns
+    # of conflicting behaviours, and they're virtually non-existent anyway.
+    defp impl_line(%{}, _env) do
+      "@impl true\n"
+    end
+
+    defp detail(%{name: "child_spec"}) do
+      "supervision specification"
+    end
+
+    defp detail(%{origin: origin, metadata: %{optional: true}}) do
+      "#{origin} callback"
+    end
+
+    defp detail(%{origin: origin, metadata: %{optional: false}}) do
+      "#{origin} callback (required)"
+    end
+
+    # cribbed from the callable translation for now.
+    defp sort_text(%{name: name, arity: arity}) do
+      normalized_arity =
+        arity
+        |> Integer.to_string()
+        |> String.pad_leading(3, "0")
+
+      "#{name}:#{normalized_arity}"
     end
   end
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callback.ex
@@ -9,7 +9,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callback do
       %Candidate.Callback{
         name: name,
         argument_names: arg_names,
-        summary: summary
+        summary: summary,
+        metadata: metadata
       } = callback
 
       insert_text =
@@ -17,14 +18,21 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callback do
           "def #{name}(#{arg_text(arg_names)}) do" <>
           "\n\t$0\nend"
 
-      Completion.Builder.snippet(env, insert_text,
+      local_boost =
+        case metadata do
+          %{optional: false} -> 9
+          _ -> 1
+        end
+
+      env
+      |> Completion.Builder.snippet(insert_text,
         label: "#{name}(#{Enum.join(arg_names, ", ")})",
         kind: :interface,
         detail: detail(callback),
         sort_text: sort_text(callback),
         filter_text: "def #{name}",
         documentation: summary
-      )
+      ) |> Completion.Builder.boost(local_boost, 8)
     end
 
     # add tab stops and join with ", "

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
@@ -36,7 +36,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
       kind: :class,
       label: label
     )
-    |> builder.boost(1, 9)
+    |> builder.boost(9)
   end
 
   def translate(%Candidate.Macro{name: "defp", arity: 2} = macro, builder, env) do

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
@@ -36,7 +36,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
       kind: :class,
       label: label
     )
-    |> builder.boost(9, 1)
+    |> builder.boost(1, 9)
   end
 
   def translate(%Candidate.Macro{name: "defp", arity: 2} = macro, builder, env) do

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/macro.ex
@@ -36,7 +36,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Macro do
       kind: :class,
       label: label
     )
-    |> builder.boost(9)
+    |> builder.boost(9, 1)
   end
 
   def translate(%Candidate.Macro{name: "defp", arity: 2} = macro, builder, env) do

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/callback_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/callback_test.exs
@@ -13,9 +13,9 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.CallbackTest d
       {:ok, completion} =
         project
         |> complete(source)
-        |> fetch_completion(kind: :function)
+        |> fetch_completion(kind: :interface)
 
-      assert apply_completion(completion) =~ "def handle_info(${1:msg}, ${2:state})"
+      assert apply_completion(completion) =~ "@impl true\ndef handle_info(${1:msg}, ${2:state}) do"
     end
 
     test "do not add parens if they're already present", %{project: project} do
@@ -29,9 +29,9 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.CallbackTest d
       {:ok, completion} =
         project
         |> complete(source)
-        |> fetch_completion(kind: :function)
+        |> fetch_completion(kind: :interface)
 
-      assert apply_completion(completion) =~ "def handle_info(msg, state)"
+      assert apply_completion(completion) =~ "@impl true\ndef handle_info(${1:msg}, ${2:state}) do"
     end
   end
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/callback_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/callback_test.exs
@@ -15,7 +15,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.CallbackTest d
         |> complete(source)
         |> fetch_completion(kind: :interface)
 
-      assert apply_completion(completion) =~ "@impl true\ndef handle_info(${1:msg}, ${2:state}) do"
+      assert apply_completion(completion) =~
+               "@impl true\ndef handle_info(${1:msg}, ${2:state}) do"
     end
 
     test "do not add parens if they're already present", %{project: project} do
@@ -31,7 +32,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.CallbackTest d
         |> complete(source)
         |> fetch_completion(kind: :interface)
 
-      assert apply_completion(completion) =~ "@impl true\ndef handle_info(${1:msg}, ${2:state}) do"
+      assert apply_completion(completion) =~
+               "@impl true\ndef handle_info(${1:msg}, ${2:state}) do"
     end
   end
 end


### PR DESCRIPTION
Callback completions should now expand to their full def-blocks, preceded with an impl tag.

In a module `use`-ing a behaviour, typing `def |` should result in the following completion options:
* `def (define a function)`
* `def callback(args) module_label`
* `(remaining callbacks)`
* Other `def*` macros
