### PR TITLE
Fixed issue where function definitions were returning references

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_definition.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_definition.ex
@@ -11,7 +11,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinition do
 
   @function_definitions [:def, :defp]
 
-  def extract({definition, metadata, [{fn_name, _, args}, body]} = ast, %Reducer{} = reducer)
+  def extract({definition, metadata, [{fn_name, _, args}, body]}, %Reducer{} = reducer)
       when is_atom(fn_name) and definition in @function_definitions do
     range = get_definition_range(reducer.analysis, metadata, body)
 
@@ -39,7 +39,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinition do
     entry =
       Entry.block_definition(path, block, mfa, type, range, Application.get_application(module))
 
-    {:ok, entry, ast}
+    {:ok, entry, [args, body]}
   end
 
   def extract(_ast, _reducer) do

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/function_definition_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/function_definition_test.exs
@@ -7,6 +7,12 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinitionTest
     end)
   end
 
+  def index_all(source) do
+    do_index(source, fn entry ->
+      entry.type in [:function, :public_function, :private_function]
+    end)
+  end
+
   describe "indexing public function definitions" do
     test "finds zero arity public functions (no parens)" do
       code =
@@ -128,6 +134,20 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinitionTest
 
       {:ok, [something], _} = index(code)
       assert "def something(name) do" = extract(code, something.range)
+    end
+
+    test "returns no references" do
+      {:ok, [function_definition], doc} =
+        ~q[
+        def my_fn(a, b) do
+        end
+        ]
+        |> in_a_module()
+        |> index_all()
+
+      assert function_definition.type == :public_function
+      assert function_definition.subtype == :definition
+      assert "def my_fn(a, b) do" = extract(doc, function_definition.range)
     end
   end
 
@@ -273,6 +293,20 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinitionTest
 
       {:ok, [something], _} = index(code)
       assert "defp something(name) do" = extract(code, something.range)
+    end
+
+    test "returns no references" do
+      {:ok, [function_definition], doc} =
+        ~q[
+        defp my_fn(a, b) do
+        end
+        ]
+        |> in_a_module()
+        |> index_all()
+
+      assert function_definition.type == :private_function
+      assert function_definition.subtype == :definition
+      assert "defp my_fn(a, b) do" = extract(doc, function_definition.range)
     end
   end
 end


### PR DESCRIPTION
There was an issue where function definitions were returning references as well as the definition. This is because the function definition extractor didn't consume the definition AST and passed it to the function reference extractor, which would pick up the references.