### PR TITLE
Added module attribute detection

### DIFF
--- a/apps/common/lib/lexical/ast/detection.ex
+++ b/apps/common/lib/lexical/ast/detection.ex
@@ -41,34 +41,24 @@ defmodule Lexical.Ast.Detection do
 
   @type_keys [:type, :typep, :opaque]
   def ancestor_is_type?(%Analysis{} = analysis, %Position{} = position) do
-    analysis
-    |> Ast.cursor_path(position)
-    |> Enum.any?(fn
-      {:@, metadata, [{type_key, _, _}]} when type_key in @type_keys ->
-        # single line type
-        cursor_in_range?(position, metadata)
-
-      {:__block__, _, [{:@, metadata, [{type_key, _, _}]}, _]}
-      when type_key in @type_keys ->
-        # multi-line type
-        cursor_in_range?(position, metadata)
-
-      _ ->
-        false
-    end)
+    ancestor_is_attribute?(analysis, position, @type_keys)
   end
 
   def ancestor_is_spec?(%Analysis{} = analysis, %Position{} = position) do
+    ancestor_is_attribute?(analysis, position, :spec)
+  end
+
+  def ancestor_is_attribute?(%Analysis{} = analysis, %Position{} = position, attr_name \\ nil) do
     analysis
     |> Ast.cursor_path(position)
     |> Enum.any?(fn
-      {:@, metadata, [{:spec, _, _}]} ->
-        # single line spec
-        cursor_in_range?(position, metadata)
+      {:@, metadata, [{found_name, _, _}]} ->
+        # single line attribute
+        attribute_names_match?(attr_name, found_name) and cursor_in_range?(position, metadata)
 
-      {:__block__, _, [{:@, metadata, [{:spec, _, _}]}, _]} ->
-        # multi-line spec
-        cursor_in_range?(position, metadata)
+      {:__block__, _, [{:@, metadata, [{found_name, _, _}]}, _]} ->
+        # multi-line attribute
+        attribute_names_match?(attr_name, found_name) and cursor_in_range?(position, metadata)
 
       _ ->
         false
@@ -87,4 +77,12 @@ defmodule Lexical.Ast.Detection do
       cursor_line < expression_end_line
     end
   end
+
+  defp attribute_names_match?(expected_names, actual_name)
+       when is_list(expected_names),
+       do: actual_name in expected_names
+
+  defp attribute_names_match?(nil, _), do: true
+  defp attribute_names_match?(same, same), do: true
+  defp attribute_names_match?(_, _), do: false
 end

--- a/apps/common/lib/lexical/ast/detection/module_attribute.ex
+++ b/apps/common/lib/lexical/ast/detection/module_attribute.ex
@@ -1,0 +1,16 @@
+defmodule Lexical.Ast.Detection.ModuleAttribute do
+  alias Lexical.Ast.Analysis
+  alias Lexical.Ast.Detection
+  alias Lexical.Document.Position
+
+  use Detection
+
+  @impl Detection
+  def detected?(%Analysis{} = analysis, %Position{} = position) do
+    ancestor_is_attribute?(analysis, position)
+  end
+
+  def detected?(%Analysis{} = analysis, %Position{} = position, name) do
+    ancestor_is_attribute?(analysis, position, name)
+  end
+end

--- a/apps/common/lib/lexical/ast/env.ex
+++ b/apps/common/lib/lexical/ast/env.ex
@@ -99,17 +99,35 @@ defmodule Lexical.Ast.Env do
       :alias ->
         Detection.Alias.detected?(analysis, position)
 
+      :behaviour ->
+        Detection.ModuleAttribute.detected?(analysis, position, :behaviour)
+
       :bitstring ->
         Detection.Bitstring.detected?(analysis, position)
 
       :comment ->
         Detection.Comment.detected?(analysis, position)
 
+      :doc ->
+        Detection.ModuleAttribute.detected?(analysis, position, :doc)
+
       :function_capture ->
         Detection.FunctionCapture.detected?(analysis, position)
 
+      :impl ->
+        Detection.ModuleAttribute.detected?(analysis, position, :impl)
+
       :import ->
         Detection.Import.detected?(analysis, position)
+
+      :module_attribute ->
+        Detection.ModuleAttribute.detected?(analysis, position)
+
+      {:module_attribute, name} ->
+        Detection.ModuleAttribute.detected?(analysis, position, name)
+
+      :moduledoc ->
+        Detection.ModuleAttribute.detected?(analysis, position, :moduledoc)
 
       :pipe ->
         Detection.Pipe.detected?(analysis, position)

--- a/apps/common/lib/lexical/ast/env.ex
+++ b/apps/common/lib/lexical/ast/env.ex
@@ -105,6 +105,9 @@ defmodule Lexical.Ast.Env do
       :bitstring ->
         Detection.Bitstring.detected?(analysis, position)
 
+      :callback ->
+        Detection.ModuleAttribute.detected?(analysis, position, :callback)
+
       :comment ->
         Detection.Comment.detected?(analysis, position)
 
@@ -125,6 +128,9 @@ defmodule Lexical.Ast.Env do
 
       {:module_attribute, name} ->
         Detection.ModuleAttribute.detected?(analysis, position, name)
+
+      :macrocallback ->
+        Detection.ModuleAttribute.detected?(analysis, position, :macrocallback)
 
       :moduledoc ->
         Detection.ModuleAttribute.detected?(analysis, position, :moduledoc)

--- a/apps/common/test/lexical/ast/detection/module_attribute_test.exs
+++ b/apps/common/test/lexical/ast/detection/module_attribute_test.exs
@@ -5,6 +5,7 @@ defmodule Lexical.Ast.Detection.ModuleAttributeTest do
     for: Detection.ModuleAttribute,
     assertions: [
       [:module_attribute, :*],
+      [:callbacks, :*],
       [:doc, :*],
       [:module_doc, :*]
     ],

--- a/apps/common/test/lexical/ast/detection/module_attribute_test.exs
+++ b/apps/common/test/lexical/ast/detection/module_attribute_test.exs
@@ -1,0 +1,13 @@
+defmodule Lexical.Ast.Detection.ModuleAttributeTest do
+  alias Lexical.Ast.Detection
+
+  use Lexical.Test.DetectionCase,
+    for: Detection.ModuleAttribute,
+    assertions: [
+      [:module_attribute, :*],
+      [:doc, :*],
+      [:module_doc, :*]
+    ],
+    skip: [[:type, :*], [:spec, :*]],
+    variations: [:module]
+end

--- a/apps/common/test/lexical/ast/detection/pipe_test.exs
+++ b/apps/common/test/lexical/ast/detection/pipe_test.exs
@@ -4,7 +4,8 @@ defmodule Lexical.Ast.Detection.PipeTest do
   use Lexical.Test.DetectionCase,
     for: Detection.Pipe,
     assertions: [[:pipe, :*]],
-    variations: [:function_arguments]
+    variations: [:function_arguments],
+    skip: [[:module_attribute, :multi_line_pipe]]
 
   test "is false if there is no pipe in the string" do
     refute_detected ~q[Enum.foo]

--- a/apps/common/test/lexical/ast/env_test.exs
+++ b/apps/common/test/lexical/ast/env_test.exs
@@ -212,5 +212,15 @@ defmodule Lexical.Ast.EnvTest do
       ])
       assert in_context?(env, :moduledoc)
     end
+
+    test "can detect callbacks" do
+      env = new_env("@callback do_stuff|(integer(), map()) :: any()")
+      assert in_context?(env, :callback)
+    end
+
+    test "can detect macro callbacks" do
+      env = new_env("@macrocallback write_code(integer(), map(|)) :: any()")
+      assert in_context?(env, :macrocallback)
+    end
   end
 end

--- a/apps/common/test/lexical/ast/env_test.exs
+++ b/apps/common/test/lexical/ast/env_test.exs
@@ -164,4 +164,53 @@ defmodule Lexical.Ast.EnvTest do
              ] = tokens
     end
   end
+
+  describe "in_context?/2" do
+    test "can detect module attributes" do
+      env = new_env("@my_attr 3|")
+
+      assert in_context?(env, {:module_attribute, :my_attr})
+      refute in_context?(env, {:module_attribute, :other})
+    end
+
+    test "can detect behaviours" do
+      env = new_env("@behaviour Modul|e")
+
+      assert in_context?(env, :behaviour)
+    end
+
+    test "can detect behaviour implementations" do
+      env = new_env("@impl GenServer|")
+
+      assert in_context?(env, :impl)
+    end
+
+    test "can detect docstrings " do
+      env = new_env("@doc false|")
+      assert in_context?(env, :doc)
+
+      env = new_env(~S[@doc "hi"])
+      assert in_context?(env, :doc)
+
+      env = new_env(~S[@doc """
+      Multi - line
+      """|
+      ])
+      assert in_context?(env, :doc)
+    end
+
+    test "can detect moduledocs " do
+      env = new_env("@moduledoc false|")
+      assert in_context?(env, :moduledoc)
+
+      env = new_env(~S[@moduledoc "hi"])
+      assert in_context?(env, :moduledoc)
+
+      env = new_env(~S[@moduledoc """
+      Multi - line
+      """|
+      ])
+      assert in_context?(env, :moduledoc)
+    end
+  end
 end

--- a/apps/common/test/support/lexical/test/detection_case/suite.ex
+++ b/apps/common/test/support/lexical/test/detection_case/suite.ex
@@ -40,6 +40,29 @@ defmodule Lexical.Test.DetectionCase.Suite do
            »>>
            ]
       ],
+      callbacks: [
+        callback: [
+          zero_arg: "@«callback my_cb() :: boolean()»",
+          one_arg: "@«callback my_cb(foo :: integer) :: String.t()»",
+          multiple_args: "@«callback my_cb(foo :: integer, bar:: String.t()) :: [pos_integer()]»",
+          multiple_line: """
+          @«callback my_cb(
+              foo :: String.t(),
+              bar :: pos_integer()) :: pos_integer()»
+          """
+        ],
+        macrocallback: [
+          zero_arg: "@«macrocallback my_cb() :: boolean()»",
+          one_arg: "@«macrocallback my_cb(foo :: integer) :: String.t()»",
+          multiple_args:
+            "@«macrocallback my_cb(foo :: integer, bar:: String.t()) :: [pos_integer()]»",
+          multiple_line: """
+          @«macrocallback my_cb(
+              foo :: String.t(),
+              bar :: pos_integer()) :: pos_integer()»
+          """
+        ]
+      ],
       comment: [
         start_of_line: "«# IO.puts»",
         end_of_line: "IO.puts(thing) «# IO.puts»"

--- a/apps/common/test/support/lexical/test/detection_case/suite.ex
+++ b/apps/common/test/support/lexical/test/detection_case/suite.ex
@@ -44,6 +44,15 @@ defmodule Lexical.Test.DetectionCase.Suite do
         start_of_line: "«# IO.puts»",
         end_of_line: "IO.puts(thing) «# IO.puts»"
       ],
+      doc: [
+        empty: ~S[@«doc ""»],
+        false: "@«doc false»",
+        single_line: ~S[@«doc "this is my doc»"],
+        multi_line: ~S[@«doc """
+        This is the doc
+        """»
+        ]
+      ],
       function_capture: [
         local_arity: ~q[&«my_fun/1»],
         local_argument: ~q[&«my_fun(arg, &1)»],
@@ -84,6 +93,30 @@ defmodule Lexical.Test.DetectionCase.Suite do
       map: [
         single_line:
           ~q(%{«string: "value", atom: :value2, int: 6 float: 2.0, list: [1, 2], tuple: {3, 4}}»)
+      ],
+      module_doc: [
+        empty: ~S[@«moduledoc ""»],
+        false: "@«moduledoc false»",
+        single_line: ~S[@«moduledoc "this is my moduledoc»"],
+        multi_line: ~S[@«moduledoc """
+        This is the moduledoc
+        """»
+        ]
+      ],
+      module_attribute: [
+        single_line: "@«attr 45»",
+        multi_line_pipe: """
+        @«attr other_thing»
+          |> «Enum.shuffle()»
+          |> «Enum.max()»
+        """,
+        multi_line_list: """
+        @«attrs [»
+          «:foo»,
+          «:bar»,
+          «:baz»
+        ]
+        """
       ],
       pipe: [
         one_line: ~q[foo |> «bar»() |> «RemoteCall.fun»() |> «:remote_erlang.call»()],


### PR DESCRIPTION
Our environment can now detect when it's in a module attribute context

This will enable us to check for randomly named module attributes and fix some of our longstanding issues.