### PR TITLE
Handled comments when resolving locations

### DIFF
--- a/apps/common/lib/lexical/ast/detection.ex
+++ b/apps/common/lib/lexical/ast/detection.ex
@@ -9,13 +9,13 @@ defmodule Lexical.Ast.Detection do
   """
 
   alias Lexical.Ast
-  alias Lexical.Document
+  alias Lexical.Ast.Analysis
   alias Lexical.Document.Position
 
   @doc """
   Returns true if the given position is detected by the current module
   """
-  @callback detected?(Document.t(), Position.t()) :: boolean()
+  @callback detected?(Analysis.t(), Position.t()) :: boolean()
 
   defmacro __using__(_) do
     quote do
@@ -24,8 +24,8 @@ defmodule Lexical.Ast.Detection do
     end
   end
 
-  def ancestor_is_def?(%Document{} = document, %Position{} = position) do
-    document
+  def ancestor_is_def?(%Analysis{} = analysis, %Position{} = position) do
+    analysis
     |> Ast.cursor_path(position)
     |> Enum.any?(fn
       {:def, _, _} ->
@@ -40,8 +40,8 @@ defmodule Lexical.Ast.Detection do
   end
 
   @type_keys [:type, :typep, :opaque]
-  def ancestor_is_type?(%Document{} = document, %Position{} = position) do
-    document
+  def ancestor_is_type?(%Analysis{} = analysis, %Position{} = position) do
+    analysis
     |> Ast.cursor_path(position)
     |> Enum.any?(fn
       {:@, metadata, [{type_key, _, _}]} when type_key in @type_keys ->
@@ -58,8 +58,8 @@ defmodule Lexical.Ast.Detection do
     end)
   end
 
-  def ancestor_is_spec?(%Document{} = document, %Position{} = position) do
-    document
+  def ancestor_is_spec?(%Analysis{} = analysis, %Position{} = position) do
+    analysis
     |> Ast.cursor_path(position)
     |> Enum.any?(fn
       {:@, metadata, [{:spec, _, _}]} ->

--- a/apps/common/lib/lexical/ast/detection/alias.ex
+++ b/apps/common/lib/lexical/ast/detection/alias.ex
@@ -1,7 +1,7 @@
 defmodule Lexical.Ast.Detection.Alias do
+  alias Lexical.Ast.Analysis
   alias Lexical.Ast.Detection
   alias Lexical.Ast.Tokens
-  alias Lexical.Document
   alias Lexical.Document.Position
 
   use Detection
@@ -22,8 +22,8 @@ defmodule Lexical.Ast.Detection.Alias do
   we backtrack until we hit the alias keyword
   """
   @impl Detection
-  def detected?(%Document{} = document, %Position{} = position) do
-    document
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    analysis.document
     |> Tokens.prefix_stream(position)
     |> Stream.with_index()
     |> Enum.to_list()

--- a/apps/common/lib/lexical/ast/detection/bitstring.ex
+++ b/apps/common/lib/lexical/ast/detection/bitstring.ex
@@ -1,4 +1,5 @@
 defmodule Lexical.Ast.Detection.Bitstring do
+  alias Lexical.Ast.Analysis
   alias Lexical.Ast.Detection
   alias Lexical.Ast.Tokens
   alias Lexical.Document
@@ -7,7 +8,8 @@ defmodule Lexical.Ast.Detection.Bitstring do
   use Detection
 
   @impl Detection
-  def detected?(%Document{} = document, %Position{} = position) do
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    document = analysis.document
     Document.fragment(document, Position.new(document, position.line, 1), position)
 
     document

--- a/apps/common/lib/lexical/ast/detection/comment.ex
+++ b/apps/common/lib/lexical/ast/detection/comment.ex
@@ -1,0 +1,8 @@
+defmodule Lexical.Ast.Detection.Comment do
+  alias Lexical.Ast.Analysis
+  alias Lexical.Document.Position
+
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    Analysis.commented?(analysis, position)
+  end
+end

--- a/apps/common/lib/lexical/ast/detection/directive.ex
+++ b/apps/common/lib/lexical/ast/detection/directive.ex
@@ -1,10 +1,10 @@
 defmodule Lexical.Ast.Detection.Directive do
+  alias Lexical.Ast.Analysis
   alias Lexical.Ast.Tokens
-  alias Lexical.Document
   alias Lexical.Document.Position
 
-  def detected?(%Document{} = document, %Position{} = position, directive_type) do
-    document
+  def detected?(%Analysis{} = analysis, %Position{} = position, directive_type) do
+    analysis.document
     |> Tokens.prefix_stream(position)
     |> Enum.to_list()
     |> Enum.reduce_while(false, fn

--- a/apps/common/lib/lexical/ast/detection/function_capture.ex
+++ b/apps/common/lib/lexical/ast/detection/function_capture.ex
@@ -1,14 +1,14 @@
 defmodule Lexical.Ast.Detection.FunctionCapture do
+  alias Lexical.Ast.Analysis
   alias Lexical.Ast.Detection
   alias Lexical.Ast.Tokens
-  alias Lexical.Document
   alias Lexical.Document.Position
 
   use Detection
 
   @impl Detection
-  def detected?(%Document{} = document, %Position{} = position) do
-    document
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    analysis.document
     |> Tokens.prefix_stream(position)
     |> Enum.reduce_while(false, fn
       {:paren, :")", _}, _ ->

--- a/apps/common/lib/lexical/ast/detection/import.ex
+++ b/apps/common/lib/lexical/ast/detection/import.ex
@@ -1,13 +1,13 @@
 defmodule Lexical.Ast.Detection.Import do
+  alias Lexical.Ast.Analysis
   alias Lexical.Ast.Detection
   alias Lexical.Ast.Detection.Directive
-  alias Lexical.Document
   alias Lexical.Document.Position
 
   use Detection
 
   @impl Detection
-  def detected?(%Document{} = document, %Position{} = position) do
-    Directive.detected?(document, position, 'import')
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    Directive.detected?(analysis, position, 'import')
   end
 end

--- a/apps/common/lib/lexical/ast/detection/pipe.ex
+++ b/apps/common/lib/lexical/ast/detection/pipe.ex
@@ -1,14 +1,14 @@
 defmodule Lexical.Ast.Detection.Pipe do
+  alias Lexical.Ast.Analysis
   alias Lexical.Ast.Detection
   alias Lexical.Ast.Tokens
-  alias Lexical.Document
   alias Lexical.Document.Position
 
   use Detection
 
   @impl Detection
-  def detected?(%Document{} = document, %Position{} = position) do
-    document
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    analysis.document
     |> Tokens.prefix_stream(position)
     |> Enum.to_list()
     |> Enum.reduce_while(false, fn

--- a/apps/common/lib/lexical/ast/detection/require.ex
+++ b/apps/common/lib/lexical/ast/detection/require.ex
@@ -1,13 +1,13 @@
 defmodule Lexical.Ast.Detection.Require do
+  alias Lexical.Ast.Analysis
   alias Lexical.Ast.Detection
   alias Lexical.Ast.Detection.Directive
-  alias Lexical.Document
   alias Lexical.Document.Position
 
   use Detection
 
   @impl Detection
-  def detected?(%Document{} = document, %Position{} = position) do
-    Directive.detected?(document, position, 'require')
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    Directive.detected?(analysis, position, 'require')
   end
 end

--- a/apps/common/lib/lexical/ast/detection/spec.ex
+++ b/apps/common/lib/lexical/ast/detection/spec.ex
@@ -1,12 +1,12 @@
 defmodule Lexical.Ast.Detection.Spec do
+  alias Lexical.Ast.Analysis
   alias Lexical.Ast.Detection
-  alias Lexical.Document
   alias Lexical.Document.Position
 
   use Detection
 
   @impl Detection
-  def detected?(%Document{} = document, %Position{} = position) do
-    ancestor_is_spec?(document, position)
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    ancestor_is_spec?(analysis, position)
   end
 end

--- a/apps/common/lib/lexical/ast/detection/struct_field_key.ex
+++ b/apps/common/lib/lexical/ast/detection/struct_field_key.ex
@@ -1,14 +1,14 @@
 defmodule Lexical.Ast.Detection.StructFieldKey do
   alias Lexical.Ast
+  alias Lexical.Ast.Analysis
   alias Lexical.Ast.Detection
-  alias Lexical.Document
   alias Lexical.Document.Position
 
   use Detection
 
   @impl Detection
-  def detected?(%Document{} = document, %Position{} = position) do
-    cursor_path = Ast.cursor_path(document, position)
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    cursor_path = Ast.cursor_path(analysis, position)
 
     match?(
       # in the key position, the cursor will always be followed by the

--- a/apps/common/lib/lexical/ast/detection/struct_field_value.ex
+++ b/apps/common/lib/lexical/ast/detection/struct_field_value.ex
@@ -1,11 +1,11 @@
 defmodule Lexical.Ast.Detection.StructFieldValue do
+  alias Lexical.Ast.Analysis
   alias Lexical.Ast.Detection.StructFieldKey
   alias Lexical.Ast.Detection.StructFields
-  alias Lexical.Document
   alias Lexical.Document.Position
 
-  def detected?(%Document{} = document, %Position{} = position) do
-    StructFields.detected?(document, position) and
-      not StructFieldKey.detected?(document, position)
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    StructFields.detected?(analysis, position) and
+      not StructFieldKey.detected?(analysis, position)
   end
 end

--- a/apps/common/lib/lexical/ast/detection/struct_fields.ex
+++ b/apps/common/lib/lexical/ast/detection/struct_fields.ex
@@ -1,17 +1,14 @@
 defmodule Lexical.Ast.Detection.StructFields do
   alias Lexical.Ast
+  alias Lexical.Ast.Analysis
   alias Lexical.Ast.Detection
-  alias Lexical.Document
   alias Lexical.Document.Position
 
   use Detection
 
   @impl Detection
-  def detected?(%Document{} = document, %Position{} = position) do
-    document
-    |> Document.fragment(Position.new(document, position.line, 1), position)
-
-    document
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    analysis.document
     |> Ast.cursor_path(position)
     |> Enum.any?(&match?({:%, _, _}, &1))
   end

--- a/apps/common/lib/lexical/ast/detection/struct_reference.ex
+++ b/apps/common/lib/lexical/ast/detection/struct_reference.ex
@@ -1,15 +1,15 @@
 defmodule Lexical.Ast.Detection.StructReference do
   alias Lexical.Ast
+  alias Lexical.Ast.Analysis
   alias Lexical.Ast.Detection
   alias Lexical.Ast.Tokens
-  alias Lexical.Document
   alias Lexical.Document.Position
 
   use Detection
 
   @impl Detection
-  def detected?(%Document{} = document, %Position{} = position) do
-    case Ast.cursor_context(document, position) do
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    case Ast.cursor_context(analysis, position) do
       {:ok, {:struct, []}} ->
         false
 
@@ -21,7 +21,7 @@ defmodule Lexical.Ast.Detection.StructReference do
         # def foo(%__)
 
         starts_with_percent? =
-          document
+          analysis.document
           |> Tokens.prefix_stream(position)
           |> Enum.take(2)
           |> Enum.any?(fn
@@ -30,7 +30,7 @@ defmodule Lexical.Ast.Detection.StructReference do
           end)
 
         starts_with_percent? and possible_dunder_module(possible_module_struct) and
-          (ancestor_is_def?(document, position) or ancestor_is_type?(document, position))
+          (ancestor_is_def?(analysis, position) or ancestor_is_type?(analysis, position))
 
       _ ->
         false

--- a/apps/common/lib/lexical/ast/detection/type.ex
+++ b/apps/common/lib/lexical/ast/detection/type.ex
@@ -1,12 +1,12 @@
 defmodule Lexical.Ast.Detection.Type do
+  alias Lexical.Ast.Analysis
   alias Lexical.Ast.Detection
-  alias Lexical.Document
   alias Lexical.Document.Position
 
   use Detection
 
   @impl Detection
-  def detected?(%Document{} = document, %Position{} = position) do
-    ancestor_is_type?(document, position)
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    ancestor_is_type?(analysis, position)
   end
 end

--- a/apps/common/lib/lexical/ast/detection/use.ex
+++ b/apps/common/lib/lexical/ast/detection/use.ex
@@ -1,13 +1,13 @@
 defmodule Lexical.Ast.Detection.Use do
+  alias Lexical.Ast.Analysis
   alias Lexical.Ast.Detection
   alias Lexical.Ast.Detection.Directive
-  alias Lexical.Document
   alias Lexical.Document.Position
 
   use Detection
 
   @impl Detection
-  def detected?(%Document{} = document, %Position{} = position) do
-    Directive.detected?(document, position, 'use')
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    Directive.detected?(analysis, position, 'use')
   end
 end

--- a/apps/common/lib/lexical/ast/env.ex
+++ b/apps/common/lib/lexical/ast/env.ex
@@ -92,48 +92,51 @@ defmodule Lexical.Ast.Env do
   @impl Environment
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def in_context?(%__MODULE__{} = env, context_type) do
-    document = env.document
+    analysis = env.analysis
     position = env.position
 
     case context_type do
       :alias ->
-        Detection.Alias.detected?(document, position)
+        Detection.Alias.detected?(analysis, position)
 
       :bitstring ->
-        Detection.Bitstring.detected?(document, position)
+        Detection.Bitstring.detected?(analysis, position)
+
+      :comment ->
+        Detection.Comment.detected?(analysis, position)
 
       :function_capture ->
-        Detection.FunctionCapture.detected?(document, position)
+        Detection.FunctionCapture.detected?(analysis, position)
 
       :import ->
-        Detection.Import.detected?(document, position)
+        Detection.Import.detected?(analysis, position)
 
       :pipe ->
-        Detection.Pipe.detected?(document, position)
+        Detection.Pipe.detected?(analysis, position)
 
       :require ->
-        Detection.Require.detected?(document, position)
+        Detection.Require.detected?(analysis, position)
 
       :spec ->
-        Detection.Spec.detected?(document, position)
+        Detection.Spec.detected?(analysis, position)
 
       :struct_fields ->
-        Detection.StructFields.detected?(document, position)
+        Detection.StructFields.detected?(analysis, position)
 
       :struct_field_key ->
-        Detection.StructFieldKey.detected?(document, position)
+        Detection.StructFieldKey.detected?(analysis, position)
 
       :struct_field_value ->
-        Detection.StructFieldValue.detected?(document, position)
+        Detection.StructFieldValue.detected?(analysis, position)
 
       :struct_reference ->
-        Detection.StructReference.detected?(document, position)
+        Detection.StructReference.detected?(analysis, position)
 
       :type ->
-        Detection.Type.detected?(document, position)
+        Detection.Type.detected?(analysis, position)
 
       :use ->
-        Detection.Use.detected?(document, position)
+        Detection.Use.detected?(analysis, position)
     end
   end
 

--- a/apps/common/test/lexical/ast/detection/comment_test.exs
+++ b/apps/common/test/lexical/ast/detection/comment_test.exs
@@ -1,0 +1,7 @@
+defmodule Lexical.Ast.Detection.CommentTest do
+  alias Lexical.Ast.Detection
+
+  use Lexical.Test.DetectionCase,
+    for: Detection.Comment,
+    assertions: [[:comment, :*]]
+end

--- a/apps/common/test/lexical/ast_test.exs
+++ b/apps/common/test/lexical/ast_test.exs
@@ -320,8 +320,8 @@ defmodule Lexical.AstTest do
 
   defp ast(s) do
     case Ast.from(s) do
-      {:ok, {:__block__, _, [node]}} -> node
-      {:ok, node} -> node
+      {:ok, {:__block__, _, [node]}, _comments} -> node
+      {:ok, node, _comments} -> node
     end
   end
 

--- a/apps/common/test/lexical/ast_test.exs
+++ b/apps/common/test/lexical/ast_test.exs
@@ -60,6 +60,20 @@ defmodule Lexical.AstTest do
       Ast.path_at(document, position)
     end
 
+    defp end_location({_, metadata, _}), do: end_location(metadata)
+
+    defp end_location(metadata) when is_list(metadata) do
+      case metadata do
+        [line: line, column: column] ->
+          {line, column}
+
+        metadata ->
+          [end_line: line, end_column: column] = Keyword.take(metadata, [:end_line, :end_column])
+
+          {line, column}
+      end
+    end
+
     test "returns an error if the cursor cannot be found in any node" do
       code = ~q[
         |
@@ -75,7 +89,8 @@ defmodule Lexical.AstTest do
         defmodule |Foo do
       ]
 
-      assert {:error, {[line: 2, column: 1], "missing terminator: end" <> _, ""}} = path_at(code)
+      assert {:error, {metadata, "missing terminator: end" <> _, ""}} = path_at(code)
+      assert end_location(metadata) == {2, 1}
     end
 
     test "returns a path to the innermost leaf at position" do

--- a/apps/common/test/support/lexical/test/detection_case/suite.ex
+++ b/apps/common/test/support/lexical/test/detection_case/suite.ex
@@ -40,6 +40,10 @@ defmodule Lexical.Test.DetectionCase.Suite do
            »>>
            ]
       ],
+      comment: [
+        start_of_line: "«# IO.puts»",
+        end_of_line: "IO.puts(thing) «# IO.puts»"
+      ],
       function_capture: [
         local_arity: ~q[&«my_fun/1»],
         local_argument: ~q[&«my_fun(arg, &1)»],

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/entity_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/entity_test.exs
@@ -458,6 +458,21 @@ defmodule Lexical.RemoteControl.CodeIntelligence.EntityTest do
       assert {:ok, {:call, Kernel, :defstruct, 1}, resolved_range} = resolve(code)
       assert resolved_range =~ "  «defstruct» foo: nil"
     end
+
+    test "comments are ignored" do
+      code = ~q[
+        defmodule Scratch do
+          def many_such_pipes() do
+            "pipe"
+            |> a_humble_pipe()
+            # |> another_|humble_pipe()
+            |> a_humble_pipe()
+          end
+        end
+      ]
+
+      assert {:error, :not_found} = resolve(code)
+    end
   end
 
   describe "local call" do

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/metadata_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/metadata_test.exs
@@ -184,7 +184,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.MetadataTest do
 
   defp decorate_location(code) do
     document = Document.new("file:///file.ex", code, 1)
-    {:ok, ast} = Ast.from(document)
+    {:ok, ast, _} = Ast.from(document)
 
     case Metadata.location(ast) do
       {:block, _position, {start_line, start_char}, {end_line, end_char}} ->

--- a/apps/remote_control/test/support/lexical/test/code_mod_case.ex
+++ b/apps/remote_control/test/support/lexical/test/code_mod_case.ex
@@ -28,7 +28,10 @@ defmodule Lexical.Test.CodeMod.Case do
         alias Lexical.Ast
 
         if Keyword.get(options, :convert_to_ast, unquote(convert_to_ast?)) do
-          Ast.from(code)
+          case Ast.from(code) do
+            {:ok, ast, _comments} -> {:ok, ast}
+            other -> other
+          end
         else
           {:ok, nil}
         end

--- a/apps/server/lib/lexical/server/code_intelligence/completion.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion.ex
@@ -105,8 +105,12 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
         local_length > 1 or has_surround_context?(env.prefix, 1, surround_begin)
 
       _ ->
-        true
+        not inside_comment?(env)
     end
+  end
+
+  defp inside_comment?(env) do
+    Env.in_context?(env, :comment)
   end
 
   defp has_surround_context?(fragment, line, column)

--- a/apps/server/lib/lexical/server/code_intelligence/completion.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion.ex
@@ -80,7 +80,11 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
   end
 
   defp should_emit_completions?(%Env{} = env) do
-    always_emit_completions?() or has_meaningful_completions?(env)
+    if inside_comment?(env) do
+      false
+    else
+      always_emit_completions?() or has_meaningful_completions?(env)
+    end
   end
 
   defp always_emit_completions? do
@@ -105,7 +109,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
         local_length > 1 or has_surround_context?(env.prefix, 1, surround_begin)
 
       _ ->
-        not inside_comment?(env)
+        true
     end
   end
 

--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -64,6 +64,14 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
       assert %Completion.List{is_incomplete: true, items: []} =
                complete(project, " ", as_list: false)
     end
+
+    test "returns no completions in a comment at the beginning of a line", %{project: project} do
+      assert [] == complete(project, "# IO.in|")
+    end
+
+    test "returns no completions in a comment at the end of a line", %{project: project} do
+      assert [] == complete(project, "IO.inspe # IO.in|")
+    end
   end
 
   describe "do/end" do


### PR DESCRIPTION
Previously, we would resolve commented out code as if it wasn't commented out, which caused a crash in #638.

Commented out code shouldn't resolve, but finding comments requires calling a different function with a different return shape than `Code.string_to_quoted`. This PR moves to
`Code.string_to_quoted_with_comments` and puts the comment metadata into the analysis struct where it can be queried.

Fixes #638