### PR TITLE
Fixed: Error while calculating block spans

### DIFF
--- a/apps/common/lib/lexical/ast/analysis.ex
+++ b/apps/common/lib/lexical/ast/analysis.ex
@@ -100,7 +100,13 @@ defmodule Lexical.Ast.Analysis do
         quoted,
         State.new(document),
         fn quoted, state ->
-          {quoted, analyze_node(quoted, state)}
+          case analyze_node(quoted, state) do
+            {new_quoted, new_state} ->
+              {new_quoted, new_state}
+
+            new_state ->
+              {quoted, new_state}
+          end
         end,
         fn quoted, state ->
           case {scope_id(quoted), State.current_scope(state)} do
@@ -186,6 +192,49 @@ defmodule Lexical.Ast.Analysis do
     quoted
   end
 
+  @skip :skipped?
+
+  defp skip_leading_do({_, meta, _} = root_ast) do
+    # Marks the first do block after the passed in node. This is because
+    # that do block doesn't have accurate ending information, and if we build
+    # a scope around it, it won't end properly, which will cause information
+    # contained in scopes to leak out of them.
+
+    case Keyword.fetch(meta, :do) do
+      {:ok, [line: line, column: column]} ->
+        Macro.prewalk(root_ast, fn
+          {:__block__, _meta, [:do]} = block_ast ->
+            case Sourceror.get_start_position(block_ast) do
+              [line: ^line, column: ^column] ->
+                skip(block_ast)
+
+              _ ->
+                block_ast
+            end
+
+          other ->
+            other
+        end)
+
+      _ ->
+        root_ast
+    end
+  end
+
+  defp skip({_, _, _} = quoted) do
+    Macro.update_meta(quoted, &Keyword.put(&1, @skip, true))
+  end
+
+  defp skipped?({_, meta, _}) when is_list(meta) do
+    skipped?(meta)
+  end
+
+  defp skipped?(meta) when is_list(meta) do
+    Keyword.get(meta, @skip, false)
+  end
+
+  defp skipped?(_), do: false
+
   # defmodule Foo do
   defp analyze_node({:defmodule, meta, [{:__aliases__, _, segments} | _]} = quoted, state) do
     module =
@@ -196,12 +245,15 @@ defmodule Lexical.Ast.Analysis do
 
     current_module_alias = Alias.new(module, :__MODULE__, meta[:line])
 
-    state
-    # implicit alias belongs to the current scope
-    |> maybe_push_implicit_alias(segments, meta[:line])
-    # new __MODULE__ alias belongs to the new scope
-    |> State.push_scope_for(quoted, module)
-    |> State.push_alias(current_module_alias)
+    new_state =
+      state
+      # implicit alias belongs to the current scope
+      |> maybe_push_implicit_alias(segments, meta[:line])
+      # new __MODULE__ alias belongs to the new scope
+      |> State.push_scope_for(quoted, module)
+      |> State.push_alias(current_module_alias)
+
+    {skip_leading_do(quoted), new_state}
   end
 
   # defimpl Foo, for: SomeProtocol do
@@ -219,12 +271,15 @@ defmodule Lexical.Ast.Analysis do
     for_alias = Alias.new(for_segments, :"@for", line)
     protocol_alias = Alias.new(protocol_segments, :"@protocol", line)
 
-    state
-    |> maybe_push_implicit_alias(protocol_segments, line)
-    |> State.push_scope_for(quoted, module)
-    |> State.push_alias(current_module_alias)
-    |> State.push_alias(for_alias)
-    |> State.push_alias(protocol_alias)
+    new_state =
+      state
+      |> maybe_push_implicit_alias(protocol_segments, line)
+      |> State.push_scope_for(quoted, module)
+      |> State.push_alias(current_module_alias)
+      |> State.push_alias(for_alias)
+      |> State.push_alias(protocol_alias)
+
+    {skip_leading_do(quoted), new_state}
   end
 
   # alias Foo.{Bar, Baz, Buzz.Qux}
@@ -276,15 +331,19 @@ defmodule Lexical.Ast.Analysis do
     State.push_import(state, Import.new(module, meta[:line]))
   end
 
-  # clauses: ->
+  # stab clauses: ->
   defp analyze_node({clause, _, _} = quoted, state) when clause in @clauses do
-    State.maybe_push_scope_for(state, quoted)
+    maybe_push_scope_for(state, quoted)
   end
 
   # blocks: do, else, etc.
-  defp analyze_node({{:__block__, _, [block]}, _} = quoted, state)
+  defp analyze_node({{:__block__, meta, [block]}, _} = quoted, state)
        when block in @block_keywords do
-    State.maybe_push_scope_for(state, quoted)
+    if skipped?(meta) do
+      state
+    else
+      maybe_push_scope_for(state, quoted)
+    end
   end
 
   # catch-all
@@ -405,5 +464,13 @@ defmodule Lexical.Ast.Analysis do
   # When the `as` section is incomplete, like: `alias Foo, a`
   defp fetch_alias_as(_) do
     :error
+  end
+
+  defp maybe_push_scope_for(%State{} = state, ast) do
+    if skipped?(ast) do
+      state
+    else
+      State.maybe_push_scope_for(state, ast)
+    end
   end
 end

--- a/apps/common/lib/lexical/ast/analysis.ex
+++ b/apps/common/lib/lexical/ast/analysis.ex
@@ -267,15 +267,15 @@ defmodule Lexical.Ast.Analysis do
           ]} = quoted,
          state
        ) do
-    module = protocol_segments ++ for_segments
     line = meta[:line]
+    expanded_for = expand_alias(for_segments, state)
+    module = expand_alias(protocol_segments ++ expanded_for, state)
     current_module_alias = Alias.new(module, :__MODULE__, line)
-    for_alias = Alias.new(for_segments, :"@for", line)
+    for_alias = Alias.new(expanded_for, :"@for", line)
     protocol_alias = Alias.new(protocol_segments, :"@protocol", line)
 
     new_state =
       state
-      |> maybe_push_implicit_alias(protocol_segments, line)
       |> State.push_scope_for(quoted, module)
       |> State.push_alias(current_module_alias)
       |> State.push_alias(for_alias)

--- a/apps/common/lib/lexical/ast/analysis.ex
+++ b/apps/common/lib/lexical/ast/analysis.ex
@@ -235,8 +235,10 @@ defmodule Lexical.Ast.Analysis do
 
   defp skipped?(_), do: false
 
-  # defmodule Foo do
-  defp analyze_node({:defmodule, meta, [{:__aliases__, _, segments} | _]} = quoted, state) do
+  @module_defining_forms [:defmodule, :defprotocol]
+  # defmodule Foo do or defprotocol MyProtocol do
+  defp analyze_node({form, meta, [{:__aliases__, _, segments} | _]} = quoted, state)
+       when form in @module_defining_forms do
     module =
       case State.current_module(state) do
         [] -> segments

--- a/apps/remote_control/lib/lexical/remote_control/analyzer.ex
+++ b/apps/remote_control/lib/lexical/remote_control/analyzer.ex
@@ -92,10 +92,19 @@ defmodule Lexical.RemoteControl.Analyzer do
       {:ok, Module.concat(resolved)}
     else
       _ ->
-        if Enum.all?(segments, &is_atom/1) do
-          {:ok, Module.concat(segments)}
-        else
-          :error
+        case segments do
+          [:__MODULE__] ->
+            # we've had a request for the current module, but none was found
+            # so we've failed. This can happen if we're resolving the current
+            # module in a script, or inside the defmodule call.
+            :error
+
+          _ ->
+            if Enum.all?(segments, &is_atom/1) do
+              {:ok, Module.concat(segments)}
+            else
+              :error
+            end
         end
     end
   end

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
@@ -40,9 +40,17 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
   defguard is_structure(entry) when entry.type == :metadata and entry.subtype == :block_structure
   defguard is_block(entry) when entry.id == entry.block_id
 
-  def copy(%__MODULE__{} = orig, overrides) do
+  @doc """
+  Creates a new entry by copying the passed-in entry.
+
+  The returned entry will have the same fields set as the one passed in,
+  but a different id.
+  You can also pass in a keyword list of overrides, which will overwrit values in
+  the returned struct.
+  """
+  def copy(%__MODULE__{} = orig, overrides \\ []) when is_list(overrides) do
     %__MODULE__{orig | id: Identifier.next_global!()}
-    |> Map.merge(overrides)
+    |> struct(overrides)
   end
 
   def block_structure(path, structure) do

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
@@ -40,6 +40,11 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
   defguard is_structure(entry) when entry.type == :metadata and entry.subtype == :block_structure
   defguard is_block(entry) when entry.id == entry.block_id
 
+  def copy(%__MODULE__{} = orig, overrides) do
+    %__MODULE__{orig | id: Identifier.next_global!()}
+    |> Map.merge(overrides)
+  end
+
   def block_structure(path, structure) do
     %__MODULE__{
       path: path,

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module.ex
@@ -62,34 +62,31 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Module do
 
   # defimpl MyProtocol, for: MyStruct do ...
   def extract(
-        {:defimpl, _,
-         [
-           {:__aliases__, module_name_meta, module_name},
-           _for_block,
-           _impl_body
-         ]} = defimpl_ast,
+        {:defimpl, _, [{:__aliases__, _, module_name}, [for_block], _impl_body]} = defimpl_ast,
         %Reducer{} = reducer
       ) do
     %Block{} = block = Reducer.current_block(reducer)
 
-    case resolve_alias(reducer, module_name) do
-      {:ok, aliased_module} ->
-        module_position = Metadata.position(module_name_meta)
-        detail_range = to_range(reducer, module_name, module_position)
+    with {:ok, aliased_module} <- resolve_alias(reducer, module_name),
+         {:ok, for_target} <- resolve_for_block(reducer, for_block) do
+      protocol_module = Module.concat(aliased_module, for_target)
 
-        entry =
-          Entry.block_definition(
-            reducer.analysis.document.path,
-            block,
-            Subject.module(aliased_module),
-            :protocol_implementation,
-            block_range(reducer.analysis.document, defimpl_ast),
-            detail_range,
-            Application.get_application(aliased_module)
-          )
+      detail_range = defimpl_range(reducer, defimpl_ast)
 
-        {:ok, entry}
+      implementation_entry =
+        Entry.block_definition(
+          reducer.analysis.document.path,
+          block,
+          Subject.module(protocol_module),
+          :protocol_implementation,
+          block_range(reducer.analysis.document, defimpl_ast),
+          detail_range,
+          Application.get_application(aliased_module)
+        )
 
+      module_entry = Entry.copy(implementation_entry, %{type: :module})
+      {:ok, [implementation_entry, module_entry]}
+    else
       _ ->
         :ignored
     end
@@ -112,6 +109,44 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Module do
             :module,
             range,
             Application.get_application(module)
+          )
+
+        {:ok, entry, nil}
+
+      _ ->
+        :ignored
+    end
+  end
+
+  @module_length String.length("__MODULE__")
+  # This matches __MODULE__ references
+  def extract({:__MODULE__, metadata, _} = ast, %Reducer{} = reducer) do
+    line = Sourceror.get_line(ast)
+    pos = Position.new(reducer.analysis.document, line - 1, 1)
+
+    case RemoteControl.Analyzer.current_module(reducer.analysis, pos) do
+      {:ok, current_module} ->
+        {start_line, start_col} = Metadata.position(metadata)
+        start_pos = Position.new(reducer.analysis.document, start_line, start_col)
+
+        end_pos =
+          Position.new(
+            reducer.analysis.document,
+            start_line,
+            start_col + @module_length
+          )
+
+        range = Range.new(start_pos, end_pos)
+        %Block{} = current_block = Reducer.current_block(reducer)
+
+        entry =
+          Entry.reference(
+            reducer.analysis.document.path,
+            current_block,
+            Subject.module(current_module),
+            :module,
+            range,
+            Application.get_application(current_module)
           )
 
         {:ok, entry}
@@ -185,6 +220,28 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Module do
   def extract(_, _) do
     :ignored
   end
+
+  defp defimpl_range(%Reducer{} = reducer, {_, protocol_meta, _} = protocol_ast) do
+    start = Sourceror.get_start_position(protocol_ast)
+    {finish_line, finish_column} = Metadata.position(protocol_meta, :do)
+    # add two to include the do
+    finish_column = finish_column + 2
+    document = reducer.analysis.document
+
+    Range.new(
+      Position.new(document, start[:line], start[:column]),
+      Position.new(document, finish_line, finish_column)
+    )
+  end
+
+  defp resolve_for_block(
+         %Reducer{} = reducer,
+         {{:__block__, _, [:for]}, {:__aliases__, _, for_target}}
+       ) do
+    resolve_alias(reducer, for_target)
+  end
+
+  defp resolve_for_block(_, _), do: :error
 
   defp resolve_alias(%Reducer{} = reducer, unresolved_alias) do
     {line, column} = reducer.position

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module.ex
@@ -84,7 +84,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Module do
           Application.get_application(aliased_module)
         )
 
-      module_entry = Entry.copy(implementation_entry, %{type: :module})
+      module_entry = Entry.copy(implementation_entry, type: :module)
       {:ok, [implementation_entry, module_entry]}
     else
       _ ->

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/struct_definition.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/struct_definition.ex
@@ -7,20 +7,26 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.StructDefinition do
   def extract({:defstruct, _, [_fields]} = definition, %Reducer{} = reducer) do
     document = reducer.analysis.document
     block = Reducer.current_block(reducer)
-    {:ok, current_module} = Analyzer.current_module(reducer.analysis, Reducer.position(reducer))
-    range = Ast.Range.fetch!(definition, document)
 
-    entry =
-      Entry.definition(
-        document.path,
-        block,
-        current_module,
-        :struct,
-        range,
-        Application.get_application(current_module)
-      )
+    case Analyzer.current_module(reducer.analysis, Reducer.position(reducer)) do
+      {:ok, current_module} ->
+        range = Ast.Range.fetch!(definition, document)
 
-    {:ok, entry}
+        entry =
+          Entry.definition(
+            document.path,
+            block,
+            current_module,
+            :struct,
+            range,
+            Application.get_application(current_module)
+          )
+
+        {:ok, entry}
+
+      _ ->
+        :ignored
+    end
   end
 
   def extract(_, _) do

--- a/apps/remote_control/test/lexical/remote_control/analyzer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/analyzer_test.exs
@@ -72,6 +72,19 @@ defmodule Lexical.RemoteControl.AnalyzerTest do
       analysis = Ast.analyze(document)
       assert {:ok, Parent.Child} = Analyzer.current_module(analysis, position)
     end
+
+    test "works in a protocol definition" do
+      {position, document} =
+        ~q[
+          defprotocol MyProtocol do
+            def something(data)|
+          end
+        ]
+        |> pop_cursor(as: :document)
+
+      analysis = Ast.analyze(document)
+      assert {:ok, MyProtocol} = Analyzer.current_module(analysis, position)
+    end
   end
 
   describe "expand_alias/4" do

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/entity_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/entity_test.exs
@@ -362,7 +362,9 @@ defmodule Lexical.RemoteControl.CodeIntelligence.EntityTest do
             defstruct []
           end
 
-          %|Inner{}
+         def make do
+           %|Inner{}
+         end
         end
       >
 

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/symbols_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/symbols_test.exs
@@ -20,303 +20,304 @@ defmodule Lexical.RemoteControl.CodeIntelligence.SymbolsTest do
     """
   end
 
-  test "a top level module is found" do
-    {[%Symbols.Document{} = module], doc} =
-      ~q[
-      defmodule MyModule do
-      end
-      ]
-      |> document_symbols()
+  describe "document symbols" do
+    test "a top level module is found" do
+      {[%Symbols.Document{} = module], doc} =
+        ~q[
+        defmodule MyModule do
+        end
+        ]
+        |> document_symbols()
 
-    assert decorate(doc, module.detail_range) =~ "defmodule «MyModule» do"
-    assert module.name == "MyModule"
-    assert module.type == :module
-  end
+      assert decorate(doc, module.detail_range) =~ "defmodule «MyModule» do"
+      assert module.name == "MyModule"
+      assert module.type == :module
+    end
 
-  test "multiple top-level modules are found" do
-    {[first, second], doc} =
-      ~q[
-      defmodule First do
-      end
+    test "multiple top-level modules are found" do
+      {[first, second], doc} =
+        ~q[
+       defmodule First do
+       end
 
-      defmodule Second do
-      end
-      ]
-      |> document_symbols()
+       defmodule Second do
+       end
+       ]
+        |> document_symbols()
 
-    assert decorate(doc, first.detail_range) =~ "defmodule «First» do"
-    assert first.name == "First"
-    assert first.type == :module
+      assert decorate(doc, first.detail_range) =~ "defmodule «First» do"
+      assert first.name == "First"
+      assert first.type == :module
 
-    assert decorate(doc, second.detail_range) =~ "defmodule «Second» do"
-    assert second.name == "Second"
-    assert second.type == :module
-  end
+      assert decorate(doc, second.detail_range) =~ "defmodule «Second» do"
+      assert second.name == "Second"
+      assert second.type == :module
+    end
 
-  test "nested modules are found" do
-    {[outer], doc} =
-      ~q[
-      defmodule Outer do
-        defmodule Inner do
-          defmodule Innerinner do
+    test "nested modules are found" do
+      {[outer], doc} =
+        ~q[
+        defmodule Outer do
+          defmodule Inner do
+            defmodule Innerinner do
+            end
           end
         end
-      end
-      ]
-      |> document_symbols()
+        ]
+        |> document_symbols()
 
-    assert decorate(doc, outer.detail_range) =~ "defmodule «Outer» do"
-    assert outer.name == "Outer"
-    assert outer.type == :module
+      assert decorate(doc, outer.detail_range) =~ "defmodule «Outer» do"
+      assert outer.name == "Outer"
+      assert outer.type == :module
 
-    assert [inner] = outer.children
-    assert decorate(doc, inner.detail_range) =~ "defmodule «Inner» do"
-    assert inner.name == "Outer.Inner"
-    assert inner.type == :module
+      assert [inner] = outer.children
+      assert decorate(doc, inner.detail_range) =~ "defmodule «Inner» do"
+      assert inner.name == "Outer.Inner"
+      assert inner.type == :module
 
-    assert [inner_inner] = inner.children
-    assert decorate(doc, inner_inner.detail_range) =~ "defmodule «Innerinner» do"
-    assert inner_inner.name == "Outer.Inner.Innerinner"
-    assert inner_inner.type == :module
-  end
+      assert [inner_inner] = inner.children
+      assert decorate(doc, inner_inner.detail_range) =~ "defmodule «Innerinner» do"
+      assert inner_inner.name == "Outer.Inner.Innerinner"
+      assert inner_inner.type == :module
+    end
 
-  test "module attribute definitions are found" do
-    {[module], doc} =
-      ~q[
-      defmodule Module do
-        @first 3
-        @second 4
-      end
-      ]
-      |> document_symbols()
+    test "module attribute definitions are found" do
+      {[module], doc} =
+        ~q[
+        defmodule Module do
+          @first 3
+          @second 4
+        end
+        ]
+        |> document_symbols()
 
-    assert [first, second] = module.children
-    assert decorate(doc, first.detail_range) =~ "  «@first 3»"
-    assert first.name == "@first"
+      assert [first, second] = module.children
+      assert decorate(doc, first.detail_range) =~ "  «@first 3»"
+      assert first.name == "@first"
 
-    assert decorate(doc, second.detail_range) =~ "  «@second 4»"
-    assert second.name == "@second"
-  end
+      assert decorate(doc, second.detail_range) =~ "  «@second 4»"
+      assert second.name == "@second"
+    end
 
-  test "in-progress module attributes are skipped" do
-    {[module], doc} =
-      ~q[
-      defmodule Module do
-        @
-        @callback foo() :: :ok
-      end
-      ]
-      |> document_symbols()
+    test "in-progress module attributes are skipped" do
+      {[module], doc} =
+        ~q[
+        defmodule Module do
+          @
+          @callback foo() :: :ok
+        end
+        ]
+        |> document_symbols()
 
-    assert module.type == :module
-    assert module.name == "Module"
+      assert module.type == :module
+      assert module.name == "Module"
 
-    [callback] = module.children
+      [callback] = module.children
 
-    assert callback.type == :module_attribute
-    assert callback.name == "@callback"
-    assert callback.range == callback.detail_range
-    assert decorate(doc, callback.range) =~ "«@callback foo() :: :ok»"
-  end
+      assert callback.type == :module_attribute
+      assert callback.name == "@callback"
+      assert callback.range == callback.detail_range
+      assert decorate(doc, callback.range) =~ "«@callback foo() :: :ok»"
+    end
 
-  test "module attribute references are skipped" do
-    {[module], _doc} =
-      ~q[
+    test "module attribute references are skipped" do
+      {[module], _doc} =
+        ~q[
         defmodule Parent do
          @attr 3
          def my_fun() do
           @attr
          end
         end
+        ]
+        |> document_symbols()
 
-      ]
-      |> document_symbols()
+      [_attr_def, function_def] = module.children
+      [] = function_def.children
+    end
 
-    [_attr_def, function_def] = module.children
-    [] = function_def.children
-  end
-
-  test "public function definitions are found" do
-    {[module], doc} =
-      ~q[
-      defmodule Module do
-        def my_fn do
+    test "public function definitions are found" do
+      {[module], doc} =
+        ~q[
+        defmodule Module do
+          def my_fn do
+          end
         end
-      end
-      ]
-      |> document_symbols()
+        ]
+        |> document_symbols()
 
-    assert [function] = module.children
-    assert decorate(doc, function.detail_range) =~ " def «my_fn» do"
-  end
+      assert [function] = module.children
+      assert decorate(doc, function.detail_range) =~ " def «my_fn» do"
+    end
 
-  test "private function definitions are found" do
-    {[module], doc} =
-      ~q[
-      defmodule Module do
-        defp my_fn do
+    test "private function definitions are found" do
+      {[module], doc} =
+        ~q[
+        defmodule Module do
+          defp my_fn do
+          end
         end
-      end
-      ]
-      |> document_symbols()
+        ]
+        |> document_symbols()
 
-    assert [function] = module.children
-    assert decorate(doc, function.detail_range) =~ " defp «my_fn» do"
-    assert function.name == "my_fn"
-  end
+      assert [function] = module.children
+      assert decorate(doc, function.detail_range) =~ " defp «my_fn» do"
+      assert function.name == "my_fn"
+    end
 
-  test "struct definitions are found" do
-    {[module], doc} =
-      ~q{
-      defmodule Module do
-        defstruct [:name, :value]
-      end
-      }
-      |> document_symbols()
-
-    assert [struct] = module.children
-    assert decorate(doc, struct.detail_range) =~ "  «defstruct [:name, :value]»"
-    assert struct.name == "%Module{}"
-    assert struct.type == :struct
-  end
-
-  test "struct references are skippedd" do
-    assert {[], _doc} =
-             ~q[%OtherModule{}]
-             |> document_symbols()
-  end
-
-  test "variable definitions are skipped" do
-    {[module], _doc} =
-      ~q[
-      defmodule Module do
-        defp my_fn do
-          my_var = 3
+    test "struct definitions are found" do
+      {[module], doc} =
+        ~q{
+        defmodule Module do
+          defstruct [:name, :value]
         end
-      end
-      ]
-      |> document_symbols()
+        }
+        |> document_symbols()
 
-    assert [function] = module.children
-    assert [] = function.children
-  end
+      assert [struct] = module.children
+      assert decorate(doc, struct.detail_range) =~ "  «defstruct [:name, :value]»"
+      assert struct.name == "%Module{}"
+      assert struct.type == :struct
+    end
 
-  test "variable references are skipped" do
-    {[module], _doc} =
-      ~q[
-      defmodule Module do
-        defp my_fn do
-          my_var = 3
-          my_var
+    test "struct references are skippedd" do
+      assert {[], _doc} =
+               ~q[%OtherModule{}]
+               |> document_symbols()
+    end
+
+    test "variable definitions are skipped" do
+      {[module], _doc} =
+        ~q[
+        defmodule Module do
+          defp my_fn do
+            my_var = 3
+          end
         end
-      end
-      ]
-      |> document_symbols()
+        ]
+        |> document_symbols()
 
-    assert [function] = module.children
-    assert [] = function.children
-  end
+      assert [function] = module.children
+      assert [] = function.children
+    end
 
-  test "guards shown in the name" do
-    {[module], doc} =
-      ~q[
-      defmodule Module do
-        def my_fun(x) when x > 0 do
+    test "variable references are skipped" do
+      {[module], _doc} =
+        ~q[
+        defmodule Module do
+          defp my_fn do
+            my_var = 3
+            my_var
+          end
         end
-      end
-      ]
-      |> document_symbols()
+        ]
+        |> document_symbols()
 
-    [fun] = module.children
-    assert decorate(doc, fun.detail_range) =~ "  def «my_fun(x) when x > 0» do"
-    assert fun.type == :public_function
-    assert fun.name == "my_fun(x) when x > 0"
-    assert [] == fun.children
-  end
+      assert [function] = module.children
+      assert [] = function.children
+    end
 
-  test "types show only their name" do
-    {[module], doc} =
-      ~q[
-       @type something :: :ok
-      ]
-      |> in_a_module()
-      |> document_symbols()
+    test "guards shown in the name" do
+      {[module], doc} =
+        ~q[
+        defmodule Module do
+          def my_fun(x) when x > 0 do
+          end
+        end
+        ]
+        |> document_symbols()
 
-    assert module.type == :module
+      [fun] = module.children
+      assert decorate(doc, fun.detail_range) =~ "  def «my_fun(x) when x > 0» do"
+      assert fun.type == :public_function
+      assert fun.name == "my_fun(x) when x > 0"
+      assert [] == fun.children
+    end
 
-    [type] = module.children
-    assert decorate(doc, type.detail_range) =~ "«@type something :: :ok»"
-    assert type.name == "@type something"
-    assert type.type == :type
-  end
+    test "types show only their name" do
+      {[module], doc} =
+        ~q[
+         @type something :: :ok
+        ]
+        |> in_a_module()
+        |> document_symbols()
 
-  test "specs are ignored" do
-    {[module], _doc} =
-      ~q[
-      @spec my_fun(integer()) :: :ok
-      ]
-      |> in_a_module()
-      |> document_symbols()
+      assert module.type == :module
 
-    assert module.type == :module
-  end
+      [type] = module.children
+      assert decorate(doc, type.detail_range) =~ "«@type something :: :ok»"
+      assert type.name == "@type something"
+      assert type.type == :type
+    end
 
-  test "docs are ignored" do
-    assert {[module], _doc} =
-             ~q[
+    test "specs are ignored" do
+      {[module], _doc} =
+        ~q[
+        @spec my_fun(integer()) :: :ok
+        ]
+        |> in_a_module()
+        |> document_symbols()
+
+      assert module.type == :module
+    end
+
+    test "docs are ignored" do
+      assert {[module], _doc} =
+               ~q[
                 @doc """
                  Hello
                 """
-             ]
-             |> in_a_module()
-             |> document_symbols()
+               ]
+               |> in_a_module()
+               |> document_symbols()
 
-    assert module.type == :module
-  end
+      assert module.type == :module
+    end
 
-  test "moduledocs are ignored" do
-    assert {[module], _doc} =
-             ~q[
+    test "moduledocs are ignored" do
+      assert {[module], _doc} =
+               ~q[
                 @moduledoc """
                  Hello
                 """
-             ]
-             |> in_a_module()
-             |> document_symbols()
+               ]
+               |> in_a_module()
+               |> document_symbols()
 
-    assert module.type == :module
-  end
+      assert module.type == :module
+    end
 
-  test "derives are ignored" do
-    assert {[module], _doc} =
-             ~q[
-               @derive {Something, other}
-             ]
-             |> in_a_module()
-             |> document_symbols()
+    test "derives are ignored" do
+      assert {[module], _doc} =
+               ~q[
+                 @derive {Something, other}
+               ]
+               |> in_a_module()
+               |> document_symbols()
 
-    assert module.type == :module
-  end
+      assert module.type == :module
+    end
 
-  test "impl declarations are ignored" do
-    assert {[module], _doc} =
-             ~q[
-              @impl GenServer
-             ]
-             |> in_a_module()
-             |> document_symbols()
+    test "impl declarations are ignored" do
+      assert {[module], _doc} =
+               ~q[
+                @impl GenServer
+               ]
+               |> in_a_module()
+               |> document_symbols()
 
-    assert module.type == :module
-  end
+      assert module.type == :module
+    end
 
-  test "tags ignored" do
-    assert {[module], _doc} =
-             ~q[
-              @tag :skip
-             ]
-             |> in_a_module()
-             |> document_symbols()
+    test "tags ignored" do
+      assert {[module], _doc} =
+               ~q[
+                @tag :skip
+               ]
+               |> in_a_module()
+               |> document_symbols()
 
-    assert module.type == :module
+      assert module.type == :module
+    end
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/symbols_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/symbols_test.exs
@@ -12,6 +12,14 @@ defmodule Lexical.RemoteControl.CodeIntelligence.SymbolsTest do
     {symbols, doc}
   end
 
+  defp in_a_module(code) do
+    """
+    defmodule Parent do
+      #{code}
+    end
+    """
+  end
+
   test "a top level module is found" do
     {[%Symbols.Document{} = module], doc} =
       ~q[
@@ -227,66 +235,88 @@ defmodule Lexical.RemoteControl.CodeIntelligence.SymbolsTest do
   end
 
   test "types show only their name" do
-    {[type], doc} =
+    {[module], doc} =
       ~q[
        @type something :: :ok
       ]
+      |> in_a_module()
       |> document_symbols()
 
+    assert module.type == :module
+
+    [type] = module.children
     assert decorate(doc, type.detail_range) =~ "«@type something :: :ok»"
     assert type.name == "@type something"
     assert type.type == :type
   end
 
   test "specs are ignored" do
-    {[], _doc} =
+    {[module], _doc} =
       ~q[
       @spec my_fun(integer()) :: :ok
       ]
+      |> in_a_module()
       |> document_symbols()
+
+    assert module.type == :module
   end
 
   test "docs are ignored" do
-    assert {[], _doc} =
+    assert {[module], _doc} =
              ~q[
                 @doc """
                  Hello
                 """
              ]
+             |> in_a_module()
              |> document_symbols()
+
+    assert module.type == :module
   end
 
   test "moduledocs are ignored" do
-    assert {[], _doc} =
+    assert {[module], _doc} =
              ~q[
                 @moduledoc """
                  Hello
                 """
              ]
+             |> in_a_module()
              |> document_symbols()
+
+    assert module.type == :module
   end
 
   test "derives are ignored" do
-    assert {[], _doc} =
+    assert {[module], _doc} =
              ~q[
                @derive {Something, other}
              ]
+             |> in_a_module()
              |> document_symbols()
+
+    assert module.type == :module
   end
 
   test "impl declarations are ignored" do
-    assert {[], _doc} =
+    assert {[module], _doc} =
              ~q[
               @impl GenServer
              ]
+             |> in_a_module()
              |> document_symbols()
+
+    assert module.type == :module
   end
 
   test "tags ignored" do
-    assert {[], _doc} =
+    assert {[module], _doc} =
              ~q[
               @tag :skip
              ]
+             |> in_a_module()
              |> document_symbols()
+
+    assert module.type == :module
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/function_definition_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/function_definition_test.exs
@@ -7,7 +7,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinitionTest
     end)
   end
 
-  def index_all(source) do
+  def index_functions(source) do
     do_index(source, fn entry ->
       entry.type in [:function, :public_function, :private_function]
     end)
@@ -170,7 +170,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinitionTest
         end
         ]
         |> in_a_module()
-        |> index_all()
+        |> index_functions()
 
       assert function_definition.type == :public_function
       assert function_definition.subtype == :definition
@@ -357,7 +357,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinitionTest
         end
         ]
         |> in_a_module()
-        |> index_all()
+        |> index_functions()
 
       assert function_definition.type == :private_function
       assert function_definition.subtype == :definition

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/protocol_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/protocol_test.exs
@@ -44,7 +44,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ProtocolTest do
 
       assert protocol.type == :protocol_implementation
       assert protocol.subtype == :definition
-      assert protocol.subject == Something
+      assert protocol.subject == Something.Atom
 
       expected_block =
         ~q[
@@ -56,8 +56,91 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ProtocolTest do
         ]t
         |> String.trim_trailing()
 
-      assert decorate(doc, protocol.range) == "defimpl «Something», for: Atom do"
+      assert decorate(doc, protocol.range) == "«defimpl Something, for: Atom do»"
       assert decorate(doc, protocol.block_range) == expected_block
     end
+  end
+
+  test "__MODULE__ is correct in implementations" do
+    {:ok, [protocol], doc} =
+      ~q[
+       defimpl Something, for: Atom do
+         def something(atom) do
+           __MODULE__
+         end
+       end
+      ]
+      |> index()
+
+    assert protocol.type == :protocol_implementation
+    assert protocol.subtype == :definition
+    assert protocol.subject == Something.Atom
+
+    expected_block = ~q[
+      «defimpl Something, for: Atom do
+        def something(atom) do
+          __MODULE__
+        end
+      end»
+      ]t
+
+    assert decorate(doc, protocol.range) == "«defimpl Something, for: Atom do»"
+    assert decorate(doc, protocol.block_range) == expected_block
+  end
+
+  test "indexes all parts of a protocol" do
+    {:ok, extracted, doc} =
+      ~q[
+       defimpl Protocol, for: Target do
+         def function(arg) do
+            __MODULE__
+         end
+       end
+      ]
+      |> index_everything()
+
+    [
+      protocol_impl_def,
+      module_def,
+      protocol_ref,
+      target_ref,
+      function_def,
+      proto_module_ref
+    ] = extracted
+
+    expected_block = ~q[
+     «defimpl Protocol, for: Target do
+       def function(arg) do
+          __MODULE__
+       end
+     end»
+    ]t
+
+    assert protocol_impl_def.type == :protocol_implementation
+    assert protocol_impl_def.subtype == :definition
+    assert protocol_impl_def.subject == Protocol.Target
+    assert decorate(doc, protocol_impl_def.range) =~ "«defimpl Protocol, for: Target do»"
+    assert decorate(doc, protocol_impl_def.block_range) =~ expected_block
+
+    assert module_def.type == :module
+    assert module_def.subtype == :definition
+    assert module_def.subject == Protocol.Target
+    assert decorate(doc, module_def.range) =~ "«defimpl Protocol, for: Target do»"
+    assert decorate(doc, module_def.block_range) =~ expected_block
+
+    assert protocol_ref.type == :module
+    assert protocol_ref.subtype == :reference
+    assert protocol_ref.subject == Protocol
+    assert decorate(doc, protocol_ref.range) =~ "defimpl «Protocol», "
+
+    assert target_ref.type == :module
+    assert target_ref.subtype == :reference
+    assert target_ref.subject == Target
+    assert decorate(doc, target_ref.range) =~ "defimpl Protocol, for: «Target» do"
+
+    assert function_def.type == :public_function
+
+    assert proto_module_ref.type == :module
+    assert proto_module_ref.subject == Protocol.Target
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/structure_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/structure_test.exs
@@ -12,25 +12,27 @@ defmodule Lexical.RemoteControl.Search.Indexer.StructureTest do
     test "when multiple blocks end at once" do
       {:ok, results} =
         ~q[
-          def function_1 do
-            case something() do
-              :ok -> :yep
-              _ -> :nope
+          defmodule Parent do
+            def function_1 do
+              case something() do
+                :ok -> :yep
+                _ -> :nope
+              end
             end
-          end
 
-          defp function_2 do
+            defp function_2 do
+            end
           end
         ]
         |> index()
 
-      [public_function, private_function] =
+      [module, public_function, private_function] =
         Enum.filter(results, fn entry ->
           entry.subtype == :definition
         end)
 
-      assert public_function.block_id == :root
-      assert private_function.block_id == :root
+      assert public_function.block_id == module.id
+      assert private_function.block_id == module.id
     end
 
     test "when an expression occurs after a block" do

--- a/apps/remote_control/test/support/lexical/test/extractor_case.ex
+++ b/apps/remote_control/test/support/lexical/test/extractor_case.ex
@@ -13,6 +13,10 @@ defmodule Lexical.Test.ExtractorCase do
     end
   end
 
+  def index_everything(source) do
+    do_index(source, fn entry -> entry.type != :metadata end)
+  end
+
   def do_index(source, filter, extractors \\ nil)
 
   def do_index(source, filter, extractors) when is_binary(source) do


### PR DESCRIPTION
While trying to enhance the indexing of protocol modules, I found a fairly serious bug with alias / import detection. When we'd encounter a block of code (usually starting with do), we used soureror's detection of start and end. The problem is that it starts that block before the do, so for example, `defmodule MyModule do..` would start at the `defmodule` call.

This meant that the module we were defining starts at the defmodule call, so our current module detection would be off by almost an entire line. This caused errors when builidng module names for protocols and when people would do `defmodule __MODULE__.Child do`.

We were also making nonsensical module names like `Elixir.__MODULE__` when we called `current_module` despite the fact that not all code is inside a module.

Now, module detection is character accurate and can fail, and some code had to have error detection added. For future reference, all calls to `current_module(analysis, position)` can now fail, so doing a hard pattern match on `{:ok, module}` will fail in contexts outside of a module.