### PR TITLE
Fixed crash for in-progress module attributes

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module_attribute.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module_attribute.ex
@@ -31,6 +31,14 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ModuleAttribute do
     {:ok, reference}
   end
 
+  # an attribute being typed above an already existing attribute will have the name `@`, which we ignore
+  # example:
+  # @|
+  # @callback foo() :: :ok
+  def extract({:@, _, [{:@, _, _attr_value}]}, %Reducer{}) do
+    :ignored
+  end
+
   # Finds module attribute definitions @foo 3
   def extract({:@, _, [{attr_name, _, _attr_value}]} = attr, %Reducer{} = reducer) do
     block = Reducer.current_block(reducer)

--- a/apps/remote_control/lib/lexical/remote_control/search/subject.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/subject.ex
@@ -9,7 +9,7 @@ defmodule Lexical.RemoteControl.Search.Subject do
   end
 
   def module_attribute(module, attribute_name) do
-    "#{module}@#{attribute_name}"
+    Formats.module(module) <> "@" <> to_string(attribute_name)
   end
 
   def mfa(module, function, arity) do

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/symbols_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/symbols_test.exs
@@ -90,6 +90,27 @@ defmodule Lexical.RemoteControl.CodeIntelligence.SymbolsTest do
     assert second.name == "@second"
   end
 
+  test "in-progress module attributes are skipped" do
+    {[module], doc} =
+      ~q[
+      defmodule Module do
+        @
+        @callback foo() :: :ok
+      end
+      ]
+      |> document_symbols()
+
+    assert module.type == :module
+    assert module.name == "Module"
+
+    [callback] = module.children
+
+    assert callback.type == :module_attribute
+    assert callback.name == "@callback"
+    assert callback.range == callback.detail_range
+    assert decorate(doc, callback.range) =~ "«@callback foo() :: :ok»"
+  end
+
   test "module attribute references are skipped" do
     {[module], _doc} =
       ~q[

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/module_attribute_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/module_attribute_test.exs
@@ -25,6 +25,18 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ModuleAttributeTest do
       assert decorate(doc, attr.range) =~ "«@attribute 32»"
     end
 
+    test "in-progress module attributes are ignored" do
+      {:ok, [latter_attribute], _doc} =
+        ~q[
+        defmodule Root do
+          @
+          @callback foo() :: :ok
+        end
+        ]
+        |> index()
+      assert latter_attribute.subject == "Root@callback"
+    end
+
     test "finds multiple definitions of the same attribute" do
       {:ok, [first, second, third], doc} =
         ~q[


### PR DESCRIPTION
If you're typing a module attribute before another module attribute, the parser would emit an extra module attribute with the name of `@` in addition to the existing module attribute.
This change ignores module attributes with the name `@`.

Fixes #690