### PR TITLE
Granted write permissions

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -7,14 +7,16 @@ on:
 
 jobs:
   auto-update-nix-hash:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     name: Auto update Nix hash
     steps:
-    - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
-    - run: |
-        nix run .#update-hash
-        git config user.email ""
-        git config user.name "GitHub Action Bot"
-        git commit -m 'Update Nix hash of Mix deps' nix/hash && git push || true
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: |
+          nix run .#update-hash
+          git config user.email ""
+          git config user.name "GitHub Action Bot"
+          git commit -m 'Update Nix hash of Mix deps' nix/hash && git push || true


### PR DESCRIPTION
The nix job was failing due to insufficient permissions. This grants write access to the job.