### PR TITLE
Fix: Non-string test names crash exunit indexer

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/ex_unit.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/ex_unit.ex
@@ -32,7 +32,8 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ExUnit do
   end
 
   # Test block test "test name" do ... or test "test name", arg do
-  def extract({:test, _, [{_, _, [test_name]} | _] = args} = test, %Reducer{} = reducer) do
+  def extract({:test, _, [{_, _, [test_name]} | _] = args} = test, %Reducer{} = reducer)
+      when is_binary(test_name) do
     {:ok, module} = Analyzer.current_module(reducer.analysis, Reducer.position(reducer))
     arity = arity_for(args)
     module_name = Formats.module(module)

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/ex_unit_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/ex_unit_test.exs
@@ -246,10 +246,10 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ExUnitTest do
     test "when pending" do
       {:ok, [test], doc} =
         ~q[
-      defmodule SomeTest do
-        test "my test"
-      end
-      ]
+        defmodule SomeTest do
+          test "my test"
+        end
+        ]
         |> index_definitions()
 
       assert test.type == :ex_unit_test
@@ -262,11 +262,11 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ExUnitTest do
     test "when they only have a block" do
       {:ok, [test], doc} =
         ~q[
-      defmodule SomeTest do
-        test "my test" do
+        defmodule SomeTest do
+          test "my test" do
+          end
         end
-      end
-      ]
+        ]
         |> index_definitions()
 
       assert test.type == :ex_unit_test
@@ -279,11 +279,11 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ExUnitTest do
     test "when they have a block and a context" do
       {:ok, [test], doc} =
         ~q[
-      defmodule SomeTest do
-        test "my test", context do
+        defmodule SomeTest do
+          test "my test", context do
+          end
         end
-      end
-      ]
+        ]
         |> index_definitions()
 
       assert test.type == :ex_unit_test
@@ -301,12 +301,12 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ExUnitTest do
     test "describe contains tests" do
       {:ok, [module, describe, test], _} =
         ~q[
-        defmodule SomeTexst do
-          describe "outer" do
-            test "my test", context do
-            end
-          end
-        end
+         defmodule SomeTexst do
+           describe "outer" do
+             test "my test", context do
+             end
+           end
+         end
         ]
         |> index_with_structure()
 
@@ -318,6 +318,20 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ExUnitTest do
 
       assert test.type == :ex_unit_test
       assert test.block_id == describe.id
+    end
+  end
+
+  describe "things that it will miss" do
+    test "quoted test cases" do
+      {:ok, [], _} =
+        ~q[
+        quote do
+         test unquote(test_name) do
+         end
+        end
+        ]
+        |> in_a_module()
+        |> index_definitions()
     end
   end
 end


### PR DESCRIPTION
We had a test case that was auto-generating tests, and the unquote crashed the exunit indexer because the test name wasn't a literal string.

This change ignores such tests
Fixes #675