### PR TITLE
Fixed bug where blocks weren't popped correctly

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/source/reducer.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/source/reducer.ex
@@ -87,6 +87,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Source.Reducer do
       {:expression, position} ->
         reducer
         |> update_position(position)
+        |> maybe_pop_block()
         |> apply_extractors(element)
     end
   end
@@ -176,7 +177,9 @@ defmodule Lexical.RemoteControl.Search.Indexer.Source.Reducer do
 
   defp maybe_pop_block(%__MODULE__{} = reducer) do
     if block_ended?(reducer) do
-      pop_block(reducer)
+      reducer
+      |> pop_block()
+      |> maybe_pop_block()
     else
       reducer
     end

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/structure_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/structure_test.exs
@@ -1,0 +1,52 @@
+defmodule Lexical.RemoteControl.Search.Indexer.StructureTest do
+  use Lexical.Test.ExtractorCase
+
+  def index(source) do
+    case do_index(source, fn entry -> entry.type != :metadata end) do
+      {:ok, results, _doc} -> {:ok, results}
+      error -> error
+    end
+  end
+
+  describe "blocks are correctly popped " do
+    test "when multiple blocks end at once" do
+      {:ok, results} =
+        ~q[
+          def function_1 do
+            case something() do
+              :ok -> :yep
+              _ -> :nope
+            end
+          end
+
+          defp function_2 do
+          end
+        ]
+        |> index()
+
+      [public_function, private_function] =
+        Enum.filter(results, fn entry ->
+          entry.subtype == :definition
+        end)
+
+      assert public_function.block_id == :root
+      assert private_function.block_id == :root
+    end
+
+    test "when an expression occurs after a block" do
+      {:ok, [first_call, _, last_call]} =
+        ~q[
+          first_call()
+          case something() do
+            :ok -> :yep
+            _ -> :nope
+          end
+          call()
+        ]
+        |> index()
+
+      assert first_call.block_id == :root
+      assert last_call.block_id == :root
+    end
+  end
+end


### PR DESCRIPTION
While traversing the AST, it's pretty common to not get the position updated consistently. Because of this, it's possible that there might be more than one block that needs to be popped at a time.

We were also not attempting to pop blocks when an expression occurred, which would cause block mismatches in an expression that occurred after a block ended.