### PR TITLE
Current modules can be nil

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/entity.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/entity.ex
@@ -18,7 +18,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Entity do
           | {:struct, maybe_module()}
           | {:call, maybe_module(), fun_name :: atom(), arity :: non_neg_integer()}
           | {:type, maybe_module(), type_name :: atom(), arity :: non_neg_integer()}
-          | {:module_attribute, container_module :: maybe_module(), attribut_name :: atom()}
+          | {:module_attribute, container_module :: maybe_module(), attribute_name :: atom()}
           | {:variable, variable_name :: atom()}
 
   defguardp is_call(form) when Sourceror.Identifier.is_call(form) and elem(form, 0) != :.

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/entity.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/entity.ex
@@ -12,12 +12,13 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Entity do
   require Logger
   require Sourceror.Identifier
 
+  @type maybe_module :: module() | nil
   @type resolved ::
-          {:module, module() | nil}
-          | {:struct, module()}
-          | {:call, module(), fun_name :: atom(), arity :: non_neg_integer()}
-          | {:type, module(), type_name :: atom(), arity :: non_neg_integer()}
-          | {:module_attribute, container_module :: module(), attribut_name :: atom()}
+          {:module, maybe_module()}
+          | {:struct, maybe_module()}
+          | {:call, maybe_module(), fun_name :: atom(), arity :: non_neg_integer()}
+          | {:type, maybe_module(), type_name :: atom(), arity :: non_neg_integer()}
+          | {:module_attribute, container_module :: maybe_module(), attribut_name :: atom()}
           | {:variable, variable_name :: atom()}
 
   defguardp is_call(form) when Sourceror.Identifier.is_call(form) and elem(form, 0) != :.

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/entity_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/entity_test.exs
@@ -695,6 +695,13 @@ defmodule Lexical.RemoteControl.CodeIntelligence.EntityTest do
       assert {:ok, {:call, Parent, :local_call, 1}, resolved_range} = resolve(code)
       assert resolved_range =~ ~S[   |> «local_call»()]
     end
+
+    test "fails gracefully when outside of a module" do
+      code = ~q[
+        local_call()|
+      ]
+      assert {:error, :not_found} = resolve(code)
+    end
   end
 
   describe "imported call" do
@@ -842,6 +849,15 @@ defmodule Lexical.RemoteControl.CodeIntelligence.EntityTest do
 
       assert {:ok, {:module_attribute, Parent, :foo}, resolved_range} = resolve(code)
       assert resolved_range =~ "%{foo: «@foo»}"
+    end
+
+    test "returns a failure if you're not in a module" do
+      code = ~q[
+       @fo|o 3
+      ]
+
+      assert {:ok, {:module_attribute, nil, :foo}, resolved_range} = resolve(code)
+      assert resolved_range =~ "«@foo» 3"
     end
   end
 

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/entity_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/entity_test.exs
@@ -696,11 +696,12 @@ defmodule Lexical.RemoteControl.CodeIntelligence.EntityTest do
       assert resolved_range =~ ~S[   |> «local_call»()]
     end
 
-    test "fails gracefully when outside of a module" do
+    test "returns a nil module when outside of a module" do
       code = ~q[
-        local_call()|
+        local_call|()
       ]
-      assert {:error, :not_found} = resolve(code)
+      assert {:ok, {:call, nil, :local_call, 0}, resolved_range} = resolve(code)
+      assert resolved_range =~ ~S[«local_call»()]
     end
   end
 
@@ -851,7 +852,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.EntityTest do
       assert resolved_range =~ "%{foo: «@foo»}"
     end
 
-    test "returns a failure if you're not in a module" do
+    test "returns nil module you're not in a module context" do
       code = ~q[
        @fo|o 3
       ]


### PR DESCRIPTION
In contexts like heex templates, the current module can be nil, but entity didn't account for that, as it was hard matching on {:ok, module}, which caused crashes in things like hover.

Fixes #693