### PR TITLE
Fixed two bugs with alias calculation

### DIFF
--- a/apps/common/lib/lexical/ast/analysis/scope.ex
+++ b/apps/common/lib/lexical/ast/analysis/scope.ex
@@ -42,13 +42,13 @@ defmodule Lexical.Ast.Analysis.Scope do
     # sorting by line ensures that aliases on later lines
     # override aliases on earlier lines
     |> Enum.sort_by(& &1.range.start.line)
-    |> Enum.take_while(fn %Alias{range: range} ->
+    |> Enum.take_while(fn %Alias{range: alias_range} ->
       case position do
         %Position{} = pos ->
-          pos.line >= range.end.line
+          pos.line >= alias_range.start.line
 
         line when is_integer(line) ->
-          line >= range.end.line
+          line >= alias_range.start.line
 
         :end ->
           true

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/module.ex
@@ -248,8 +248,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.Module do
   defp resolve_for_block(_, _), do: :error
 
   defp resolve_alias(%Reducer{} = reducer, unresolved_alias) do
-    {line, column} = reducer.position
-    position = Position.new(reducer.analysis.document, line, column)
+    position = Reducer.position(reducer)
 
     RemoteControl.Analyzer.expand_alias(unresolved_alias, reducer.analysis, position)
   end

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/module_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/module_test.exs
@@ -139,6 +139,23 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.ModuleTest do
       assert decorate(doc, module_ref.range) =~ "    «Thing.Util» = arg"
     end
 
+    test "can detect a module reference in a nested alias" do
+      {:ok, [_top_level, _foo, _first, second, fourth], doc} = ~q[
+        defmodule TopLevel do
+          alias Foo.{
+            First,
+            Second,
+            Third.Fourth
+          }
+        end] |> index()
+
+      assert second.subject == Foo.Second
+      assert decorate(doc, second.range) == "    «Second»,"
+
+      assert fourth.subject == Foo.Third.Fourth
+      assert decorate(doc, fourth.range) == "    «Third.Fourth»"
+    end
+
     test "can detect a module reference on the right side of a pattern match" do
       {:ok, [_module, module_ref], doc} =
         ~q[


### PR DESCRIPTION
My prior PR gave aliases ranges, and determined that an alias start at the end of its range. This meant that all the aliases inside a curly-brace defined alias wouldn't be added to the alias mappings until after the closing curly, which meant the aliases indexer wouldn't get the correct module names for them.

The second bug was always there. We look for the first item in the alias segments in the aliases mapping, and return error if it's not there. However, in a multiple alias, you can do alias Foo.{Bar.Baz}. In that instance, Baz, is the last thing in the segment list, and it wouldn't be found.