### PR TITLE
Added boost for matches directly following the last period

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/search/fuzzy/scorer.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/fuzzy/scorer.ex
@@ -13,7 +13,7 @@ defmodule Lexical.RemoteControl.Search.Fuzzy.Scorer do
     2. Patterns that match more consecutive characters
     3. Patterns that match the beginning of the subject
     4. Patterns that match the case of the subject
-    5. Patterns that match after the last period
+    5. Patterns that match the tail of a subject starting at the last period
 
   Based loosely on https://medium.com/@Srekel/implementing-a-fuzzy-search-algorithm-for-the-debuginator-cacc349e6c55
   """
@@ -170,7 +170,7 @@ defmodule Lexical.RemoteControl.Search.Fuzzy.Scorer do
 
     match_amount_boost = consecutive_count * pattern_length
 
-    match_boost = match_boost(score, subject, pattern_length)
+    match_boost = tail_match_boost(score, subject, pattern_length)
 
     camel_case_boost = camel_case_boost(score.matched_character_positions, subject)
 
@@ -187,9 +187,8 @@ defmodule Lexical.RemoteControl.Search.Fuzzy.Scorer do
   end
 
   @tail_match_boost 55
-  @max_match_boost_boost 10
 
-  defp match_boost(
+  defp tail_match_boost(
          %__MODULE__{} = score,
          subject(graphemes: graphemes, period_positions: period_positions),
          pattern_length
@@ -204,8 +203,7 @@ defmodule Lexical.RemoteControl.Search.Fuzzy.Scorer do
       # and the pattern matches the most local parts
       @tail_match_boost
     else
-      # penalize first matches further in the string by making them negative.
-      max(0 - first_match_position, @max_match_boost_boost)
+      0
     end
   end
 

--- a/apps/remote_control/test/lexical/remote_control/search/fuzzy/scorer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/fuzzy/scorer_test.exs
@@ -41,7 +41,6 @@ defmodule Lexical.RemoteControl.Search.Fuzzy.ScorerTest do
   end
 
   describe "matching heuristics" do
-    @tag :skip
     test "more complete matches are boosted" do
       results =
         score_and_sort(
@@ -53,7 +52,6 @@ defmodule Lexical.RemoteControl.Search.Fuzzy.ScorerTest do
                ~w(Lexical.Document Lexical.Document.Range Something.Else.Lexical.Other.Type.Document.Thing)
     end
 
-    @tag :skip
     test "matches at the beginning of the string are boosted" do
       results =
         score_and_sort(
@@ -64,16 +62,24 @@ defmodule Lexical.RemoteControl.Search.Fuzzy.ScorerTest do
       assert results == ~w(Document Something.Document Something.Else.Document)
     end
 
-    @tag :skip
     test "patterns that match consecutive characters are boosted" do
       results = score_and_sort(~w(axxxbxxxcxxxdxxx axxbxxcxxdxx axbxcxdx abcd), "abcd")
       assert results == ~w(abcd axbxcxdx axxbxxcxxdxx axxxbxxxcxxxdxxx)
     end
 
-    @tag :skip
     test "patterns that match the case are boosted" do
       results = score_and_sort(~w(stinky stinkY StiNkY STINKY), "STINKY")
       assert results == ~w(STINKY StiNkY stinkY stinky)
+    end
+
+    test "matches at the end of a module are boosted" do
+      results =
+        score_and_sort(
+          ~w(First.Third.Second Third.First.Second First.Second.Third),
+          "Third"
+        )
+
+      assert ["First.Second.Third" | _] = results
     end
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/search/fuzzy/scorer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/fuzzy/scorer_test.exs
@@ -67,9 +67,14 @@ defmodule Lexical.RemoteControl.Search.Fuzzy.ScorerTest do
       assert results == ~w(abcd axbxcxdx axxbxxcxxdxx axxxbxxxcxxxdxxx)
     end
 
-    test "patterns that match the case are boosted" do
-      results = score_and_sort(~w(stinky stinkY StiNkY STINKY), "STINKY")
-      assert results == ~w(STINKY StiNkY stinkY stinky)
+    test "patterns that match camel case are boosted" do
+      results =
+        score_and_sort(
+          ~w(lotsofcamelcase LotsofcamelCase LotsofCamelCase LotsOfCamelCase),
+          "LotsOfCamelCase"
+        )
+
+      assert results == ~w(LotsOfCamelCase LotsofCamelCase LotsofcamelCase lotsofcamelcase)
     end
 
     test "matches at the end of a module are boosted" do
@@ -80,6 +85,12 @@ defmodule Lexical.RemoteControl.Search.Fuzzy.ScorerTest do
         )
 
       assert ["First.Second.Third" | _] = results
+    end
+
+    test "modules are boosted" do
+      results = score_and_sort(~w(create_user save_user Demo.Accounts.User), "User")
+
+      assert ["Demo.Accounts.User" | _] = results
     end
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/search/fuzzy/scorer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/fuzzy/scorer_test.exs
@@ -87,10 +87,11 @@ defmodule Lexical.RemoteControl.Search.Fuzzy.ScorerTest do
       assert ["First.Second.Third" | _] = results
     end
 
-    test "modules are boosted" do
-      results = score_and_sort(~w(create_user save_user Demo.Accounts.User), "User")
+    test "tail matches are boosted" do
+      results =
+        score_and_sort(~w(create_user save_user Foo.Bar.Baz.Demo.Accounts.LiveDemo.User), "User")
 
-      assert ["Demo.Accounts.User" | _] = results
+      assert ["Foo.Bar.Baz.Demo.Accounts.LiveDemo.User" | _] = results
     end
   end
 end

--- a/apps/server/lib/lexical/server/provider/handlers/workspace_symbol.ex
+++ b/apps/server/lib/lexical/server/provider/handlers/workspace_symbol.ex
@@ -14,7 +14,7 @@ defmodule Lexical.Server.Provider.Handlers.WorkspaceSymbol do
 
   def handle(%WorkspaceSymbol{} = request, %Env{} = env) do
     symbols =
-      if String.length(request.query) > 3 do
+      if String.length(request.query) > 1 do
         env.project
         |> Api.workspace_symbols(request.query)
         |> tap(fn symbols -> Logger.info("syms #{inspect(Enum.take(symbols, 5))}") end)


### PR DESCRIPTION
If something matches starting after the last period (of a likely module) it is boosted. This makes a match for `MyModule.Structs.User` take precedence over `MyModule.User.Something` while querying for `User`