### PR TITLE
Impl suggest behaviours

### DIFF
--- a/apps/remote_control/test/fixtures/project/lib/behaviours.ex
+++ b/apps/remote_control/test/fixtures/project/lib/behaviours.ex
@@ -1,0 +1,3 @@
+defmodule Userlike do
+  @callback first_name(any()) :: String.t()
+end

--- a/apps/remote_control/test/fixtures/project/lib/behaviours.ex
+++ b/apps/remote_control/test/fixtures/project/lib/behaviours.ex
@@ -1,3 +1,3 @@
-defmodule Userlike do
-  @callback first_name(any()) :: String.t()
+defmodule Unary do
+  @callback ary(any()) :: :un
 end

--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -72,6 +72,12 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
     test "returns no completions in a comment at the end of a line", %{project: project} do
       assert [] == complete(project, "IO.inspe # IO.in|")
     end
+
+    test "only modules that are behaviuors are completed in an @impl", %{project: project} do
+      assert [behaviour] = complete(project, "@impl U|")
+      assert behaviour.label == "Userlike"
+      assert behaviour.kind == :module
+    end
   end
 
   describe "do/end" do

--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -75,7 +75,7 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
 
     test "only modules that are behaviuors are completed in an @impl", %{project: project} do
       assert [behaviour] = complete(project, "@impl U|")
-      assert behaviour.label == "Userlike"
+      assert behaviour.label == "Unary"
       assert behaviour.kind == :module
     end
   end


### PR DESCRIPTION
Only suggest behaviours in `@impl`

Currently, we suggest all modules when in an `@impl` declaration. This
is an opportunity for mistakes. This PR changes the suggestion to
behaviour modules or modules that are ancestors of behaviour modules.

Fixes #437