### PR TITLE
Speed up indexing by not calling `deps_dir` for every file

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/indexer.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer.ex
@@ -13,10 +13,12 @@ defmodule Lexical.RemoteControl.Search.Indexer do
 
   def create_index(%Project{} = project) do
     ProcessCache.with_cleanup do
+      deps_dir = deps_dir()
+
       entries =
         project
         |> indexable_files()
-        |> async_chunks(&index_path(&1, deps_dir()))
+        |> async_chunks(&index_path(&1, deps_dir))
 
       {:ok, entries}
     end


### PR DESCRIPTION
This significantly speeds up indexing on _very_ large codebases.
Brought down indexing time from ~2 hours to ~2 minutes on the project I tested this on.