### PR TITLE
Fix crashing in unsaved vscode files

### DIFF
--- a/projects/lexical_shared/lib/lexical/document/path.ex
+++ b/projects/lexical_shared/lib/lexical/document/path.ex
@@ -59,7 +59,7 @@ defmodule Lexical.Document.Path do
   end
 
   def from_uri(%URI{scheme: scheme}) do
-    raise ArgumentError, message: "unexpected URI scheme #{inspect(scheme)}"
+    raise ArgumentError, message: "unsupported URI scheme #{inspect(scheme)}"
   end
 
   def from_uri(uri) when is_binary(uri) do

--- a/projects/lexical_shared/test/lexical/document/path_test.exs
+++ b/projects/lexical_shared/test/lexical/document/path_test.exs
@@ -118,6 +118,16 @@ defmodule ElixirLS.LanguageServer.SourceFile.PathTest do
     test "vscode unsaved file uri" do
       assert from_uri("untitled:Untitled-1") == "untitled:Untitled-1"
     end
+
+    test "unsupported uri schemas" do
+      assert_raise ArgumentError, fn ->
+        from_uri("https://elixir-lang.org")
+      end
+
+      assert_raise ArgumentError, fn ->
+        from_uri("unsaved://343C3EE7-D575-486D-9D33-93AFFAF773BD")
+      end
+    end
   end
 
   describe "to_uri/1" do

--- a/projects/lexical_shared/test/lexical/document/path_test.exs
+++ b/projects/lexical_shared/test/lexical/document/path_test.exs
@@ -115,14 +115,8 @@ defmodule ElixirLS.LanguageServer.SourceFile.PathTest do
       end)
     end
 
-    test "wrong schema" do
-      assert_raise ArgumentError, fn ->
-        from_uri("untitled:Untitled-1")
-      end
-
-      assert_raise ArgumentError, fn ->
-        from_uri("unsaved://343C3EE7-D575-486D-9D33-93AFFAF773BD")
-      end
+    test "vscode unsaved file uri" do
+      assert from_uri("untitled:Untitled-1") == "untitled:Untitled-1"
     end
   end
 


### PR DESCRIPTION
Pursuant to #641

* match on and handle `untitled:Untitled-N` URIs. Previously they were errantly being treated as file path URIs.
* add `is_binary` guards to `Document.Path` functions. This makes for slightly more explicit errors.