### PR TITLE
Don't pass project without project module to formatter lookup

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/code_mod/format.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_mod/format.ex
@@ -74,7 +74,7 @@ defmodule Lexical.RemoteControl.CodeMod.Format do
 
     {formatter, _opts} =
       if RemoteControl.project_node?() do
-        case RemoteControl.Mix.in_project(project, fetch_formatter) do
+        case RemoteControl.Mix.in_project(fetch_formatter) do
           {:ok, result} ->
             result
 


### PR DESCRIPTION
This fixes an edge case described in #227 for the formatter code action:

* if the project is an umbrella, and
* the umbrella is in a folder called `foo`, and
* none of the apps in the umbrella is called `foo` but
* at least one of the apps in the umbrella depends on a library called `foo`

Then the formatter will pick up the right `.formatter.exs` but the wrong dependency tree / `Mix.Project` context, and
formatting will fail. There's a fallback but it relies on `Code.format_string!` with the raw contents of `.formatter.exs` passed as formatter options. This does not always result in correct formatting because `import_deps` is ignored and not an option one can use with `Code.format_string!`. 

This PR does not have a solution for the last problem of the fallback not yielding correct results, it rather makes sure that the "normal" formatting is more likely to work.

The solution is to _not_ pass the project struct to the formatter handler, but instead to have the  `in_project` helper fetch the cached project struct from ETS. The cached one is set during bootstrap and has the `project_module` field set, while the project passed from the LSP does not. This leads `Mix.Project.in_project` to be invoked with `foo` instead of the module name of the umbrella mixfile, and ultimately confusing the umbrella with the dependency of the same name.