### PR TITLE
textDocument/definition: respond with nil result when not found

### DIFF
--- a/apps/remote_control/test/fixtures/navigations/lib/uses.ex
+++ b/apps/remote_control/test/fixtures/navigations/lib/uses.ex
@@ -4,4 +4,8 @@ defmodule Navigations.Uses do
   def my_function do
     MyDefinition.greet("world")
   end
+
+  def other_function do
+    IO.puts("hi")
+  end
 end

--- a/apps/server/lib/lexical/server/provider/handlers/go_to_definition.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/go_to_definition.ex
@@ -12,7 +12,7 @@ defmodule Lexical.Server.Provider.Handlers.GoToDefinition do
 
       {:error, reason} ->
         Logger.error("GoToDefinition failed: #{inspect(reason)}")
-        {:reply, Responses.GoToDefinition.error(request.id, :request_failed, inspect(reason))}
+        {:reply, Responses.GoToDefinition.new(request.id, nil)}
     end
   end
 end

--- a/apps/server/test/lexical/server/provider/handlers/go_to_definition_test.exs
+++ b/apps/server/test/lexical/server/provider/handlers/go_to_definition_test.exs
@@ -56,12 +56,34 @@ defmodule Lexical.Server.Provider.Handlers.GoToDefinitionTest do
   describe "go to definition" do
     setup [:with_referenced_file]
 
-    test "find the function defintion", %{project: project, uri: referenced_uri} do
+    test "finds user-defined functions", %{project: project, uri: referenced_uri} do
       uses_file_path = file_path(project, Path.join("lib", "uses.ex"))
       {:ok, request} = build_request(uses_file_path, 4, 17)
 
       {:reply, %{result: %Location{} = location}} = handle(request, project)
       assert Location.uri(location) == referenced_uri
+    end
+
+    test "finds user-defined modules", %{project: project, uri: referenced_uri} do
+      uses_file_path = file_path(project, Path.join("lib", "uses.ex"))
+      {:ok, request} = build_request(uses_file_path, 4, 4)
+
+      {:reply, %{result: %Location{} = location}} = handle(request, project)
+      assert Location.uri(location) == referenced_uri
+    end
+
+    test "does not find built-in functions", %{project: project} do
+      uses_file_path = file_path(project, Path.join("lib", "uses.ex"))
+      {:ok, request} = build_request(uses_file_path, 8, 7)
+
+      {:reply, %{result: nil}} = handle(request, project)
+    end
+
+    test "does not find built-in modules", %{project: project} do
+      uses_file_path = file_path(project, Path.join("lib", "uses.ex"))
+      {:ok, request} = build_request(uses_file_path, 8, 4)
+
+      {:reply, %{result: nil}} = handle(request, project)
     end
   end
 end


### PR DESCRIPTION
Error responses should only be used for exceptional circumstances (e.g. a literal raised exception was caught) as opposed to "this thing wasn't found". In VS Code, for instance, error responses cause a pop-up to appear that you have to manually dismiss.

I checked all the other handlers and it looks like this was the only one still using the error response for something like this.

Fixes #697.
