### PR TITLE
chore: update FOD hash

### DIFF
--- a/nix/hash
+++ b/nix/hash
@@ -1,1 +1,1 @@
-sha256-TnWGHD1Is7rX/zS1+3+9B+dWsGXX2sm/abF1cnFkEeA=
+sha256-xihxPfdLPr5jWFfcX2tccFUl7ND1mi9u8Dn28k6lGVA=


### PR DESCRIPTION
It seems that there is still issue with autoupdater. It seems that
`main` is completely locked for direct commits, which mean that GitHub
Bot cannot update the hash automatically. I need to review the
possibility to automatically create PR from the GHA to handle that. But
for now we need to update hash manually.
