### PR TITLE
For module definitions, use the `Indexer` version instead of `ElixirSense`

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -68,9 +68,9 @@ defmodule Lexical.RemoteControl.Api do
     ])
   end
 
-  def definition(%Project{} = project, %Analysis{} = analysis, %Position{} = position) do
+  def definition(%Project{} = project, %Document{} = document, %Position{} = position) do
     RemoteControl.call(project, CodeIntelligence.Definition, :definition, [
-      analysis,
+      document,
       position
     ])
   end

--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -68,9 +68,9 @@ defmodule Lexical.RemoteControl.Api do
     ])
   end
 
-  def definition(%Project{} = project, %Document{} = document, %Position{} = position) do
+  def definition(%Project{} = project, %Analysis{} = analysis, %Position{} = position) do
     RemoteControl.call(project, CodeIntelligence.Definition, :definition, [
-      document,
+      analysis,
       position
     ])
   end

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/definition.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/definition.ex
@@ -21,8 +21,9 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Definition do
        when type in [:struct, :module] do
     module = Formats.module(entity)
 
-    with [entry] <- Store.exact(module, type: type, subtype: :definition) do
-      to_location(entry)
+    case Store.exact(module, type: type, subtype: :definition) do
+      [entry] -> to_location(entry)
+      _other -> :error
     end
   end
 

--- a/apps/remote_control/test/fixtures/navigations/lib/my_definition.ex
+++ b/apps/remote_control/test/fixtures/navigations/lib/my_definition.ex
@@ -1,6 +1,8 @@
 defmodule MyDefinition do
   @type result :: String.t()
 
+  defstruct [:field, another_field: nil]
+
   defmacro __using__(_opts) do
     quote do
       import MyDefinition

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/definition_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/definition_test.exs
@@ -354,9 +354,8 @@ defmodule Lexical.RemoteControl.CodeIntelligence.DefinitionTest do
     with {position, code} <- pop_cursor(code),
          {:ok, document} <- subject_module(project, code),
          :ok <- index(document, referenced_uri),
-         analysis = Lexical.Ast.analyze(document),
          {:ok, %Location{} = location} <-
-           RemoteControl.Api.definition(project, analysis, position) do
+           RemoteControl.Api.definition(project, document, position) do
       {:ok, location.document.uri, decorate(location.document, location.range)}
     end
   end

--- a/apps/server/lib/lexical/server/provider/handlers/go_to_definition.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/go_to_definition.ex
@@ -12,7 +12,7 @@ defmodule Lexical.Server.Provider.Handlers.GoToDefinition do
 
       {:error, reason} ->
         Logger.error("GoToDefinition failed: #{inspect(reason)}")
-        {:error, Responses.GoToDefinition.error(request.id, :request_failed, inspect(reason))}
+        {:reply, Responses.GoToDefinition.error(request.id, :request_failed, inspect(reason))}
     end
   end
 end

--- a/apps/server/test/lexical/server/provider/handlers/go_to_definition_test.exs
+++ b/apps/server/test/lexical/server/provider/handlers/go_to_definition_test.exs
@@ -15,7 +15,7 @@ defmodule Lexical.Server.Provider.Handlers.GoToDefinitionTest do
   use ExUnit.Case, async: false
 
   setup_all do
-    start_supervised(Document.Store)
+    start_supervised!(Server.Application.document_store_child_spec())
     project = project(:navigations)
 
     {:ok, _} = start_supervised({DynamicSupervisor, Server.Project.Supervisor.options()})
@@ -61,11 +61,6 @@ defmodule Lexical.Server.Provider.Handlers.GoToDefinitionTest do
       {:ok, request} = build_request(uses_file_path, 4, 17)
 
       {:reply, %{result: %Location{} = location}} = handle(request, project)
-
-      assert location.range.start.line == 15
-      assert location.range.start.character == 7
-      assert location.range.end.line == 15
-      assert location.range.end.character == 12
       assert Location.uri(location) == referenced_uri
     end
   end


### PR DESCRIPTION
Fixes #649