### PR TITLE
Improve error handling in `Transport.StdIO`.

### DIFF
--- a/apps/protocol/lib/lexical/protocol/json_rpc.ex
+++ b/apps/protocol/lib/lexical/protocol/json_rpc.ex
@@ -2,6 +2,8 @@ defmodule Lexical.Protocol.JsonRpc do
   alias Lexical.Protocol.Notifications
   alias Lexical.Protocol.Requests
 
+  require Logger
+
   @crlf "\r\n"
 
   def decode(message_string) do
@@ -30,8 +32,10 @@ defmodule Lexical.Protocol.JsonRpc do
     {:ok, json_rpc}
   end
 
+  # These messages appear to be empty Responses (per LSP spec) sent to
+  # aknowledge Requests sent from the language server to the client.
   defp do_decode(%{"id" => _id, "result" => nil}) do
-    :error
+    {:error, :empty_response}
   end
 
   defp do_decode(%{"method" => method, "id" => _id} = request) do

--- a/apps/server/lib/lexical/server/transport/std_io.ex
+++ b/apps/server/lib/lexical/server/transport/std_io.ex
@@ -1,6 +1,8 @@
 defmodule Lexical.Server.Transport.StdIO do
   alias Lexical.Protocol.JsonRpc
 
+  require Logger
+
   @behaviour Lexical.Server.Transport
 
   def start_link(device, callback) do
@@ -59,11 +61,16 @@ defmodule Lexical.Server.Transport.StdIO do
       "\n" ->
         headers = parse_headers(buffer)
 
-        with {:ok, content_length} <-
-               header_value(headers, "content-length", &String.to_integer/1),
+        with {:ok, content_length} <- content_length(headers),
              {:ok, data} <- read_body(device, content_length),
              {:ok, message} <- JsonRpc.decode(data) do
           callback.(message)
+        else
+          {:error, :empty_response} ->
+            nil
+
+          {:error, reason} ->
+            Logger.critical("error reading protocol message: #{inspect(reason)}")
         end
 
         loop([], device, callback)
@@ -76,29 +83,62 @@ defmodule Lexical.Server.Transport.StdIO do
     end
   end
 
-  defp parse_headers(headers) do
-    Enum.map(headers, &parse_header/1)
-  end
+  defp content_length(headers) do
+    case List.keyfind(headers, "content-length", 0) do
+      {_, len_str} ->
+        {:ok, String.to_integer(len_str)}
 
-  defp header_value(headers, header_name, converter) do
-    case List.keyfind(headers, header_name, 0) do
-      nil -> :error
-      {_, value} -> {:ok, converter.(value)}
+      nil ->
+        {:error, :no_content_length}
     end
   end
 
   defp read_body(device, byte_count) do
     case IO.binread(device, byte_count) do
-      data when is_binary(data) or is_list(data) ->
+      data when is_binary(data) and byte_size(data) === byte_count ->
         {:ok, data}
 
-      other ->
-        other
+      data when is_binary(data) ->
+        read_more(device, byte_count - byte_size(data), data)
+
+      data when is_list(data) ->
+        if Enum.count(data) === byte_count do
+          {:ok, data}
+        else
+          remaining_bytes = byte_count - byte_size(data)
+          read_more(device, remaining_bytes, data)
+        end
+
+      :eof ->
+        {:error, :eof}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
+  # give editor an extra ms if there's not enough bytes.
+  defp read_more(device, byte_count, data) do
+    :timer.sleep(1)
+
+    case IO.binread(device, byte_count) do
+      rest when is_binary(rest) or is_list(rest) ->
+        [data | rest]
+
+      :eof ->
+        {:error, :eof}
+
+      error ->
+        error
+    end
+  end
+
+  defp parse_headers(headers) do
+    Enum.map(headers, &parse_header/1)
+  end
+
   defp parse_header(line) do
-    [name, value] = String.split(line, ":")
+    [name, value] = String.split(line, ":", parts: 2)
 
     header_name =
       name

--- a/apps/server/lib/lexical/server/transport/std_io.ex
+++ b/apps/server/lib/lexical/server/transport/std_io.ex
@@ -98,6 +98,9 @@ defmodule Lexical.Server.Transport.StdIO do
       data when is_binary(data) and byte_size(data) == byte_count ->
         {:ok, data}
 
+      data when is_binary(data) ->
+        raise "Tried reading #{byte_count} from #{inspect(device)}, got: #{byte_size(data)}."
+
       :eof ->
         {:error, :eof}
 

--- a/apps/server/lib/lexical/server/transport/std_io.ex
+++ b/apps/server/lib/lexical/server/transport/std_io.ex
@@ -95,41 +95,14 @@ defmodule Lexical.Server.Transport.StdIO do
 
   defp read_body(device, byte_count) do
     case IO.binread(device, byte_count) do
-      data when is_binary(data) and byte_size(data) === byte_count ->
+      data when is_binary(data) and byte_size(data) == byte_count ->
         {:ok, data}
-
-      data when is_binary(data) ->
-        read_more(device, byte_count - byte_size(data), data)
-
-      data when is_list(data) ->
-        if Enum.count(data) === byte_count do
-          {:ok, data}
-        else
-          remaining_bytes = byte_count - byte_size(data)
-          read_more(device, remaining_bytes, data)
-        end
 
       :eof ->
         {:error, :eof}
 
       {:error, reason} ->
         {:error, reason}
-    end
-  end
-
-  # give editor an extra ms if there's not enough bytes.
-  defp read_more(device, byte_count, data) do
-    :timer.sleep(1)
-
-    case IO.binread(device, byte_count) do
-      rest when is_binary(rest) or is_list(rest) ->
-        [data | rest]
-
-      :eof ->
-        {:error, :eof}
-
-      error ->
-        error
     end
   end
 

--- a/apps/server/lib/lexical/server/transport/std_io.ex
+++ b/apps/server/lib/lexical/server/transport/std_io.ex
@@ -70,7 +70,7 @@ defmodule Lexical.Server.Transport.StdIO do
             nil
 
           {:error, reason} ->
-            Logger.critical("error reading protocol message: #{inspect(reason)}")
+            Logger.critical("read protocol message: #{inspect(reason)}")
         end
 
         loop([], device, callback)

--- a/apps/server/lib/lexical/server/transport/std_io.ex
+++ b/apps/server/lib/lexical/server/transport/std_io.ex
@@ -93,10 +93,19 @@ defmodule Lexical.Server.Transport.StdIO do
     end
   end
 
-  defp read_body(device, byte_count) do
-    case IO.binread(device, byte_count) do
-      data when is_binary(data) and byte_size(data) == byte_count ->
-        {:ok, data}
+  # `IO.binread/2` won't block if there aren't enough bytes in stdin to read.
+  # In exceptional circumstances Lexical may outpace the LSP client, so an extra
+  # read (or two) may be needed to receive the full message.
+  defp read_body(_device, remaining_bytes, acc \\ [])
+
+  defp read_body(_device, 0, acc) do
+    {:ok, IO.iodata_to_binary(acc)}
+  end
+
+  defp read_body(device, remaining_bytes, acc) do
+    case IO.binread(device, remaining_bytes) do
+      data when is_binary(data) ->
+        read_body(device, remaining_bytes - byte_size(data), [acc, data])
 
       :eof ->
         {:error, :eof}

--- a/apps/server/lib/lexical/server/transport/std_io.ex
+++ b/apps/server/lib/lexical/server/transport/std_io.ex
@@ -89,23 +89,14 @@ defmodule Lexical.Server.Transport.StdIO do
         {:ok, String.to_integer(len_str)}
 
       nil ->
-        {:error, :no_content_length}
+        {:error, :no_content_length_header}
     end
   end
 
-  # `IO.binread/2` won't block if there aren't enough bytes in stdin to read.
-  # In exceptional circumstances Lexical may outpace the LSP client, so an extra
-  # read (or two) may be needed to receive the full message.
-  defp read_body(_device, remaining_bytes, acc \\ [])
-
-  defp read_body(_device, 0, acc) do
-    {:ok, IO.iodata_to_binary(acc)}
-  end
-
-  defp read_body(device, remaining_bytes, acc) do
-    case IO.binread(device, remaining_bytes) do
+  defp read_body(device, byte_count) do
+    case IO.binread(device, byte_count) do
       data when is_binary(data) ->
-        read_body(device, remaining_bytes - byte_size(data), [acc, data])
+        {:ok, data}
 
       :eof ->
         {:error, :eof}

--- a/apps/server/lib/lexical/server/transport/std_io.ex
+++ b/apps/server/lib/lexical/server/transport/std_io.ex
@@ -67,7 +67,7 @@ defmodule Lexical.Server.Transport.StdIO do
           callback.(message)
         else
           {:error, :empty_response} ->
-            nil
+            :noop
 
           {:error, reason} ->
             Logger.critical("read protocol message: #{inspect(reason)}")
@@ -97,9 +97,6 @@ defmodule Lexical.Server.Transport.StdIO do
     case IO.binread(device, byte_count) do
       data when is_binary(data) and byte_size(data) == byte_count ->
         {:ok, data}
-
-      data when is_binary(data) ->
-        raise "Tried reading #{byte_count} from #{inspect(device)}, got: #{byte_size(data)}."
 
       :eof ->
         {:error, :eof}

--- a/apps/server/lib/lexical/server/transport/std_io.ex
+++ b/apps/server/lib/lexical/server/transport/std_io.ex
@@ -111,7 +111,7 @@ defmodule Lexical.Server.Transport.StdIO do
   end
 
   defp parse_header(line) do
-    [name, value] = String.split(line, ":", parts: 2)
+    [name, value] = String.split(line, ":")
 
     header_name =
       name


### PR DESCRIPTION
* Log any errors reading the protocol as critical.
* Never split header lines into more than 2 parts.
* Replace `header_value/3` with `content_length/1` for more specific errors.
* Add note about empty LSP Responses, sent from the language client.