### PR TITLE
Organize aliases

### DIFF
--- a/apps/common/lib/lexical/ast.ex
+++ b/apps/common/lib/lexical/ast.ex
@@ -87,7 +87,7 @@ defmodule Lexical.Ast do
           {location :: keyword(), String.t() | {String.t(), String.t()}, String.t()}
 
   @type patch :: %{
-          optional(:preserver_indentation) => boolean(),
+          optional(:preserve_indentation) => boolean(),
           range: patch_range(),
           change: patch_change()
         }

--- a/apps/remote_control/lib/lexical/remote_control/code_action.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_action.ex
@@ -25,7 +25,11 @@ defmodule Lexical.RemoteControl.CodeAction do
           uri: Lexical.uri()
         }
 
-  @handlers [Handlers.ReplaceRemoteFunction, Handlers.ReplaceWithUnderscore]
+  @handlers [
+    Handlers.ReplaceRemoteFunction,
+    Handlers.ReplaceWithUnderscore,
+    Handlers.OrganizeAliases
+  ]
 
   @spec new(Lexical.uri(), String.t(), code_action_kind(), Changes.t()) :: t()
   def new(uri, title, kind, changes) do

--- a/apps/remote_control/lib/lexical/remote_control/code_action/handlers/organize_aliases.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_action/handlers/organize_aliases.ex
@@ -1,0 +1,170 @@
+defmodule Lexical.RemoteControl.CodeAction.Handlers.OrganizeAliases do
+  alias Lexical.Ast.Analysis
+  alias Lexical.Ast.Analysis.Alias
+  alias Lexical.Ast.Analysis.Scope
+  alias Lexical.Document
+  alias Lexical.Document.Changes
+  alias Lexical.Document.Edit
+  alias Lexical.Document.Position
+  alias Lexical.Document.Range
+  alias Lexical.RemoteControl.CodeAction
+
+  require Logger
+
+  @behaviour CodeAction.Handler
+
+  @impl CodeAction.Handler
+  def actions(%Document{} = doc, %Range{} = range, _diagnostics) do
+    with {:ok, _doc, analysis} <- Document.Store.fetch(doc.uri, :analysis),
+         :ok <- check_aliases(doc, analysis, range) do
+      edits =
+        analysis
+        |> Analysis.scopes_at(range.start)
+        |> enclosing_scopes(range)
+        |> narrorwest_scope(range.start)
+        |> aliases_in_scope()
+        |> aliases_to_edits()
+
+      if Enum.empty?(edits) do
+        []
+      else
+        changes = Changes.new(doc, edits)
+        [CodeAction.new(doc.uri, "Organize aliases", :source, changes)]
+      end
+    else
+      _ ->
+        []
+    end
+  end
+
+  @impl CodeAction.Handler
+  def kinds do
+    [:source_organize_imports]
+  end
+
+  defp aliases_to_edits([]), do: []
+
+  defp aliases_to_edits(aliases) do
+    first_alias_start = first_alias_range(aliases).start
+    initial_spaces = first_alias_start.character - 1
+
+    alias_text =
+      aliases
+      # get rid of duplicate aliases
+      |> Enum.uniq_by(& &1.module)
+      |> Enum.map_join("\n", fn %Alias{} = a ->
+        text =
+          if List.last(a.module) == a.as do
+            "alias #{join(a.module)}"
+          else
+            "alias #{join(a.module)}, as: #{join(List.wrap(a.as))}"
+          end
+
+        indent(text, initial_spaces)
+      end)
+      |> String.trim_trailing()
+
+    zeroed_start = %Position{first_alias_start | character: 1}
+    new_alias_range = Range.new(zeroed_start, zeroed_start)
+    edits = remove_old_aliases(aliases)
+
+    edits ++
+      [Edit.new(alias_text, new_alias_range)]
+  end
+
+  defp remove_old_aliases(aliases) do
+    ranges =
+      aliases
+      # iterating back to start means we won't have prior edits
+      # clobber subsequent edits
+      |> Enum.sort_by(& &1.range.start.line, :desc)
+      |> Enum.uniq_by(& &1.range)
+      |> Enum.map(fn %Alias{} = alias ->
+        orig_range = alias.range
+
+        %Range{
+          start: %Position{orig_range.start | character: 1},
+          end: %Position{orig_range.end | line: orig_range.end.line + 1, character: 1}
+        }
+      end)
+
+    first_alias_index = length(ranges) - 1
+
+    ranges
+    |> Enum.with_index()
+    |> Enum.map(fn
+      {range, ^first_alias_index} ->
+        # add a new line where the first alias was to make space
+        # for the rewritten aliases
+        Edit.new("\n", range)
+
+      {range, _} ->
+        Edit.new("", range)
+    end)
+  end
+
+  defp check_aliases(%Document{}, %Analysis{} = analysis, %Range{} = range) do
+    narroest_scope =
+      analysis
+      |> Analysis.scopes_at(range.start)
+      |> narrorwest_scope(range.start)
+
+    with %Scope{} <- narroest_scope,
+         false <- Enum.empty?(narroest_scope.aliases) do
+      :ok
+    else
+      _ ->
+        :error
+    end
+  end
+
+  defp aliases_in_scope(%Scope{} = scope) do
+    scope.aliases
+    |> Enum.filter(fn %Alias{} = scope_alias ->
+      scope_alias.explicit? and Range.contains?(scope.range, scope_alias.range.start)
+    end)
+    |> Enum.sort_by(& &1.module)
+  end
+
+  defp aliases_in_scope(_) do
+    []
+  end
+
+  defp enclosing_scopes(scopes, range) do
+    Enum.filter(scopes, fn scope ->
+      Range.contains?(scope.range, range.start)
+    end)
+  end
+
+  defp first_alias_range(aliases) do
+    aliases
+    |> Enum.min_by(fn %Alias{} = a ->
+      {a.range.start.line, a.range.start.character}
+    end)
+    |> Map.get(:range)
+  end
+
+  defp join(module) do
+    Enum.join(module, ".")
+  end
+
+  defp indent(text, spaces) do
+    String.duplicate(" ", spaces) <> text
+  end
+
+  defp narrorwest_scope(scope_list, %Position{} = position) do
+    Enum.reduce(scope_list, nil, fn
+      scope, nil ->
+        scope
+
+      %Scope{id: :global}, %Scope{} = current ->
+        current
+
+      %Scope{} = next_scope, %Scope{} = current_scope ->
+        Enum.min_by([next_scope, current_scope], fn %Scope{} = scope ->
+          scope_start = scope.range.start
+          position.line - scope_start.line
+        end)
+    end)
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/code_action/handlers/organize_aliases_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_action/handlers/organize_aliases_test.exs
@@ -1,0 +1,294 @@
+defmodule Lexical.RemoteControl.CodeAction.Handlers.OrganizeAliasesTest do
+  alias Lexical.Document
+  alias Lexical.Document.Range
+  alias Lexical.RemoteControl.CodeAction.Handlers.OrganizeAliases
+
+  import Lexical.Test.CursorSupport
+  import Lexical.Test.CodeSigil
+
+  use Lexical.Test.CodeMod.Case, enable_ast_conversion: false
+
+  setup do
+    start_supervised!({Document.Store, derive: [analysis: &Lexical.Ast.analyze/1]})
+    :ok
+  end
+
+  def apply_code_mod(text, _ast, options) do
+    range = options[:range]
+    uri = "file:///file.ex"
+    :ok = Document.Store.open(uri, text, 1)
+    {:ok, document} = Document.Store.fetch(uri)
+
+    [action] = OrganizeAliases.actions(document, range, [])
+    {:ok, action.changes.edits}
+  end
+
+  def organize_aliases(original_text) do
+    {position, stripped_text} = pop_cursor(original_text)
+    range = Range.new(position, position)
+    modify(stripped_text, range: range)
+  end
+
+  describe "outside of a module" do
+    test "aliases are sorted alphabetically" do
+      {:ok, organized} =
+        ~q[
+          alias ZZ.XX.YY
+          alias AA.BB.CC|
+        ]
+        |> organize_aliases()
+
+      expected = ~q[
+        alias AA.BB.CC
+        alias ZZ.XX.YY
+      ]t
+
+      assert expected == organized
+    end
+
+    test "nested aliases are flattened" do
+      {:ok, organized} =
+        ~q[
+        alias A.B.{C, D, E}|
+        ]
+        |> organize_aliases()
+
+      expected = ~q[
+        alias A.B.C
+        alias A.B.D
+        alias A.B.E
+      ]t
+
+      assert expected == organized
+    end
+  end
+
+  describe "at the top of a module" do
+    test "does nothing if there are no aliases" do
+      {:ok, organized} =
+        ~q[
+          defmodule Nothing do
+            @attr true|
+          end
+        ]
+        |> organize_aliases()
+
+      expected = ~q[
+      defmodule Nothing do
+        @attr true
+      end
+      ]t
+
+      assert expected == organized
+    end
+
+    test "aliases are sorted alphabetically " do
+      {:ok, organized} =
+        ~q[
+          defmodule Simple do
+            alias Z.X.Y|
+            alias V.W.X, as: Unk
+            alias A.B.C
+          end
+        ]
+        |> organize_aliases()
+
+      expected = ~q[
+      defmodule Simple do
+        alias A.B.C
+        alias V.W.X, as: Unk
+        alias Z.X.Y
+      end
+    ]t
+      assert expected == organized
+    end
+
+    test "aliases are removed duplicate aliases" do
+      {:ok, organized} =
+        ~q[
+          defmodule Dupes do
+            alias Foo.Bar.Baz|
+            alias Other.Thing
+            alias Foo.Bar.Baz
+          end
+        ]
+        |> organize_aliases()
+
+      expected = ~q[
+        defmodule Dupes do
+          alias Foo.Bar.Baz
+          alias Other.Thing
+        end
+      ]t
+      assert expected == organized
+    end
+
+    test "dependent aliase are honored" do
+      {:ok, organized} =
+        ~q[
+          defmodule Deps do
+            alias First.Dep|
+            alias Dep.Action
+            alias Action.Third
+            alias Third.Fourth.{Fifth, Sixth}
+          end
+        ]
+        |> organize_aliases()
+
+      expected = ~q[
+      defmodule Deps do
+        alias First.Dep
+        alias First.Dep.Action
+        alias First.Dep.Action.Third
+        alias First.Dep.Action.Third.Fourth.Fifth
+        alias First.Dep.Action.Third.Fourth.Sixth
+      end
+    ]t
+
+      assert expected == organized
+    end
+
+    test "nested aliases are flattened" do
+      {:ok, organized} =
+        ~q[
+          defmodule Nested do
+            alias Foo.Bar.|{
+              Baz,
+              Quux,
+              Quux.Foorp
+            }
+          end
+        ]
+        |> organize_aliases()
+
+      expected = ~q[
+      defmodule Nested do
+        alias Foo.Bar.Baz
+        alias Foo.Bar.Quux
+        alias Foo.Bar.Quux.Foorp
+      end
+    ]t
+      assert expected == organized
+    end
+
+    test "module attributes are kept " do
+      {:ok, organized} =
+        ~q[
+          defmodule Simple do
+            alias First.Second|
+            @attr true
+            alias Second.Third
+          end
+        ]
+        |> organize_aliases()
+
+      expected = ~q[
+      defmodule Simple do
+        alias First.Second
+        alias First.Second.Third
+        @attr true
+      end
+    ]t
+
+      assert expected == organized
+    end
+
+    test "aliases in a given scope are pulled to the top" do
+      {:ok, organized} =
+        ~q[
+          defmodule Scattered do
+            alias| My.Alias
+            def my_function do
+            end
+            alias Another.Alias
+            def other_function do
+            end
+            alias Yet.Another
+          end
+        ]
+        |> organize_aliases()
+
+      expected = ~q[
+      defmodule Scattered do
+        alias Another.Alias
+        alias My.Alias
+        alias Yet.Another
+        def my_function do
+        end
+        def other_function do
+        end
+      end
+      ]t
+
+      assert expected == organized
+    end
+
+    test "aliases in different scopes are left alone" do
+      {:ok, organized} =
+        ~q[
+        defmodule Outer do
+          alias Foo.Bar|
+          alias A.B
+
+          def my_fn do
+            alias Something.Else
+            1 - Else.other(1)
+          end
+        end
+        ]
+        |> organize_aliases()
+
+      expected = ~q[
+      defmodule Outer do
+        alias A.B
+        alias Foo.Bar
+
+        def my_fn do
+          alias Something.Else
+          1 - Else.other(1)
+        end
+      end
+      ]t
+
+      assert expected == organized
+    end
+
+    test "aliases in a nested module are left alone" do
+      {:ok, organized} =
+        ~q[
+        defmodule Outer do
+          alias Foo.Bar
+          alias A.B
+
+          defmodule Nested do
+            alias Something.Else
+            alias AA.BB |
+
+            def nested_fn do
+            end
+            alias BB.CC
+          end
+        end
+        ]
+        |> organize_aliases()
+
+      expected = ~q[
+        defmodule Outer do
+          alias Foo.Bar
+          alias A.B
+
+          defmodule Nested do
+            alias AA.BB
+            alias AA.BB.CC
+            alias Something.Else
+
+            def nested_fn do
+            end
+          end
+        end
+        ]t
+
+      assert expected == organized
+    end
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/code_action/handlers/organize_aliases_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_action/handlers/organize_aliases_test.exs
@@ -19,8 +19,13 @@ defmodule Lexical.RemoteControl.CodeAction.Handlers.OrganizeAliasesTest do
     :ok = Document.Store.open(uri, text, 1)
     {:ok, document} = Document.Store.fetch(uri)
 
-    [action] = OrganizeAliases.actions(document, range, [])
-    {:ok, action.changes.edits}
+    edits =
+      case OrganizeAliases.actions(document, range, []) do
+        [action] -> action.changes.edits
+        _ -> []
+      end
+
+    {:ok, edits}
   end
 
   def organize_aliases(original_text) do

--- a/apps/remote_control/test/lexical/remote_control/code_action/handlers/organize_aliases_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_action/handlers/organize_aliases_test.exs
@@ -51,6 +51,26 @@ defmodule Lexical.RemoteControl.CodeAction.Handlers.OrganizeAliasesTest do
       assert expected == organized
     end
 
+    test "aliases are sorted in a case insensitive way" do
+      {:ok, organized} =
+        ~q[
+        defmodule Outer do
+          alias CSV
+          alias Common|
+        end
+        ]
+        |> organize_aliases()
+
+      expected = ~q[
+      defmodule Outer do
+        alias Common
+        alias CSV
+      end
+      ]t
+
+      assert expected == organized
+    end
+
     test "nested aliases are flattened" do
       {:ok, organized} =
         ~q[

--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -42,7 +42,8 @@ defmodule Lexical.Server.State do
             in_flight_requests: %{}
 
   @supported_code_actions [
-    :quick_fix
+    :quick_fix,
+    :source_organize_imports
   ]
 
   def new do


### PR DESCRIPTION
First pass at an opinionated organize aliases code action. All aliases in a given scope are pulled to the top of the scope, or where the first alias occurs and are alphabetized and flattened.

Fixes #94 