### PR TITLE
Add summaries to callable completions.

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
@@ -4,7 +4,7 @@ defmodule Lexical.RemoteControl.Completion.Candidate do
 
   defmodule Function do
     @moduledoc false
-    defstruct [:argument_names, :arity, :name, :origin, :type, :visibility, :spec, :metadata]
+    defstruct [:argument_names, :arity, :name, :origin, :type, :visibility, :spec, :summary, :metadata]
 
     def new(%{} = elixir_sense_map) do
       arg_names =
@@ -55,7 +55,7 @@ defmodule Lexical.RemoteControl.Completion.Candidate do
 
   defmodule Typespec do
     @moduledoc false
-    defstruct [:argument_names, :arity, :doc, :metadata, :name, :signature, :spec]
+    defstruct [:argument_names, :arity, :doc, :metadata, :type, :name, :signature, :spec]
 
     def new(%{} = elixir_sense_map) do
       arg_names =

--- a/apps/server/lib/lexical/server/code_intelligence/completion/builder.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/builder.ex
@@ -119,7 +119,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Builder do
     case Code.Fragment.cursor_context(env.prefix) do
       {:alias, alias_charlist} ->
         alias_charlist
-        |> :string.split('.', :all)
+        |> :string.split(~c".", :all)
         |> List.last()
         |> length()
 
@@ -230,7 +230,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Builder do
     case item.documentation do
       doc when is_binary(doc) ->
         %{item | documentation: %Content{kind: :markdown, value: doc}}
-      
+
       _ ->
         item
     end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/builder.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/builder.ex
@@ -18,6 +18,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Builder do
   alias Lexical.Document.Position
   alias Lexical.Document.Range
   alias Lexical.Protocol.Types.Completion
+  alias Lexical.Protocol.Types.Markup.Content
 
   import Document.Line
 
@@ -50,6 +51,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Builder do
     options
     |> Keyword.put(:text_edit, edits)
     |> Completion.Item.new()
+    |> markdown_docs()
     |> boost(0)
   end
 
@@ -70,6 +72,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Builder do
     |> Keyword.put(:text_edit, edits)
     |> Keyword.put(:insert_text_format, :snippet)
     |> Completion.Item.new()
+    |> markdown_docs()
     |> boost(0)
   end
 
@@ -221,5 +224,15 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Builder do
   @boost_re ~r/^[0-9_]+/
   defp strip_boost(sort_text) do
     String.replace(sort_text, @boost_re, "")
+  end
+
+  defp markdown_docs(%Completion.Item{} = item) do
+    case item.documentation do
+      doc when is_binary(doc) ->
+        %{item | documentation: %Content{kind: :markdown, value: doc}}
+      
+      _ ->
+        item
+    end
   end
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
@@ -54,6 +54,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
       kind: kind,
       detail: "(#{callable.type})",
       sort_text: sort_text(callable),
+      filter_text: "#{callable.name}",
       documentation: maybe_summary(callable),
       tags: tags
     )
@@ -71,6 +72,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
         kind: :function,
         detail: "(Capture)",
         sort_text: sort_text(callable),
+        filter_text: "#{callable.name}",
         documentation: maybe_summary(callable)
       )
       |> maybe_boost(callable, 4)
@@ -82,6 +84,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
         kind: :function,
         detail: "(Capture with arguments)",
         sort_text: sort_text(callable),
+        filter_text: "#{callable.name}",
         documentation: maybe_summary(callable)
       )
       |> maybe_boost(callable, 4)

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
@@ -50,9 +50,11 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
 
     env
     |> Builder.snippet(insert_text,
-      kind: kind,
       label: label(callable, env),
+      kind: kind,
+      detail: "(#{callable.type})",
       sort_text: sort_text(callable),
+      documentation: maybe_summary(callable),
       tags: tags
     )
     |> maybe_boost(callable)
@@ -65,20 +67,22 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
     complete_capture =
       env
       |> Builder.plain_text(name_and_arity,
-        detail: "(Capture)",
-        kind: :function,
         label: name_and_arity,
-        sort_text: sort_text(callable)
+        kind: :function,
+        detail: "(Capture)",
+        sort_text: sort_text(callable),
+        documentation: maybe_summary(callable)
       )
       |> maybe_boost(callable, 4)
 
     call_capture =
       env
       |> Builder.snippet(callable_snippet(callable, env),
-        detail: "(Capture with arguments)",
-        kind: :function,
         label: label(callable, env),
-        sort_text: sort_text(callable)
+        kind: :function,
+        detail: "(Capture with arguments)",
+        sort_text: sort_text(callable),
+        documentation: maybe_summary(callable)
       )
       |> maybe_boost(callable, 4)
 
@@ -135,5 +139,19 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
       |> String.pad_leading(3, "0")
 
     "#{name}:#{normalized_arity}"
+  end
+
+  defp maybe_summary(callable) do
+    summary =
+      if Map.has_key?(callable, :summary) do
+        callable.summary
+      end
+
+    spec =
+      if Map.has_key?(callable, :spec) do
+        "```elixir\n#{callable.spec}\n```"
+      end
+
+    "#{summary}\n#{spec}"
   end
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
@@ -55,7 +55,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
       detail: "(#{callable.type})",
       sort_text: sort_text(callable),
       filter_text: "#{callable.name}",
-      documentation: maybe_summary(callable),
+      documentation: build_docs(callable),
       tags: tags
     )
     |> maybe_boost(callable)
@@ -73,7 +73,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
         detail: "(Capture)",
         sort_text: sort_text(callable),
         filter_text: "#{callable.name}",
-        documentation: maybe_summary(callable)
+        documentation: build_docs(callable)
       )
       |> maybe_boost(callable, 4)
 
@@ -85,7 +85,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
         detail: "(Capture with arguments)",
         sort_text: sort_text(callable),
         filter_text: "#{callable.name}",
-        documentation: maybe_summary(callable)
+        documentation: build_docs(callable)
       )
       |> maybe_boost(callable, 4)
 
@@ -144,17 +144,20 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
     "#{name}:#{normalized_arity}"
   end
 
-  defp maybe_summary(callable) do
-    summary =
-      if Map.has_key?(callable, :summary) do
-        callable.summary
-      end
+  defp build_docs(%{summary: summary, spec: spec})
+       when is_binary(summary) and is_binary(spec) do
+    "#{summary}\n```elixir\n#{spec}\n```"
+  end
 
-    spec =
-      if Map.has_key?(callable, :spec) do
-        "```elixir\n#{callable.spec}\n```"
-      end
+  defp build_docs(%{summary: summary}) when is_binary(summary) do
+    summary
+  end
 
-    "#{summary}\n#{spec}"
+  defp build_docs(%{spec: spec}) when is_binary(spec) do
+    "```elixir\n#{spec}\n```"
+  end
+
+  defp build_docs(_) do
+    ""
   end
 end


### PR DESCRIPTION
* Include `:summary` from elixir_sense callback candidates.
* Append `@spec`'s to them as well.
* Format `:documentation` as markdown in LSP completions.
* Include the type of callable as a completion detail.