### PR TITLE
Fix conversion of char positions to UTF-16 code units

### DIFF
--- a/apps/common/lib/lexical/code_unit.ex
+++ b/apps/common/lib/lexical/code_unit.ex
@@ -19,7 +19,11 @@ defmodule Lexical.CodeUnit do
   @spec utf8_char_to_utf16_offset(String.t(), utf8_character_position()) ::
           utf16_code_unit_offset()
   def utf8_char_to_utf16_offset(binary, character_position) do
-    do_utf16_offset(binary, character_position, 0)
+    binary
+    |> String.slice(0, character_position)
+    |> :unicode.characters_to_binary(:utf8, :utf16)
+    |> byte_size()
+    |> div(2)
   end
 
   @doc """
@@ -70,25 +74,6 @@ defmodule Lexical.CodeUnit do
   defp do_count_utf8(<<c::utf8, rest::binary>>, count) do
     increment = code_unit_size(c, :utf8)
     do_count_utf8(rest, count + increment)
-  end
-
-  defp do_utf16_offset(_, 0, offset) do
-    offset
-  end
-
-  defp do_utf16_offset(<<>>, _, offset) do
-    # this clause pegs the offset at the end of the string
-    # no matter the character index
-    offset
-  end
-
-  defp do_utf16_offset(<<c, rest::binary>>, remaining, offset) when c < 128 do
-    do_utf16_offset(rest, remaining - 1, offset + 1)
-  end
-
-  defp do_utf16_offset(<<c::utf8, rest::binary>>, remaining, offset) do
-    increment = code_unit_size(c, :utf16)
-    do_utf16_offset(rest, remaining - 1, offset + increment)
   end
 
   # UTF-8

--- a/apps/common/lib/lexical/code_unit.ex
+++ b/apps/common/lib/lexical/code_unit.ex
@@ -16,9 +16,9 @@ defmodule Lexical.CodeUnit do
   @doc """
   Converts a 0-based UTF-8 character position to a UTF-16 code unit offset.
   """
-  @spec utf8_char_to_utf16_offset(String.t(), utf8_character_position()) ::
+  @spec utf8_position_to_utf16_offset(String.t(), utf8_character_position()) ::
           utf16_code_unit_offset()
-  def utf8_char_to_utf16_offset(binary, character_position) do
+  def utf8_position_to_utf16_offset(binary, character_position) do
     binary
     |> String.slice(0, character_position)
     |> :unicode.characters_to_binary(:utf8, :utf16)

--- a/apps/common/lib/lexical/code_unit.ex
+++ b/apps/common/lib/lexical/code_unit.ex
@@ -1,61 +1,34 @@
 defmodule Lexical.CodeUnit do
   @moduledoc """
-  Code unit and offset conversions
+  Code unit and offset conversions.
 
-  The LSP protocol speaks in positions, which defines where something happens in a document.
-  Positions have a start and an end, which are defined as code unit _offsets_ from the beginning
-  of a line. this module helps to convert between utf8, which most of the world speaks
-  natively, and utf16, which has been forced upon us by microsoft.
-
-  Converting between offsets and code units is 0(n), and allocations only happen if a
-  multi-byte character is detected, at which point, only that character is allocated.
-  This exploits the fact that most source code consists of ascii characters, with at best,
-  sporadic multi-byte characters in it. Thus, the vast majority of documents will not require
-  any allocations at all.
+  LSP positions are encoded as UTF-16 code unit offsets from the beginning of a line,
+  while positions in Elixir are UTF-8 character positions (graphemes). This module
+  deals with converting between the two.
   """
-  @type utf8_code_unit :: non_neg_integer()
-  @type utf16_code_unit :: non_neg_integer()
-  @type utf8_offset :: non_neg_integer()
-  @type utf16_offset :: non_neg_integer()
+
+  @type utf8_character_position :: non_neg_integer()
+  @type utf8_code_unit_offset :: non_neg_integer()
+  @type utf16_code_unit_offset :: non_neg_integer()
 
   @type error :: {:error, :misaligned} | {:error, :out_of_bounds}
 
-  # public
-
   @doc """
-  Converts a utf8 character offset into a utf16 character offset. This implementation
-  clamps the maximum size of an offset so that any initial character position can be
-  passed in and the offset returned will reflect the end of the line.
+  Converts a 0-based UTF-8 character position to a UTF-16 code unit offset.
   """
-  @spec utf16_offset(String.t(), utf8_offset()) :: utf16_offset()
-  def utf16_offset(binary, character_position) do
+  @spec utf8_char_to_utf16_offset(String.t(), utf8_character_position()) ::
+          utf16_code_unit_offset()
+  def utf8_char_to_utf16_offset(binary, character_position) do
     do_utf16_offset(binary, character_position, 0)
   end
 
   @doc """
-  Converts a utf16 character offset into a utf8 character offset. This implementation
-  clamps the maximum size of an offset so that any initial character position can be
-  passed in and the offset returned will reflect the end of the line.
+  Converts a 0-based UTF-16 code unit offset to a UTF-8 code unit offset.
   """
-  @spec utf8_offset(String.t(), utf16_offset()) :: utf8_offset()
-  def utf8_offset(binary, character_position) do
-    do_utf8_offset(binary, character_position, 1)
-  end
-
-  @doc """
-  Converts a utf16 position into a corresponding utf8 position
-  """
-  @spec to_utf8(String.t(), utf16_code_unit()) :: {:ok, utf8_code_unit()} | error
-  def to_utf8(binary, utf16_unit) do
+  @spec utf16_offset_to_utf8_offset(String.t(), utf16_code_unit_offset()) ::
+          {:ok, utf8_code_unit_offset()} | error
+  def utf16_offset_to_utf8_offset(binary, utf16_unit) do
     do_to_utf8(binary, utf16_unit, 1)
-  end
-
-  @doc """
-  Converts a utf8 position into a corresponding utf16 position
-  """
-  @spec to_utf16(String.t(), utf8_code_unit()) :: {:ok, utf16_code_unit()} | error
-  def to_utf16(binary, utf16_unit) do
-    do_to_utf16(binary, utf16_unit, 0)
   end
 
   @doc """
@@ -118,50 +91,7 @@ defmodule Lexical.CodeUnit do
     do_utf16_offset(rest, remaining - 1, offset + increment)
   end
 
-  defp do_to_utf16(_, 0, utf16_unit) do
-    {:ok, utf16_unit}
-  end
-
-  defp do_to_utf16(_, utf8_unit, _) when utf8_unit < 0 do
-    {:error, :misaligned}
-  end
-
-  defp do_to_utf16(<<>>, _remaining, _utf16_unit) do
-    {:error, :out_of_bounds}
-  end
-
-  defp do_to_utf16(<<c, rest::binary>>, utf8_unit, utf16_unit) when c < 128 do
-    do_to_utf16(rest, utf8_unit - 1, utf16_unit + 1)
-  end
-
-  defp do_to_utf16(<<c::utf8, rest::binary>>, utf8_unit, utf16_unit) do
-    increment = code_unit_size(c, :utf16)
-    decrement = code_unit_size(c, :utf8)
-
-    do_to_utf16(rest, utf8_unit - decrement, utf16_unit + increment)
-  end
-
   # UTF-8
-
-  defp do_utf8_offset(_, 0, offset) do
-    offset
-  end
-
-  defp do_utf8_offset(<<>>, _, offset) do
-    # this clause pegs the offset at the end of the string
-    # no matter the character index
-    offset
-  end
-
-  defp do_utf8_offset(<<c, rest::binary>>, remaining, offset) when c < 128 do
-    do_utf8_offset(rest, remaining - 1, offset + 1)
-  end
-
-  defp do_utf8_offset(<<c::utf8, rest::binary>>, remaining, offset) do
-    increment = code_unit_size(c, :utf8)
-    decrement = code_unit_size(c, :utf16)
-    do_utf8_offset(rest, remaining - decrement, offset + increment)
-  end
 
   defp do_to_utf8(_, 0, utf8_unit) do
     {:ok, utf8_unit}

--- a/apps/common/test/lexical/code_unit_test.exs
+++ b/apps/common/test/lexical/code_unit_test.exs
@@ -2,212 +2,76 @@ defmodule Lexical.CodeUnitTest do
   alias Lexical.CodeUnit
 
   use ExUnit.Case
-  use ExUnitProperties
+
   import CodeUnit
 
-  describe "utf8 offsets" do
+  describe "utf8_char_to_utf16_offset/2" do
     test "handles single-byte characters" do
       s = "do"
-      assert 1 == utf8_offset(s, 0)
-      assert 2 == utf8_offset(s, 1)
-      assert 3 == utf8_offset(s, 2)
-      assert 3 == utf8_offset(s, 3)
-      assert 3 == utf8_offset(s, 4)
+      assert 0 == utf8_char_to_utf16_offset(s, 0)
+      assert 1 == utf8_char_to_utf16_offset(s, 1)
+      assert 2 == utf8_char_to_utf16_offset(s, 2)
+      assert 2 == utf8_char_to_utf16_offset(s, 3)
+      assert 2 == utf8_char_to_utf16_offset(s, 4)
     end
 
     test "caps offsets at the end of the string and beyond" do
       line = "🎸"
-
-      # reminder, the offsets below are utf-16
-      # character code unit offsets, which differ
-      # from utf8's, and can have gaps.
-
-      assert 5 == utf8_offset(line, 1)
-      assert 5 == utf8_offset(line, 2)
-      assert 5 == utf8_offset(line, 3)
-      assert 5 == utf8_offset(line, 4)
-    end
-
-    test "handles multi-byte characters properly" do
-      line = "b🎸abc"
-
-      # reminder, the offsets below are utf-16
-      # character code unit offsets, which differ
-      # from utf8's, and can have gaps.
-
-      assert 1 == utf8_offset(line, 0)
-      assert 2 == utf8_offset(line, 1)
-      assert 6 == utf8_offset(line, 3)
-      assert 7 == utf8_offset(line, 4)
-      assert 8 == utf8_offset(line, 5)
-      assert 9 == utf8_offset(line, 6)
-      assert 9 == utf8_offset(line, 7)
-    end
-  end
-
-  describe "utf16_offset/2" do
-    test "handles single-byte characters" do
-      s = "do"
-      assert 0 == utf16_offset(s, 0)
-      assert 1 == utf16_offset(s, 1)
-      assert 2 == utf16_offset(s, 2)
-      assert 2 == utf16_offset(s, 3)
-      assert 2 == utf16_offset(s, 4)
-    end
-
-    test "caps offsets at the end of the string and beyond" do
-      line = "🎸"
-      assert 2 == utf16_offset(line, 1)
-      assert 2 == utf16_offset(line, 2)
-      assert 2 == utf16_offset(line, 3)
-      assert 2 == utf16_offset(line, 4)
+      assert 2 == utf8_char_to_utf16_offset(line, 1)
+      assert 2 == utf8_char_to_utf16_offset(line, 2)
+      assert 2 == utf8_char_to_utf16_offset(line, 3)
+      assert 2 == utf8_char_to_utf16_offset(line, 4)
     end
 
     test "handles multi-byte characters properly" do
       # guitar is 2 code units in utf16 but 4 in utf8
       line = "b🎸abc"
-      assert 0 == utf16_offset(line, 0)
-      assert 1 == utf16_offset(line, 1)
-      assert 3 == utf16_offset(line, 2)
-      assert 4 == utf16_offset(line, 3)
-      assert 5 == utf16_offset(line, 4)
-      assert 6 == utf16_offset(line, 5)
-      assert 6 == utf16_offset(line, 6)
+      assert 0 == utf8_char_to_utf16_offset(line, 0)
+      assert 1 == utf8_char_to_utf16_offset(line, 1)
+      assert 3 == utf8_char_to_utf16_offset(line, 2)
+      assert 4 == utf8_char_to_utf16_offset(line, 3)
+      assert 5 == utf8_char_to_utf16_offset(line, 4)
+      assert 6 == utf8_char_to_utf16_offset(line, 5)
+      assert 6 == utf8_char_to_utf16_offset(line, 6)
     end
   end
 
-  describe "converting to utf8" do
-    test "bounds are respected" do
-      assert {:error, :out_of_bounds} = to_utf16("h", 2)
-    end
-
+  describe "utf16_offset_to_utf8_offset" do
     test "with a multi-byte character" do
       line = "🏳️‍🌈"
 
       code_unit_count = count_utf8_code_units(line)
 
-      assert to_utf8(line, 0) == {:ok, 1}
-      assert to_utf8(line, 1) == {:error, :misaligned}
-      assert to_utf8(line, 2) == {:ok, 5}
-      assert to_utf8(line, 3) == {:ok, 8}
-      assert to_utf8(line, 4) == {:ok, 11}
-      assert to_utf8(line, 5) == {:error, :misaligned}
-      assert to_utf8(line, 6) == {:ok, code_unit_count + 1}
+      assert utf16_offset_to_utf8_offset(line, 0) == {:ok, 1}
+      assert utf16_offset_to_utf8_offset(line, 1) == {:error, :misaligned}
+      assert utf16_offset_to_utf8_offset(line, 2) == {:ok, 5}
+      assert utf16_offset_to_utf8_offset(line, 3) == {:ok, 8}
+      assert utf16_offset_to_utf8_offset(line, 4) == {:ok, 11}
+      assert utf16_offset_to_utf8_offset(line, 5) == {:error, :misaligned}
+      assert utf16_offset_to_utf8_offset(line, 6) == {:ok, code_unit_count + 1}
     end
 
     test "after a unicode character" do
       line = "    {\"🎸\",   \"ok\"}"
 
-      assert to_utf8(line, 0) == {:ok, 1}
-      assert to_utf8(line, 1) == {:ok, 2}
-      assert to_utf8(line, 4) == {:ok, 5}
-      assert to_utf8(line, 5) == {:ok, 6}
-      assert to_utf8(line, 6) == {:ok, 7}
-      assert to_utf8(line, 7) == {:error, :misaligned}
+      assert utf16_offset_to_utf8_offset(line, 0) == {:ok, 1}
+      assert utf16_offset_to_utf8_offset(line, 1) == {:ok, 2}
+      assert utf16_offset_to_utf8_offset(line, 4) == {:ok, 5}
+      assert utf16_offset_to_utf8_offset(line, 5) == {:ok, 6}
+      assert utf16_offset_to_utf8_offset(line, 6) == {:ok, 7}
+      assert utf16_offset_to_utf8_offset(line, 7) == {:error, :misaligned}
       # after the guitar character
-      assert to_utf8(line, 8) == {:ok, 11}
-      assert to_utf8(line, 9) == {:ok, 12}
-      assert to_utf8(line, 10) == {:ok, 13}
-      assert to_utf8(line, 11) == {:ok, 14}
-      assert to_utf8(line, 12) == {:ok, 15}
-      assert to_utf8(line, 13) == {:ok, 16}
-      assert to_utf8(line, 17) == {:ok, 20}
+      assert utf16_offset_to_utf8_offset(line, 8) == {:ok, 11}
+      assert utf16_offset_to_utf8_offset(line, 9) == {:ok, 12}
+      assert utf16_offset_to_utf8_offset(line, 10) == {:ok, 13}
+      assert utf16_offset_to_utf8_offset(line, 11) == {:ok, 14}
+      assert utf16_offset_to_utf8_offset(line, 12) == {:ok, 15}
+      assert utf16_offset_to_utf8_offset(line, 13) == {:ok, 16}
+      assert utf16_offset_to_utf8_offset(line, 17) == {:ok, 20}
     end
-  end
-
-  describe "converting to utf16" do
-    test "respects bounds" do
-      assert {:error, :out_of_bounds} = to_utf16("h", 2)
-    end
-
-    test "with a multi-byte character" do
-      line = "🏳️‍🌈"
-
-      code_unit_count = count_utf16_code_units(line)
-      utf8_code_unit_count = count_utf8_code_units(line)
-
-      assert to_utf16(line, 0) == {:ok, 0}
-      assert to_utf16(line, 1) == {:error, :misaligned}
-      assert to_utf16(line, 2) == {:error, :misaligned}
-      assert to_utf16(line, 3) == {:error, :misaligned}
-      assert to_utf16(line, 4) == {:ok, 2}
-      assert to_utf16(line, utf8_code_unit_count - 1) == {:error, :misaligned}
-      assert to_utf16(line, utf8_code_unit_count) == {:ok, code_unit_count}
-    end
-
-    test "after a multi-byte character" do
-      line = "    {\"🎸\",   \"ok\"}"
-
-      utf16_code_unit_count = count_utf16_code_units(line)
-      utf8_code_unit_count = count_utf8_code_units(line)
-
-      # before, the character, there is no difference between utf8 and utf16
-      for index <- 0..5 do
-        assert to_utf16(line, index) == {:ok, index}
-      end
-
-      assert to_utf16(line, 6) == {:ok, 6}
-      assert to_utf16(line, 7) == {:error, :misaligned}
-      assert to_utf16(line, 8) == {:error, :misaligned}
-      assert to_utf16(line, 9) == {:error, :misaligned}
-
-      for index <- 10..19 do
-        assert to_utf16(line, index) == {:ok, index - 2}
-      end
-
-      assert to_utf16(line, utf8_code_unit_count - 1) == {:ok, utf16_code_unit_count - 1}
-    end
-  end
-
-  property "to_utf8 and to_utf16 are inverses of each other" do
-    check all(s <- filter(string(:printable), &utf8?/1)) do
-      utf8_code_unit_count = count_utf8_code_units(s)
-      utf16_unit_count = count_utf16_code_units(s)
-
-      assert {:ok, utf16_unit} = to_utf16(s, utf8_code_unit_count)
-      assert utf16_unit == utf16_unit_count
-
-      assert {:ok, utf8_unit} = to_utf8(s, utf16_unit)
-      # adding 1 here because our utf8 conversion is one-based
-      assert utf8_unit == utf8_code_unit_count + 1
-    end
-  end
-
-  property "to_utf16 and to_utf8 are inverses" do
-    check all(s <- filter(string(:printable), &utf8?/1)) do
-      utf16_code_unit_count = count_utf16_code_units(s)
-      utf8_code_unit_count = count_utf8_code_units(s)
-
-      assert {:ok, utf8_code_unit} = to_utf8(s, utf16_code_unit_count)
-      # adding 1 here because our utf8 conversion is one-based
-      assert utf8_code_unit == utf8_code_unit_count + 1
-
-      # subtracting 1 here because our utf8 conversion is one-based
-      assert {:ok, utf16_unit} = to_utf16(s, utf8_code_unit - 1)
-      assert utf16_unit == utf16_code_unit_count
-    end
-  end
-
-  defp count_utf16_code_units(utf8_string) do
-    utf8_string
-    |> :unicode.characters_to_binary(:utf8, :utf16)
-    |> byte_size()
-    |> div(2)
   end
 
   defp count_utf8_code_units(utf8_string) do
     byte_size(utf8_string)
-  end
-
-  defp utf8?(<<_::utf8>>) do
-    true
-  end
-
-  defp utf8?(<<_::utf8, rest::binary>>) do
-    utf8?(rest)
-  end
-
-  defp utf8?(_) do
-    false
   end
 end

--- a/apps/common/test/lexical/code_unit_test.exs
+++ b/apps/common/test/lexical/code_unit_test.exs
@@ -5,34 +5,34 @@ defmodule Lexical.CodeUnitTest do
 
   import CodeUnit
 
-  describe "utf8_char_to_utf16_offset/2" do
+  describe "utf8_position_to_utf16_offset/2" do
     test "handles single-byte characters" do
       s = "do"
-      assert 0 == utf8_char_to_utf16_offset(s, 0)
-      assert 1 == utf8_char_to_utf16_offset(s, 1)
-      assert 2 == utf8_char_to_utf16_offset(s, 2)
-      assert 2 == utf8_char_to_utf16_offset(s, 3)
-      assert 2 == utf8_char_to_utf16_offset(s, 4)
+      assert 0 == utf8_position_to_utf16_offset(s, 0)
+      assert 1 == utf8_position_to_utf16_offset(s, 1)
+      assert 2 == utf8_position_to_utf16_offset(s, 2)
+      assert 2 == utf8_position_to_utf16_offset(s, 3)
+      assert 2 == utf8_position_to_utf16_offset(s, 4)
     end
 
     test "caps offsets at the end of the string and beyond" do
       line = "🎸"
-      assert 2 == utf8_char_to_utf16_offset(line, 1)
-      assert 2 == utf8_char_to_utf16_offset(line, 2)
-      assert 2 == utf8_char_to_utf16_offset(line, 3)
-      assert 2 == utf8_char_to_utf16_offset(line, 4)
+      assert 2 == utf8_position_to_utf16_offset(line, 1)
+      assert 2 == utf8_position_to_utf16_offset(line, 2)
+      assert 2 == utf8_position_to_utf16_offset(line, 3)
+      assert 2 == utf8_position_to_utf16_offset(line, 4)
     end
 
     test "handles multi-byte characters properly" do
       # guitar is 2 code units in utf16 but 4 in utf8
       line = "b🎸abc"
-      assert 0 == utf8_char_to_utf16_offset(line, 0)
-      assert 1 == utf8_char_to_utf16_offset(line, 1)
-      assert 3 == utf8_char_to_utf16_offset(line, 2)
-      assert 4 == utf8_char_to_utf16_offset(line, 3)
-      assert 5 == utf8_char_to_utf16_offset(line, 4)
-      assert 6 == utf8_char_to_utf16_offset(line, 5)
-      assert 6 == utf8_char_to_utf16_offset(line, 6)
+      assert 0 == utf8_position_to_utf16_offset(line, 0)
+      assert 1 == utf8_position_to_utf16_offset(line, 1)
+      assert 3 == utf8_position_to_utf16_offset(line, 2)
+      assert 4 == utf8_position_to_utf16_offset(line, 3)
+      assert 5 == utf8_position_to_utf16_offset(line, 4)
+      assert 6 == utf8_position_to_utf16_offset(line, 5)
+      assert 6 == utf8_position_to_utf16_offset(line, 6)
     end
   end
 

--- a/apps/protocol/lib/lexical/protocol/conversions.ex
+++ b/apps/protocol/lib/lexical/protocol/conversions.ex
@@ -143,7 +143,7 @@ defmodule Lexical.Protocol.Conversions do
   end
 
   defp extract_lsp_character(%ElixirPosition{context_line: line(text: utf8_text)} = position) do
-    code_unit = CodeUnit.utf16_offset(utf8_text, position.character - 1)
+    code_unit = CodeUnit.utf8_char_to_utf16_offset(utf8_text, position.character - 1)
     character = min(code_unit, CodeUnit.count(:utf16, utf8_text))
     {:ok, character}
   end
@@ -154,7 +154,7 @@ defmodule Lexical.Protocol.Conversions do
   end
 
   defp extract_elixir_character(%LSPosition{} = position, line(text: utf8_text)) do
-    with {:ok, code_unit} <- CodeUnit.to_utf8(utf8_text, position.character) do
+    with {:ok, code_unit} <- CodeUnit.utf16_offset_to_utf8_offset(utf8_text, position.character) do
       character = min(code_unit, byte_size(utf8_text) + 1)
       {:ok, character}
     end

--- a/apps/protocol/lib/lexical/protocol/conversions.ex
+++ b/apps/protocol/lib/lexical/protocol/conversions.ex
@@ -143,7 +143,7 @@ defmodule Lexical.Protocol.Conversions do
   end
 
   defp extract_lsp_character(%ElixirPosition{context_line: line(text: utf8_text)} = position) do
-    code_unit = CodeUnit.utf8_char_to_utf16_offset(utf8_text, position.character - 1)
+    code_unit = CodeUnit.utf8_position_to_utf16_offset(utf8_text, position.character - 1)
     character = min(code_unit, CodeUnit.count(:utf16, utf8_text))
     {:ok, character}
   end

--- a/apps/protocol/lib/lexical/protocol/conversions.ex
+++ b/apps/protocol/lib/lexical/protocol/conversions.ex
@@ -143,10 +143,9 @@ defmodule Lexical.Protocol.Conversions do
   end
 
   defp extract_lsp_character(%ElixirPosition{context_line: line(text: utf8_text)} = position) do
-    with {:ok, code_unit} <- CodeUnit.to_utf16(utf8_text, position.character - 1) do
-      character = min(code_unit, CodeUnit.count(:utf16, utf8_text))
-      {:ok, character}
-    end
+    code_unit = CodeUnit.utf16_offset(utf8_text, position.character - 1)
+    character = min(code_unit, CodeUnit.count(:utf16, utf8_text))
+    {:ok, character}
   end
 
   defp extract_elixir_character(%LSPosition{} = position, line(ascii?: true, text: text)) do

--- a/apps/protocol/test/lexical/protocol/conversions_test.exs
+++ b/apps/protocol/test/lexical/protocol/conversions_test.exs
@@ -87,8 +87,8 @@ defmodule Lexical.Protocol.ConversionsTest do
 
     test "single line utf8" do
       doc = doc("🏳️‍🌈abcde")
-      assert {:ok, pos} = Conversions.to_lsp(ex_position(doc, 1, 15))
-      assert %LSPosition{character: 6, line: 0} == pos
+      assert {:ok, pos} = Conversions.to_lsp(ex_position(doc, 1, 2))
+      assert %LSPosition{character: 2, line: 0} == pos
     end
 
     test "multi line" do

--- a/apps/protocol/test/lexical/protocol/conversions_test.exs
+++ b/apps/protocol/test/lexical/protocol/conversions_test.exs
@@ -88,7 +88,7 @@ defmodule Lexical.Protocol.ConversionsTest do
     test "single line utf8" do
       doc = doc("🏳️‍🌈abcde")
       assert {:ok, pos} = Conversions.to_lsp(ex_position(doc, 1, 2))
-      assert %LSPosition{character: 2, line: 0} == pos
+      assert %LSPosition{character: 6, line: 0} == pos
     end
 
     test "multi line" do

--- a/apps/server/test/lexical/convertibles/lexical.plugin.diagnostic.result_test.exs
+++ b/apps/server/test/lexical/convertibles/lexical.plugin.diagnostic.result_test.exs
@@ -73,7 +73,7 @@ defmodule Lexical.Convertibles.Lexical.Plugin.V1.Diagnostic.ResultTest do
     test "it can translate a diagnostic that starts after an emoji", %{uri: uri} do
       assert {:ok, %Types.Diagnostic{} = converted} = to_lsp(plugin_diagnostic(uri, {6, 10}), uri)
 
-      assert converted.range == range(:lsp, position(:lsp, 5, 7), position(:lsp, 6, 0))
+      assert converted.range == range(:lsp, position(:lsp, 5, 10), position(:lsp, 6, 0))
     end
 
     test "it converts lexical positions", %{uri: uri, document: document} do


### PR DESCRIPTION
We were previously using `CodeUnit.to_utf16`, which converts a *code unit* in a UTF-8 string to a code unit in the same string encoded as UTF-16, but we were passing in a *character position* which would lead to incorrect conversion of positions if any multi-byte characters were present before the position.

There were two tests of this existing behavior that seem to have been testing the incorrect behavior.

---

I'm marking this PR as draft for now because I'm also going to delete some `CodeUnit` conversion code that we should never be using (like `CodeUnit.to_utf16`) in a separate commit.