### PR TITLE
Fix `do` completing to `defmodule` in VSCode

### DIFF
--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -188,8 +188,6 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
         |> complete(code)
         |> Enum.sort_by(& &1.sort_text)
 
-      IO.inspect(completions, label: "completions")
-
       module_index = Enum.find_index(completions, &(&1.label == "Foo-module"))
       behaviour_index = Enum.find_index(completions, &(&1.label == "Foo-behaviour"))
       submodule_index = Enum.find_index(completions, &(&1.label == "Foo-submodule"))

--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -65,8 +65,13 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
   end
 
   describe "do/end" do
-    test "returns do/end when the last token is do", %{project: project} do
+    test "returns do/end when the last token is 'do'", %{project: project} do
       assert [completion] = complete(project, "for a <- something do|")
+      assert completion.label == "do/end block"
+    end
+
+    test "returns do/end when the last token is 'd'", %{project: project} do
+      assert [completion] = complete(project, "for a <- something d|")
       assert completion.label == "do/end block"
     end
   end
@@ -182,6 +187,8 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
         project
         |> complete(code)
         |> Enum.sort_by(& &1.sort_text)
+
+      IO.inspect(completions, label: "completions")
 
       module_index = Enum.find_index(completions, &(&1.label == "Foo-module"))
       behaviour_index = Enum.find_index(completions, &(&1.label == "Foo-behaviour"))


### PR DESCRIPTION
Pursuant to: https://discord.com/channels/269508806759809042/918183981344772117/1214563122686206033
> objectuser — Today at 8:20 AM
I'm using Lexical in VSCode. When I'm creating a do block, the first completion is defmodule and there's no completion listed in the pop-up for just do...end. Should I just use user snippets for a do...end block or is there a better way to configure these completions?

(From Elixir Discord)

Fixes include:
* Include partial `d|` in `should_emit_do_end_snippet`
* Add `filter_text: "do"` for more accurate fuzzy matching

This may warrant user-testing across different editors to ensure existing completions remain consistent, as they may convert user-input-over-time to `textDocument/completion` requests differently.