### PR TITLE
Completions: Handled nil origin and full name

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion.ex
@@ -172,8 +172,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
   defp displayable?(%Project{} = project, result) do
     suggested_module =
       case result do
-        %_{full_name: full_name} -> full_name
-        %_{origin: origin} -> origin
+        %_{full_name: full_name} when is_binary(full_name) -> full_name
+        %_{origin: origin} when is_binary(origin) -> origin
         _ -> ""
       end
 

--- a/apps/server/test/lexical/server/code_intelligence/completion_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion_test.exs
@@ -118,6 +118,29 @@ defmodule Lexical.Server.CodeIntelligence.CompletionTest do
 
       assert sort_text =~ SortScope.remote(false, 9)
     end
+
+    test "typespecs with no origin are completed", %{project: project} do
+      candidate = %Candidate.Typespec{
+        argument_names: [],
+        metadata: %{builtin: true},
+        arity: 0,
+        name: "any",
+        origin: nil
+      }
+
+      patch(Lexical.RemoteControl.Api, :complete, [candidate])
+
+      [completion] = complete(project, " @type a|")
+      assert completion.label == "any()"
+    end
+
+    test "typespecs with no full_name are completed", %{project: project} do
+      candidate = %Candidate.Struct{full_name: nil, metadata: %{}, name: "Struct"}
+      patch(Lexical.RemoteControl.Api, :complete, [candidate])
+
+      [completion] = complete(project, " %Stru|")
+      assert completion.label == "Struct"
+    end
   end
 
   def with_all_completion_candidates(_) do


### PR DESCRIPTION
We received a crash bug that indicated that elixir sense can return nil in the origin of its results (this is why having structs is nice), which wasn't handled by lexical.

The fix is to ensure that origin and full_name are binary. Fixes #686