### PR TITLE
Patch `DidOpen` handler.

### DIFF
--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -176,7 +176,7 @@ defmodule Lexical.Server.State do
       uri: uri,
       version: version,
       language_id: language_id
-    } = did_open.text_document
+    } = did_open.lsp.text_document
 
     case Document.Store.open(uri, text, version, language_id) do
       :ok ->


### PR DESCRIPTION
* `did_open.text_document` is coming up as nil, but `did_open.lsp.text_document` is present.