### PR TITLE
Fix: Current module not identified in defimpl

### DIFF
--- a/apps/common/lib/lexical/ast/analysis.ex
+++ b/apps/common/lib/lexical/ast/analysis.ex
@@ -200,11 +200,11 @@ defmodule Lexical.Ast.Analysis do
           ]} = quoted,
          state
        ) do
-    module = protocol_segments
+    module = protocol_segments ++ for_segments
     line = meta[:line]
     current_module_alias = Alias.new(module, :__MODULE__, line)
     for_alias = Alias.new(for_segments, :"@for", line)
-    protocol_alias = Alias.new(module, :"@protocol", line)
+    protocol_alias = Alias.new(protocol_segments, :"@protocol", line)
 
     state
     |> maybe_push_implicit_alias(protocol_segments, line)

--- a/apps/remote_control/test/lexical/remote_control/analyzer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/analyzer_test.exs
@@ -29,13 +29,13 @@ defmodule Lexical.RemoteControl.AnalyzerTest do
     test "works with @protocol in a protocol" do
       {position, document} =
         ~q[
-      defimpl MyProtocol, for: Atom do
+        defimpl MyProtocol, for: Atom do
 
-        def pack(atom) do
-          |
+          def pack(atom) do
+            |
+          end
         end
-      end
-      ]
+        ]
         |> pop_cursor(as: :document)
 
       analysis = Ast.analyze(document)
@@ -59,6 +59,22 @@ defmodule Lexical.RemoteControl.AnalyzerTest do
                  analysis,
                  position
                )
+    end
+
+    test "identifies the module in a protocol implementation" do
+      {position, document} =
+        ~q[
+          defimpl MyProtocol, for: Atom do
+
+            def pack(atom) do
+              |
+            end
+          end
+        ]
+        |> pop_cursor(as: :document)
+
+      analysis = Ast.analyze(document)
+      assert {:ok, MyProtocol.Atom} == Analyzer.current_module(analysis, position)
     end
   end
 


### PR DESCRIPTION
Our defimpl resolver was not generating the current module name. It was returning the same module as the protocol, which is incorrect