### PR TITLE
Find references for variables

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/entity.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/entity.ex
@@ -16,6 +16,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Entity do
           | {:call, module(), fun_name :: atom(), arity :: non_neg_integer()}
           | {:type, module(), type_name :: atom(), arity :: non_neg_integer()}
           | {:module_attribute, container_module :: module(), attribut_name :: atom()}
+          | {:variable, variable_name :: atom()}
 
   defguardp is_call(form) when Sourceror.Identifier.is_call(form) and elem(form, 0) != :.
 
@@ -84,11 +85,11 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Entity do
 
         case fetch_module_for_function(analysis, position, maybe_fun, arity) do
           {:ok, module} -> {:ok, {:call, module, maybe_fun, arity}, node_range}
-          _ -> {:error, :not_found}
+          _ -> {:ok, {:variable, List.to_atom(chars)}, node_range}
         end
 
       _ ->
-        {:error, :not_found}
+        {:ok, {:variable, List.to_atom(chars)}, node_range}
     end
   end
 

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/variable.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/variable.ex
@@ -1,0 +1,258 @@
+defmodule Lexical.RemoteControl.CodeIntelligence.Variable do
+  alias Lexical.Ast.Analysis
+  alias Lexical.Document.Position
+  alias Lexical.Document.Range
+  alias Lexical.RemoteControl.Search.Indexer
+  alias Lexical.RemoteControl.Search.Indexer.Entry
+
+  require Logger
+
+  @extractors [Indexer.Extractors.Variable]
+
+  @spec definition(Analysis.t(), Position.t(), atom()) :: {:ok, Entry.t()} | :error
+  def definition(%Analysis{} = analysis, %Position{} = position, variable_name) do
+    with {:ok, block_structure, entries} <- index_variables(analysis),
+         {:ok, %Entry{} = definition_entry} <-
+           do_find_definition(variable_name, block_structure, entries, position) do
+      {:ok, definition_entry}
+    else
+      _ ->
+        :error
+    end
+  end
+
+  @spec references(Analysis.t(), Position.t(), charlist(), boolean()) :: [Range.t()]
+  def references(
+        %Analysis{} = analysis,
+        %Position{} = position,
+        variable_name,
+        include_definitions? \\ false
+      ) do
+    with {:ok, block_structure, entries} <- index_variables(analysis),
+         {:ok, %Entry{} = definition_entry} <-
+           do_find_definition(variable_name, block_structure, entries, position) do
+      references = search_for_references(entries, definition_entry, block_structure)
+
+      entries =
+        if include_definitions? do
+          [definition_entry | references]
+        else
+          references
+        end
+
+      Enum.sort_by(entries, fn %Entry{} = entry ->
+        {entry.range.start.line, entry.range.start.character}
+      end)
+    else
+      _ ->
+        []
+    end
+  end
+
+  defp index_variables(%Analysis{} = analysis) do
+    with {:ok, entries} <- Indexer.Quoted.index(analysis, @extractors),
+         {[block_structure], entries} <- Enum.split_with(entries, &(&1.type == :metadata)) do
+      {:ok, block_structure.subject, entries}
+    end
+  end
+
+  defp do_find_definition(variable_name, block_structure, entries, position) do
+    with {:ok, entry} <- fetch_entry(entries, variable_name, position) do
+      search_for_definition(entries, entry, block_structure)
+    end
+  end
+
+  defp fetch_entry(entries, variable_name, position) do
+    entries
+    |> Enum.find(fn %Entry{} = entry ->
+      entry.subject == variable_name and entry.type == :variable and
+        Range.contains?(entry.range, position)
+    end)
+    |> case do
+      %Entry{} = entry ->
+        {:ok, entry}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp search_for_references(entries, %Entry{} = definition_entry, block_structure) do
+    block_id_to_children = block_id_to_children(block_structure)
+
+    definition_children = Map.get(block_id_to_children, definition_entry.block_id, [])
+
+    definition_start = definition_entry.range.start
+
+    # The algorithm here is to first clean up the entries so they either are definitions or references to a
+    # variable with the given name. We sort them by their occurrence in the file, working backwards on a line, so
+    # definitions earlier in the line shadow definitions later in the line.
+    # Then we start at the definition entry, and then for each entry after that,
+    # if it's a definition, we mark the state as being shadowed, but reset the state if the block
+    # id isn't in the children of the current block id. If we're not in a child of the current block
+    # id, then we're no longer shadowed
+    #
+    # Note, this algorithm doesn't work when we have a block definition whose result rebinds a variable.
+    # For example:
+    # entries = [4, 5, 6]
+    # entries =
+    #  if something() do
+    #    [1 | entries]
+    #  else
+    #    entries
+    # end
+    # Searching for the references to the initial variable won't find anything inside the block, but
+    # searching for the rebound variable will.
+
+    {entries, _, _} =
+      entries
+      |> Enum.filter(fn %Entry{} = entry ->
+        entry_start = entry.range.start
+
+        after_definition? =
+          if entry_start.line == definition_start.line do
+            entry_start.character > definition_entry.range.end.character
+          else
+            entry_start.line > definition_start.line
+          end
+
+        variable_type? = entry.type == :variable
+        correct_subject? = entry.subject == definition_entry.subject
+        child_of_definition_block? = entry.block_id in definition_children
+
+        variable_type? and correct_subject? and child_of_definition_block? and after_definition?
+      end)
+      |> Enum.sort_by(fn %Entry{} = entry ->
+        start = entry.range.start
+        {start.line, -start.character, entry.block_id}
+      end)
+      |> Enum.reduce({[], false, definition_entry.block_id}, fn
+        %Entry{subtype: :definition} = entry, {entries, _, _} ->
+          # we have a definition that's shadowing our definition entry
+          {entries, true, entry.block_id}
+
+        %Entry{subtype: :reference} = entry, {entries, true, current_block_id} ->
+          shadowed? = entry.block_id in Map.get(block_id_to_children, current_block_id, [])
+
+          entries =
+            if shadowed? do
+              entries
+            else
+              [entry | entries]
+            end
+
+          {entries, shadowed?, entry.block_id}
+
+        %Entry{} = entry, {entries, false, _} ->
+          # we're a reference and we're not being shadowed; collect it and move on.
+          {[entry | entries], false, entry.block_id}
+      end)
+
+    entries
+  end
+
+  defp search_for_definition(entries, %Entry{} = entry, block_structure) do
+    block_id_to_parents = collect_parents(block_structure)
+    block_path = Map.get(block_id_to_parents, entry.block_id)
+    entries_by_block_id = entries_by_block_id(entries)
+
+    Enum.reduce_while([entry.block_id | block_path], :error, fn block_id, _ ->
+      block_entries =
+        entries_by_block_id
+        |> Map.get(block_id, [])
+        |> then(fn entries ->
+          # In the current block, reject all entries that come after the entry whose definition
+          # we're searching for. This prevents us from finding definitions who are shadowing
+          # our entry. For example, the definition on the left of the equals in: `param = param + 1`.
+
+          if block_id == entry.block_id do
+            Enum.drop_while(entries, &(&1.id != entry.id))
+          else
+            entries
+          end
+        end)
+
+      case Enum.find(block_entries, &definition_of?(entry, &1)) do
+        %Entry{} = definition ->
+          {:halt, {:ok, definition}}
+
+        nil ->
+          {:cont, :error}
+      end
+    end)
+  end
+
+  defp definition_of?(%Entry{} = needle, %Entry{} = compare) do
+    compare.type == :variable and compare.subtype == :definition and
+      compare.subject == needle.subject
+  end
+
+  defp entries_by_block_id(entries) do
+    entries
+    |> Enum.reduce(%{}, fn %Entry{} = entry, acc ->
+      Map.update(acc, entry.block_id, [entry], &[entry | &1])
+    end)
+    |> Map.new(fn {block_id, entries} ->
+      entries =
+        Enum.sort_by(
+          entries,
+          fn %Entry{} = entry ->
+            {entry.range.start.line, -entry.range.start.character}
+          end,
+          :desc
+        )
+
+      {block_id, entries}
+    end)
+  end
+
+  def block_id_to_parents(hierarchy) do
+    hierarchy
+    |> flatten_hierarchy()
+    |> Enum.reduce(%{}, fn {parent_id, child_id}, acc ->
+      old_parents = [parent_id | Map.get(acc, parent_id, [])]
+      Map.update(acc, child_id, old_parents, &Enum.concat(&1, old_parents))
+    end)
+    |> Map.put(:root, [])
+  end
+
+  def block_id_to_children(hierarchy) do
+    # Note: Parent ids are included in their children list in order to simplify
+    # checks for "is this id in one of its children"
+
+    hierarchy
+    |> flatten_hierarchy()
+    |> Enum.reverse()
+    |> Enum.reduce(%{root: [:root]}, fn {parent_id, child_id}, current_mapping ->
+      current_children = [child_id | Map.get(current_mapping, child_id, [parent_id])]
+
+      current_mapping
+      |> Map.put_new(child_id, [child_id])
+      |> Map.update(parent_id, current_children, &Enum.concat(&1, current_children))
+    end)
+  end
+
+  def flatten_hierarchy(hierarchy) do
+    Enum.flat_map(hierarchy, fn
+      {k, v} when is_map(v) and map_size(v) > 0 ->
+        v
+        |> Map.keys()
+        |> Enum.map(&{k, &1})
+        |> Enum.concat(flatten_hierarchy(v))
+
+      _ ->
+        []
+    end)
+  end
+
+  defp collect_parents(block_structure) do
+    do_collect_parents(block_structure, %{}, [])
+  end
+
+  defp do_collect_parents(hierarchy, parent_map, path) do
+    Enum.reduce(hierarchy, parent_map, fn {block_id, children}, acc ->
+      parent_map = Map.put(acc, block_id, path)
+      do_collect_parents(children, parent_map, [block_id | path])
+    end)
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/variable.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/variable.ex
@@ -23,14 +23,14 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Variable do
   def extract({:<-, _, [left, right]}, %Reducer{} = reducer) do
     entries = extract_definitions(left, reducer)
 
-    {:ok, entries, right}
+    {:ok, entries, List.wrap(right)}
   end
 
   # Match operator left = right
   def extract({:=, _, [left, right]}, %Reducer{} = reducer) do
     definitions = extract_definitions(left, reducer)
 
-    {:ok, definitions, [right]}
+    {:ok, definitions, List.wrap(right)}
   end
 
   # String interpolations "#{foo}"

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/variable.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/variable.ex
@@ -41,6 +41,20 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Variable do
     {:ok, [], body}
   end
 
+  # Test declarations
+  def extract(
+        {:test, _metadata,
+         [
+           {:__block__, [delimiter: "\"", line: 3, column: 8], ["my test"]},
+           args,
+           body
+         ]},
+        %Reducer{} = reducer
+      ) do
+    entries = extract_definitions(args, reducer)
+    {:ok, entries, body}
+  end
+
   def extract({:binary, _, _}, %Reducer{}) do
     :ignored
   end

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/source/reducer.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/source/reducer.ex
@@ -87,6 +87,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Source.Reducer do
       {:expression, position} ->
         reducer
         |> update_position(position)
+        |> maybe_pop_block()
         |> apply_extractors(element)
     end
   end

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/variable_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/variable_test.exs
@@ -1,0 +1,489 @@
+defmodule Lexical.RemoteControl.CodeIntelligence.VariableTest do
+  alias Lexical.Ast
+  alias Lexical.RemoteControl.CodeIntelligence.Variable
+
+  use ExUnit.Case
+
+  import Lexical.Test.CodeSigil
+  import Lexical.Test.CursorSupport
+  import Lexical.Test.RangeSupport
+
+  def find_definition(code) do
+    {position, document} = pop_cursor(code, as: :document)
+    analysis = Ast.analyze(document)
+    {:ok, {:local_or_var, var_name}} = Ast.cursor_context(analysis, position)
+
+    case Variable.definition(analysis, position, List.to_atom(var_name)) do
+      {:ok, entry} -> {:ok, entry.range, document}
+      error -> error
+    end
+  end
+
+  def find_references(code, include_definition? \\ false) do
+    {position, document} = pop_cursor(code, as: :document)
+    analysis = Ast.analyze(document)
+    {:ok, {:local_or_var, var_name}} = Ast.cursor_context(analysis, position)
+
+    ranges =
+      analysis
+      |> Variable.references(position, List.to_atom(var_name), include_definition?)
+      |> Enum.map(& &1.range)
+
+    {:ok, ranges, document}
+  end
+
+  describe "definitions in a single scope" do
+    test "are returned if it is selected" do
+      {:ok, range, doc} =
+        ~q[
+          def foo(param|) do
+            param
+          end
+        ]
+        |> find_definition()
+
+      assert decorate(doc, range) =~ "def foo(«param») do"
+    end
+
+    test "are found in a parameter" do
+      {:ok, range, doc} =
+        ~q[
+          def foo(param) do
+            param|
+          end
+        ]
+        |> find_definition()
+
+      assert decorate(doc, range) =~ "def foo(«param») do"
+    end
+
+    test "are found in a parameter list" do
+      {:ok, range, doc} =
+        ~q[
+          def foo(other_param, param) do
+            param|
+          end
+        ]
+        |> find_definition()
+
+      assert decorate(doc, range) =~ "def foo(other_param, «param») do"
+    end
+
+    test "are found when shadowed" do
+      {:ok, range, doc} =
+        ~q[
+          def foo(param) do
+            param = param + 1
+            param|
+          end
+        ]
+        |> find_definition()
+
+      assert decorate(doc, range) =~ "«param» = param + 1"
+    end
+
+    test "are found when shadowing a parameter" do
+      {:ok, range, doc} =
+        ~q[
+          def foo(param) do
+            param = param| + 1
+          end
+        ]
+        |> find_definition()
+
+      assert decorate(doc, range) =~ "def foo(«param») do"
+    end
+
+    test "when there are multiple definitions on one line" do
+      {:ok, range, doc} =
+        ~q[
+            param = 3
+            foo = param = param + 1
+            param|
+        ]
+        |> find_definition()
+
+      assert decorate(doc, range) =~ "= «param» = param + 1"
+    end
+
+    test "when the definition is in a map key" do
+      {:ok, range, doc} =
+        ~q[
+          %{key: value} = map
+          value|
+        ]
+        |> find_definition()
+
+      assert decorate(doc, range) =~ "%{key: «value»} = map"
+    end
+  end
+
+  describe "definitions across scopes" do
+    test "works in an if in a function" do
+      {:ok, range, doc} =
+        ~q[
+          def my_fun do
+            foo = 3
+            if something do
+              foo|
+            end
+          end
+        ]
+        |> find_definition()
+
+      assert decorate(doc, range) =~ "«foo» = 3"
+    end
+
+    test "works for variables defined in a module" do
+      {:ok, range, doc} =
+        ~q[
+          defmodule Parent do
+            x = 3
+            def fun do
+              unquote(x|)
+            end
+          end
+        ]
+        |> find_definition()
+
+      assert decorate(doc, range) =~ "«x» = 3"
+    end
+
+    test "works for variables defined outside module" do
+      {:ok, range, doc} =
+        ~q[
+          x = 3
+          defmodule Parent do
+            def fun do
+              unquote(x|)
+            end
+          end
+        ]
+        |> find_definition()
+
+      assert decorate(doc, range) =~ "«x» = 3"
+    end
+  end
+
+  describe "references" do
+    test "in a function parameter" do
+      {:ok, [range], doc} =
+        ~q[
+          def something(param|) do
+            param
+          end
+        ]
+        |> find_references()
+
+      assert decorate(doc, range) =~ "«param»"
+    end
+
+    test "can include definitions" do
+      {:ok, [definition, reference], doc} =
+        ~q[
+          def something(param|) do
+            param
+          end
+        ]
+        |> find_references(true)
+
+      assert decorate(doc, definition) =~ "def something(«param») do"
+      assert decorate(doc, reference) =~ "  «param»"
+    end
+
+    test "can be found via a usage" do
+      {:ok, [first, second, third], doc} =
+        ~q[
+          def something(param) do
+           y = param + 3
+           z = param + 4
+           param| + y + z
+          end
+        ]
+        |> find_references()
+
+      assert decorate(doc, first) =~ " y = «param» + 3"
+      assert decorate(doc, second) =~ " z = «param» + 4"
+      assert decorate(doc, third) =~ " «param» + y + z"
+    end
+
+    test "are found in a function body" do
+      {:ok, [first, second, third, fourth, fifth], doc} =
+        ~q[
+          def something(param|) do
+            x = param + param + 3
+            y = param + x
+            z = 10 + param
+            x + y + z + param
+          end
+        ]
+        |> find_references()
+
+      assert decorate(doc, first) =~ "  x = «param» + param + 3"
+      assert decorate(doc, second) =~ "  x = param + «param» + 3"
+      assert decorate(doc, third) =~ "  y = «param» + x"
+      assert decorate(doc, fourth) =~ "  z = 10 + «param»"
+      assert decorate(doc, fifth) =~ " x + y + z + «param»"
+    end
+
+    test "are constrained to their definition function" do
+      {:ok, [range], doc} =
+        ~q[
+          def something(param|) do
+            param
+          end
+
+          def other_fn(param) do
+            param + 1
+          end
+        ]
+        |> find_references()
+
+      assert decorate(doc, range) =~ "«param»"
+    end
+
+    test "are visible across blocks" do
+      {:ok, [first, second], doc} =
+        ~q[
+          def something(param|) do
+            if something() do
+              param + 1
+            else
+              param + 2
+            end
+          end
+        ]
+        |> find_references()
+
+      assert decorate(doc, first) =~ "  «param» + 1"
+      assert decorate(doc, second) =~ "  «param» + 2"
+    end
+
+    test "dont leak out of blocks" do
+      {:ok, [range], doc} =
+        ~q[
+          def something(param) do
+
+            if something() do
+              param| = 3
+              param + 1
+            end
+            param + 1
+          end
+        ]
+        |> find_references()
+
+      assert decorate(doc, range) =~ "«param»"
+    end
+
+    test "are found in the head of a case statement" do
+      {:ok, [range], doc} =
+        ~q[
+          def something(param|) do
+            case param do
+             _ -> :ok
+            end
+          end
+        ]
+        |> find_references()
+
+      assert decorate(doc, range) =~ "  case «param» do"
+    end
+
+    test "are constrained to a single arm of a case statement" do
+      {:ok, [range], doc} =
+        ~q[
+          def something(param) do
+            case param do
+             param| when is_number(param) -> param + 1
+             param -> 0
+            end
+          end
+        ]
+        |> find_references()
+
+      assert decorate(doc, range) =~ "  param when is_number(param) -> «param» + 1"
+    end
+
+    test "are found in a module body" do
+      {:ok, [range], doc} =
+        ~q[
+        defmodule Outer do
+          something| = 3
+          def foo(unquote(something)) do
+          end
+        end
+        ]
+        |> find_references()
+
+      assert decorate(doc, range) =~ "def foo(unquote(«something»)) do"
+    end
+
+    test "are found in anonymous function parameters" do
+      {:ok, [first, second], doc} =
+        ~q[
+        def outer do
+          fn param| ->
+            y = param + 1
+            x = param + 2
+            x + y
+          end
+        end
+        ]
+        |> find_references()
+
+      assert decorate(doc, first) =~ "y = «param» + 1"
+      assert decorate(doc, second) =~ "x = «param» + 2"
+    end
+
+    test "are found in a pin operator" do
+      {:ok, [ref], doc} =
+        ~q[
+        def outer(param|) do
+          fn ^param ->
+            nil
+          end
+        end
+        ]
+        |> find_references()
+
+      assert decorate(doc, ref) =~ "fn ^«param» ->"
+    end
+
+    test "are found inside of string interpolation" do
+      {:ok, [ref], doc} =
+        ~S[
+          name| = "Stinky"
+          "#{name} Stinkman"
+        ]
+        |> find_references()
+
+      assert decorate(doc, ref) =~ "\#{«name»} Stinkman"
+    end
+
+    # Note: This test needs to pass before we can implement renaming variables reliably
+    @tag :skip
+    test "works for variables defined outside of an if while being shadowed" do
+      {:ok, [first, second], doc} =
+        ~q{
+          entries| = [1, 2, 3]
+          entries =
+            if something() do
+              [4 | entries]
+            else
+              entries
+            end
+        }
+        |> find_references()
+
+      assert decorate(doc, first) =~ "[4 | «entries»]"
+      assert decorate(doc, second) =~ "«entries»"
+    end
+
+    test "finds variables defined in anonymous function arms" do
+      {:ok, [first, second], doc} =
+        ~q"
+          shadowed? = false
+          fn
+          {:foo, entries|} ->
+            if shadowed? do
+              [1, entries]
+            else
+              entries
+            end
+          {:bar, entries} ->
+            entries
+          end
+        "
+        |> find_references()
+
+      assert decorate(doc, first) =~ "[1, «entries»]"
+      assert decorate(doc, second) =~ "«entries»"
+    end
+  end
+
+  describe "reference shadowing" do
+    test "on a single line" do
+      {:ok, [], _doc} =
+        ~q[
+          def something(param) do
+            other = other = other| = param
+          end
+      ]
+        |> find_references()
+    end
+
+    test "in a function body" do
+      {:ok, [], _doc} =
+        ~q[
+          def something(param|) do
+           param = 3
+           param
+          end
+      ]
+        |> find_references()
+    end
+
+    test "in anonymous function arguments" do
+      {:ok, [], _doc} =
+        ~q[
+          def something(param|) do
+           fn param ->
+             param + 1
+           end
+           :ok
+          end
+        ]
+        |> find_references()
+    end
+
+    test "inside of a block" do
+      {:ok, [range], doc} =
+        ~q[
+          def something do
+           shadow| = 4
+           if true do
+             shadow = shadow + 1
+             shadow
+           end
+          end
+        ]
+        |> find_references()
+
+      assert decorate(doc, range) == "   shadow = «shadow» + 1"
+    end
+
+    test "exiting a block" do
+      {:ok, [range], doc} =
+        ~q[
+          def something do
+           shadow| = 4
+           if true do
+             shadow = :ok
+             shadow
+           end
+           shadow + 1
+          end
+        ]
+        |> find_references()
+
+      assert decorate(doc, range) == " «shadow» + 1"
+    end
+
+    test "exiting nested blocks" do
+      {:ok, [range], doc} =
+        ~q[
+          def something(param| = arg) do
+            case arg do
+              param when is_number(n) ->
+                param + 4
+            end
+            param + 5
+          end
+        ]
+        |> find_references()
+
+      assert decorate(doc, range) == "  «param» + 5"
+    end
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/variable_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/variable_test.exs
@@ -291,7 +291,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.VariableTest do
     end
 
     test "are constrained to a single arm of a case statement" do
-      {:ok, [range], doc} =
+      {:ok, [guard_range, usage_range], doc} =
         ~q[
           def something(param) do
             case param do
@@ -302,7 +302,8 @@ defmodule Lexical.RemoteControl.CodeIntelligence.VariableTest do
         ]
         |> find_references()
 
-      assert decorate(doc, range) =~ "  param when is_number(param) -> «param» + 1"
+      assert decorate(doc, guard_range) =~ "  param when is_number(«param») -> param + 1"
+      assert decorate(doc, usage_range) =~ "  param when is_number(param) -> «param» + 1"
     end
 
     test "are found in a module body" do

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/variable_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/variable_test.exs
@@ -558,6 +558,22 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.VariableTest do
       assert decorate(doc, tuple_second.range) =~
                "%struct_module{key: [list_elem, {tuple_first, «tuple_second»}]} = whatever"
     end
+
+    test "from test arguments" do
+      {:ok, [test_def], doc} =
+        ~q[
+        defmodule TestCase do
+          use ExUnit.Case
+          test "my test", %{var: var} do
+            var
+          end
+        end
+        ]
+        |> index_definitions()
+
+      assert_definition(test_def, :var)
+      assert decorate(doc, test_def.range) =~ "%{var: «var»} do"
+    end
   end
 
   describe "variable references are extracted" do

--- a/apps/remote_control/test/support/lexical/test/extractor_case.ex
+++ b/apps/remote_control/test/support/lexical/test/extractor_case.ex
@@ -1,6 +1,7 @@
 defmodule Lexical.Test.ExtractorCase do
   alias Lexical.Document
   alias Lexical.RemoteControl.Search.Indexer
+
   use ExUnit.CaseTemplate
   import Lexical.Test.CodeSigil
 
@@ -12,11 +13,13 @@ defmodule Lexical.Test.ExtractorCase do
     end
   end
 
-  def do_index(source, filter, extractors \\ nil) do
+  def do_index(source, filter, extractors \\ nil)
+
+  def do_index(source, filter, extractors) when is_binary(source) do
     path = "/foo/bar/baz.ex"
     doc = Document.new("file:///#{path}", source, 1)
 
-    case Indexer.Source.index("/foo/bar/baz.ex", source, extractors) do
+    case Indexer.Source.index(path, source, extractors) do
       {:ok, indexed_items} ->
         indexed_items = Enum.filter(indexed_items, filter)
         {:ok, indexed_items, doc}
@@ -24,6 +27,11 @@ defmodule Lexical.Test.ExtractorCase do
       error ->
         error
     end
+  end
+
+  def do_index(quoted_source, filter, extractors) do
+    source_string = Macro.to_string(quoted_source)
+    do_index(source_string, filter, extractors)
   end
 
   def in_a_module(code, module_name \\ "Parent") do

--- a/apps/server/lib/lexical/server/provider/handlers/find_references.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/find_references.ex
@@ -12,12 +12,10 @@ defmodule Lexical.Server.Provider.Handlers.FindReferences do
     include_declaration? = !!request.context.include_declaration
 
     locations =
-      with {:ok, _document, %Ast.Analysis{} = analysis} <-
-             Document.Store.fetch(request.document.uri, :analysis),
-           {:ok, locations} <-
-             Api.references(env.project, analysis, request.position, include_declaration?) do
-        locations
-      else
+      case Document.Store.fetch(request.document.uri, :analysis) do
+        {:ok, _document, %Ast.Analysis{} = analysis} ->
+          Api.references(env.project, analysis, request.position, include_declaration?)
+
         _ ->
           nil
       end

--- a/apps/server/test/lexical/server/provider/handlers/find_references_test.exs
+++ b/apps/server/test/lexical/server/provider/handlers/find_references_test.exs
@@ -62,7 +62,7 @@ defmodule Lexical.Server.Provider.Handlers.FindReferencesTest do
           )
         ]
 
-        {:ok, locations}
+        locations
       end)
 
       {:ok, request} = build_request(uri, 5, 6)
@@ -73,7 +73,7 @@ defmodule Lexical.Server.Provider.Handlers.FindReferencesTest do
     end
 
     test "returns nothing if the entity can't resolve it", %{project: project, uri: uri} do
-      patch(RemoteControl.Api, :references, {:error, :not_found})
+      patch(RemoteControl.Api, :references, nil)
 
       {:ok, request} = build_request(uri, 1, 5)
 

--- a/projects/lexical_shared/lib/lexical/document/range.ex
+++ b/projects/lexical_shared/lib/lexical/document/range.ex
@@ -41,6 +41,9 @@ defmodule Lexical.Document.Range do
     %__MODULE__{start: start_pos, end: end_pos} = range
 
     cond do
+      position.line == start_pos.line and position.line == end_pos.line ->
+        position.character >= start_pos.character and position.character <= end_pos.character
+
       position.line == start_pos.line ->
         position.character >= start_pos.character
 


### PR DESCRIPTION
This PR implements find references for variables and fixes a couple bugs and missed cases in the variable indexer.

There's a notable edge case present in the implementation. A rebound variable that's assigned to a block will effectively shadow the variable of that name inside the block. I believe this is a limitation of the information we get back from the indexer, so another approach might be necessary in the future if this becomes an issue. An example follows:

```elixir
name = "Stinky"
name = if some_condition() do
  "Smelly"
else
  name
end
```

Searching for references for the `name` variable on the first line will return no results, but searching for references to the rebind on the second line will return the reference in the `else` clause in the if.