### PR TITLE
Use `languageId` field provided by LSP clients.

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build.ex
@@ -2,6 +2,7 @@ defmodule Lexical.RemoteControl.Build do
   alias Lexical.Document
   alias Lexical.Project
   alias Lexical.RemoteControl
+  alias Lexical.RemoteControl.Build.Document.Compilers.HEEx
   alias Lexical.RemoteControl.Build.State
   alias Lexical.VM.Versions
 
@@ -26,7 +27,8 @@ defmodule Lexical.RemoteControl.Build do
   end
 
   def compile_document(%Project{} = project, %Document{} = document) do
-    unless Path.absname(document.path) == "mix.exs" do
+    with false <- Path.absname(document.path) == "mix.exs",
+         false <- HEEx.recognizes?(document.language_id) do
       RemoteControl.call(project, GenServer, :cast, [__MODULE__, {:compile_file, document}])
     end
 
@@ -35,7 +37,8 @@ defmodule Lexical.RemoteControl.Build do
 
   # this is for testing
   def force_compile_document(%Project{} = project, %Document{} = document) do
-    unless Path.absname(document.path) == "mix.exs" do
+    with false <- Path.absname(document.path) == "mix.exs",
+         false <- HEEx.recognizes?(document.language_id) do
       RemoteControl.call(project, GenServer, :call, [
         __MODULE__,
         {:force_compile_file, document}

--- a/apps/remote_control/lib/lexical/remote_control/build/document/compilers/eex.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document/compilers/eex.ex
@@ -10,14 +10,14 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.EEx do
 
   @behaviour Compiler
 
-  def recognizes?(%Document{} = document) do
-    Path.extname(document.path) == ".eex"
-  end
+  @impl true
+  def recognizes?(%Document{language_id: "eex"}), do: true
+  def recognizes?(_), do: false
 
-  def enabled? do
-    true
-  end
+  @impl true
+  def enabled?, do: true
 
+  @impl true
   def compile(%Document{} = document) do
     with {:ok, quoted} <- eex_to_quoted(document),
          :ok <- eval_quoted(document, quoted) do

--- a/apps/remote_control/lib/lexical/remote_control/build/document/compilers/elixir.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document/compilers/elixir.ex
@@ -9,16 +9,15 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.Elixir do
   alias Lexical.RemoteControl.Build.Document.Compilers
 
   @behaviour Build.Document.Compiler
-  @valid_extensions ~w(.ex .exs)
 
-  def recognizes?(%Document{} = doc) do
-    Path.extname(doc.path) in @valid_extensions
-  end
+  @impl true
+  def recognizes?(%Document{language_id: "elixir"}), do: true
+  def recognizes?(_), do: false
 
-  def enabled? do
-    true
-  end
+  @impl true
+  def enabled?, do: true
 
+  @impl true
   def compile(%Document{} = document) do
     case to_quoted(document) do
       {:ok, quoted} ->

--- a/apps/remote_control/lib/lexical/remote_control/build/document/compilers/heex.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document/compilers/heex.ex
@@ -10,9 +10,9 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.HEEx do
 
   @behaviour Compiler
 
-  def recognizes?(%Document{} = document) do
-    Path.extname(document.path) == ".heex"
-  end
+  def recognizes?(%Document{language_id: "phoenix-heex"}), do: true
+  def recognizes?(%Document{language_id: "heex"}), do: true
+  def recognizes?(_), do: false
 
   def enabled? do
     true

--- a/apps/remote_control/lib/lexical/remote_control/code_action/handlers/replace_remote_function.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_action/handlers/replace_remote_function.ex
@@ -93,7 +93,7 @@ defmodule Lexical.RemoteControl.CodeAction.Handlers.ReplaceRemoteFunction do
     end
   end
 
-  @function_re ~r/(warning: )?([^\/]+)\/(.*) is undefined or private. Did you mean:.*/
+  @function_re ~r/(warning: |function )?([^\/]+)\/(.*) is undefined or private. Did you mean:.*/
   defp extract_function(message) do
     result =
       with [[_, _, module_and_function, arity]] <- Regex.scan(@function_re, message),

--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -176,7 +176,7 @@ defmodule Lexical.Server.State do
       uri: uri,
       version: version,
       language_id: language_id
-    } = did_open.lsp.text_document
+    } = did_open.text_document
 
     case Document.Store.open(uri, text, version, language_id) do
       :ok ->

--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -170,11 +170,20 @@ defmodule Lexical.Server.State do
     end
   end
 
-  def apply(%__MODULE__{} = state, %DidOpen{lsp: event}) do
-    %TextDocument.Item{text: text, uri: uri, version: version} =
-      text_document = event.text_document
+  def apply(%__MODULE__{} = state, %DidOpen{} = did_open) do
+    %DidOpen{
+      lsp: %DidOpen.LSP{
+        text_document:
+          %TextDocument.Item{
+            text: text,
+            uri: uri,
+            version: version,
+            language_id: language_id
+          } = text_document
+      }
+    } = did_open
 
-    case Document.Store.open(uri, text, version) do
+    case Document.Store.open(uri, text, language_id, version) do
       :ok ->
         Logger.info("opened #{uri}")
         {:ok, state}

--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -178,7 +178,7 @@ defmodule Lexical.Server.State do
       language_id: language_id
     } = event.text_document
 
-    case Document.Store.open(uri, text, language_id, version) do
+    case Document.Store.open(uri, text, version, language_id) do
       :ok ->
         Logger.info("opened #{uri}")
         {:ok, state}

--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -170,18 +170,13 @@ defmodule Lexical.Server.State do
     end
   end
 
-  def apply(%__MODULE__{} = state, %DidOpen{} = did_open) do
-    %DidOpen{
-      lsp: %DidOpen.LSP{
-        text_document:
-          %TextDocument.Item{
-            text: text,
-            uri: uri,
-            version: version,
-            language_id: language_id
-          } = text_document
-      }
-    } = did_open
+  def apply(%__MODULE__{} = state, %DidOpen{lsp: event}) do
+    %TextDocument.Item{
+      text: text,
+      uri: uri,
+      version: version,
+      language_id: language_id
+    } = event.text_document
 
     case Document.Store.open(uri, text, language_id, version) do
       :ok ->
@@ -189,7 +184,7 @@ defmodule Lexical.Server.State do
         {:ok, state}
 
       error ->
-        Logger.error("Could not open #{text_document.uri} #{inspect(error)}")
+        Logger.error("Could not open #{uri} #{inspect(error)}")
         error
     end
   end

--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -170,13 +170,13 @@ defmodule Lexical.Server.State do
     end
   end
 
-  def apply(%__MODULE__{} = state, %DidOpen{lsp: event}) do
+  def apply(%__MODULE__{} = state, %DidOpen{} = did_open) do
     %TextDocument.Item{
       text: text,
       uri: uri,
       version: version,
       language_id: language_id
-    } = event.text_document
+    } = did_open.lsp.text_document
 
     case Document.Store.open(uri, text, version, language_id) do
       :ok ->

--- a/projects/lexical_shared/lib/lexical/document.ex
+++ b/projects/lexical_shared/lib/lexical/document.ex
@@ -44,28 +44,22 @@ defmodule Lexical.Document do
   as a binary and the vewrsion.
   """
   @spec new(Lexical.path() | Lexical.uri(), String.t(), version()) :: t
-  def new(maybe_uri, text, version) do
+  def new(maybe_uri, text, version, language_id \\ nil) do
     uri = DocumentPath.ensure_uri(maybe_uri)
     path = DocumentPath.from_uri(uri)
-    lang_id = language_id_from_path(path)
+
+    language_id =
+      if language_id === nil do
+        language_id_from_path(path)
+      else
+        language_id
+      end
 
     %__MODULE__{
       uri: uri,
       version: version,
       lines: Lines.new(text),
       path: path,
-      language_id: lang_id
-    }
-  end
-
-  def new(maybe_uri, text, language_id, version) do
-    uri = DocumentPath.ensure_uri(maybe_uri)
-
-    %__MODULE__{
-      uri: uri,
-      version: version,
-      lines: Lines.new(text),
-      path: DocumentPath.from_uri(uri),
       language_id: language_id
     }
   end

--- a/projects/lexical_shared/lib/lexical/document.ex
+++ b/projects/lexical_shared/lib/lexical/document.ex
@@ -45,7 +45,7 @@ defmodule Lexical.Document do
   def new(maybe_uri, text, version) do
     uri = DocumentPath.ensure_uri(maybe_uri)
     path = DocumentPath.from_uri(uri)
-    lang_id = DocumentPath.language_id_from_path(path)
+    lang_id = language_id_from_path(path)
 
     %__MODULE__{
       uri: uri,
@@ -233,6 +233,28 @@ defmodule Lexical.Document do
     document
     |> to_iodata()
     |> IO.iodata_to_binary()
+  end
+
+  @spec language_id_from_path(Lexical.path()) :: String.t()
+  def language_id_from_path(path) do
+    case Path.extname(path) do
+      ".ex" ->
+        "elixir"
+
+      ".exs" ->
+        "elixir"
+
+      ".eex" ->
+        "eex"
+
+      ".heex" ->
+        "phoenix-heex"
+
+      extension ->
+        Logger.warning("can't infer lang ID for #{path}, ext: #{extension}.")
+
+        "unsupported (#{extension})"
+    end
   end
 
   # private

--- a/projects/lexical_shared/lib/lexical/document.ex
+++ b/projects/lexical_shared/lib/lexical/document.ex
@@ -20,12 +20,13 @@ defmodule Lexical.Document do
 
   @derive {Inspect, only: [:path, :version, :dirty?, :lines]}
 
-  defstruct [:uri, :path, :version, dirty?: false, lines: nil]
+  defstruct [:uri, :language_id, :path, :version, dirty?: false, lines: nil]
 
   @type version :: non_neg_integer()
   @type fragment_position :: Position.t() | Convertible.t()
   @type t :: %__MODULE__{
           uri: String.t(),
+          language_id: String.t(),
           version: version(),
           dirty?: boolean,
           lines: Lines.t(),
@@ -43,12 +44,27 @@ defmodule Lexical.Document do
   @spec new(Lexical.path() | Lexical.uri(), String.t(), version()) :: t
   def new(maybe_uri, text, version) do
     uri = DocumentPath.ensure_uri(maybe_uri)
+    path = DocumentPath.from_uri(uri)
+    lang_id = DocumentPath.language_id_from_path(path)
 
     %__MODULE__{
       uri: uri,
       version: version,
       lines: Lines.new(text),
-      path: DocumentPath.from_uri(uri)
+      path: path,
+      language_id: lang_id
+    }
+  end
+
+  def new(maybe_uri, text, language_id, version) do
+    uri = DocumentPath.ensure_uri(maybe_uri)
+
+    %__MODULE__{
+      uri: uri,
+      version: version,
+      lines: Lines.new(text),
+      path: DocumentPath.from_uri(uri),
+      language_id: language_id
     }
   end
 

--- a/projects/lexical_shared/lib/lexical/document.ex
+++ b/projects/lexical_shared/lib/lexical/document.ex
@@ -16,6 +16,8 @@ defmodule Lexical.Document do
 
   import Lexical.Document.Line
 
+  require Logger
+
   alias __MODULE__.Path, as: DocumentPath
 
   @derive {Inspect, only: [:path, :version, :dirty?, :lines]}
@@ -233,6 +235,13 @@ defmodule Lexical.Document do
     document
     |> to_iodata()
     |> IO.iodata_to_binary()
+  end
+
+  @spec language_id_from_uri(Lexical.uri()) :: String.t()
+  def language_id_from_uri(uri) do
+    %URI{path: path} = URI.parse(uri)
+
+    language_id_from_path(path)
   end
 
   @spec language_id_from_path(Lexical.path()) :: String.t()

--- a/projects/lexical_shared/lib/lexical/document.ex
+++ b/projects/lexical_shared/lib/lexical/document.ex
@@ -48,12 +48,7 @@ defmodule Lexical.Document do
     uri = DocumentPath.ensure_uri(maybe_uri)
     path = DocumentPath.from_uri(uri)
 
-    language_id =
-      if language_id === nil do
-        language_id_from_path(path)
-      else
-        language_id
-      end
+    language_id = language_id || language_id_from_path(path)
 
     %__MODULE__{
       uri: uri,
@@ -231,15 +226,8 @@ defmodule Lexical.Document do
     |> IO.iodata_to_binary()
   end
 
-  @spec language_id_from_uri(Lexical.uri()) :: String.t()
-  def language_id_from_uri(uri) do
-    %URI{path: path} = URI.parse(uri)
-
-    language_id_from_path(path)
-  end
-
   @spec language_id_from_path(Lexical.path()) :: String.t()
-  def language_id_from_path(path) do
+  defp language_id_from_path(path) do
     case Path.extname(path) do
       ".ex" ->
         "elixir"

--- a/projects/lexical_shared/lib/lexical/document/path.ex
+++ b/projects/lexical_shared/lib/lexical/document/path.ex
@@ -127,28 +127,6 @@ defmodule Lexical.Document.Path do
     end
   end
 
-  @spec language_id_from_path(Lexical.path()) :: String.t()
-  def language_id_from_path(path) do
-    case Path.extname(path) do
-      ".ex" ->
-        "elixir"
-
-      ".exs" ->
-        "elixir"
-
-      ".eex" ->
-        "eex"
-
-      ".heex" ->
-        "phoenix-heex"
-
-      extension ->
-        Logger.warning("can't infer lang ID for #{path}, ext: #{extension}.")
-
-        "unsupported (#{extension})"
-    end
-  end
-
   @spec language_id_from_uri(Lexical.uri()) :: String.t()
   def language_id_from_uri(uri) do
     %URI{path: path} = URI.parse(uri)

--- a/projects/lexical_shared/lib/lexical/document/path.ex
+++ b/projects/lexical_shared/lib/lexical/document/path.ex
@@ -1,9 +1,8 @@
 defmodule Lexical.Document.Path do
-  require Logger
-
   @moduledoc """
   A collection of functions dealing with converting filesystem paths to URIs and back
   """
+
   @file_scheme "file"
 
   @type uri_or_path :: Lexical.uri() | Lexical.path()
@@ -125,13 +124,6 @@ defmodule Lexical.Document.Path do
     else
       path
     end
-  end
-
-  @spec language_id_from_uri(Lexical.uri()) :: String.t()
-  def language_id_from_uri(uri) do
-    %URI{path: path} = URI.parse(uri)
-
-    language_id_from_path(path)
   end
 
   defp convert_separators_to_universal(path) do

--- a/projects/lexical_shared/lib/lexical/document/path.ex
+++ b/projects/lexical_shared/lib/lexical/document/path.ex
@@ -1,4 +1,6 @@
 defmodule Lexical.Document.Path do
+  require Logger
+
   @moduledoc """
   A collection of functions dealing with converting filesystem paths to URIs and back
   """
@@ -123,6 +125,35 @@ defmodule Lexical.Document.Path do
     else
       path
     end
+  end
+
+  @spec language_id_from_path(Lexical.path()) :: String.t()
+  def language_id_from_path(path) do
+    case Path.extname(path) do
+      ".ex" ->
+        "elixir"
+
+      ".exs" ->
+        "elixir"
+
+      ".eex" ->
+        "eex"
+
+      ".heex" ->
+        "phoenix-heex"
+
+      extension ->
+        Logger.warning("can't infer lang ID for #{path}, ext: #{extension}.")
+
+        "unsupported (#{extension})"
+    end
+  end
+
+  @spec language_id_from_uri(Lexical.uri()) :: String.t()
+  def language_id_from_uri(uri) do
+    %URI{path: path} = URI.parse(uri)
+
+    language_id_from_path(path)
   end
 
   defp convert_separators_to_universal(path) do

--- a/projects/lexical_shared/lib/lexical/document/path.ex
+++ b/projects/lexical_shared/lib/lexical/document/path.ex
@@ -2,7 +2,6 @@ defmodule Lexical.Document.Path do
   @moduledoc """
   A collection of functions dealing with converting filesystem paths to URIs and back
   """
-
   @file_scheme "file"
 
   @type uri_or_path :: Lexical.uri() | Lexical.path()

--- a/projects/lexical_shared/lib/lexical/document/store.ex
+++ b/projects/lexical_shared/lib/lexical/document/store.ex
@@ -259,7 +259,7 @@ defmodule Lexical.Document.Store do
 
   @spec open(Lexical.uri(), String.t(), pos_integer()) :: :ok | {:error, :already_open}
   def open(uri, text, version) do
-    language_id = Document.Path.language_id_from_uri(uri)
+    language_id = Document.language_id_from_uri(uri)
 
     GenServer.call(name(), {:open, uri, text, language_id, version})
   end

--- a/projects/lexical_shared/lib/lexical/document/store.ex
+++ b/projects/lexical_shared/lib/lexical/document/store.ex
@@ -93,8 +93,6 @@ defmodule Lexical.Document.Store do
 
     @spec open(t, Lexical.uri(), String.t(), pos_integer(), String.t()) ::
             {:ok, t} | {:error, :already_open}
-    def open(store, uri, text, version, language_id \\ nil)
-
     def open(%__MODULE__{temporary_open_refs: refs} = store, uri, text, version, language_id)
         when is_map_key(refs, uri) do
       {_, store} =
@@ -259,16 +257,9 @@ defmodule Lexical.Document.Store do
     GenServer.call(name(), {:open?, uri})
   end
 
-  @spec open(Lexical.uri(), String.t(), pos_integer()) :: :ok | {:error, :already_open}
-  def open(uri, text, version) do
-    language_id = Document.language_id_from_uri(uri)
-
-    GenServer.call(name(), {:open, uri, text, version, language_id})
-  end
-
-  @spec open(Lexical.uri(), String.t(), String.t(), pos_integer()) ::
+  @spec open(Lexical.uri(), String.t(), String.t(), pos_integer() | nil) ::
           :ok | {:error, :already_open}
-  def open(uri, text, version, language_id) do
+  def open(uri, text, version, language_id \\ nil) do
     GenServer.call(name(), {:open, uri, text, version, language_id})
   end
 

--- a/projects/lexical_shared/lib/lexical/document/store.ex
+++ b/projects/lexical_shared/lib/lexical/document/store.ex
@@ -91,7 +91,7 @@ defmodule Lexical.Document.Store do
       end
     end
 
-    @spec open(t, Lexical.uri(), String.t(), String.t(), pos_integer()) ::
+    @spec open(t, Lexical.uri(), String.t(), pos_integer(), String.t()) ::
             {:ok, t} | {:error, :already_open}
     def open(store, uri, text, version, language_id \\ nil)
 


### PR DESCRIPTION
Presently, Lexical reads file extensions to evaluate files as eex, heex, or elixir. This approach doesn't work for documents that haven't been saved to the file system. Consequently unsaved eex and heex files don't receive proper diagnostics.

This commit adds `language_id` to the `Document` struct and sets it when provided by LSP. If not available, the file extension will be used as a fallback.