### PR TITLE
Slimmed down representations of range and position

### DIFF
--- a/projects/lexical_shared/lib/lexical/document/position.ex
+++ b/projects/lexical_shared/lib/lexical/document/position.ex
@@ -15,7 +15,6 @@ defmodule Lexical.Document.Position do
   alias Lexical.Document
   alias Lexical.Document.Lines
 
-  @derive {Inspect, only: [:line, :character]}
   defstruct [
     :line,
     :character,
@@ -70,5 +69,21 @@ defmodule Lexical.Document.Position do
           starting_index: starting_index
         }
     end
+  end
+end
+
+defimpl Inspect, for: Lexical.Document.Position do
+  import Inspect.Algebra
+
+  def inspect(nil, _), do: "nil"
+
+  def inspect(pos, _) do
+    concat(["LxPos", to_string(pos)])
+  end
+end
+
+defimpl String.Chars, for: Lexical.Document.Position do
+  def to_string(pos) do
+    "<<#{pos.line}, #{pos.character}>>"
   end
 end

--- a/projects/lexical_shared/lib/lexical/document/range.ex
+++ b/projects/lexical_shared/lib/lexical/document/range.ex
@@ -55,3 +55,11 @@ defmodule Lexical.Document.Range do
     end
   end
 end
+
+defimpl Inspect, for: Lexical.Document.Range do
+  import Inspect.Algebra
+
+  def inspect(range, _) do
+    concat(["LxRange[", to_string(range.start), "...", to_string(range.end), "]"])
+  end
+end


### PR DESCRIPTION
We use range and positions a lot, and the default inspect implementations were very wordy. This changes them to:

Range: `LxRange[<<1, 1>>...<<5,1>>]`
Position: `LxPos<<1, 1>>`