### PR TITLE
chore: update Nix workflow to not return error

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: |
-          nix run .#update-hash
+          nix run .#update-hash | tee nix/hash
           git config user.email ""
           git config user.name "GitHub Action Bot"
           git commit -m 'Update Nix hash of Mix deps' nix/hash && git push || true

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
 
             text = ''
               nix --extra-experimental-features 'nix-command flakes' \
-                build --no-link "${self}#__fodHashGen" 2>&1 | gawk '/got:/ { print $2 }'
+                build --no-link "${self}#__fodHashGen" 2>&1 | gawk '/got:/ { print $2 }' || true
             '';
           };
         in {

--- a/nix/hash
+++ b/nix/hash
@@ -1,1 +1,1 @@
-sha256-G0mT+rvXZWLJIMfrhxq3TXt26wDImayu44wGEYJ+3CE=
+sha256-TnWGHD1Is7rX/zS1+3+9B+dWsGXX2sm/abF1cnFkEeA=


### PR DESCRIPTION
The script is expected to fail, so we need to handle that value. This
commit changes Nix script to not fail anymore (it will always succeed)
and it will update `nix/hash` to new value as needed.

Additionally this updates value immediately.
