### PR TITLE
Indexed delegated functions

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/symbols/document.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/symbols/document.ex
@@ -27,14 +27,14 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Symbols.Document do
   @do_regex ~r/\s*do\s*$/
 
   defp name_and_type({:function, type}, %Entry{} = entry, %Document{} = document)
-       when type in [:public, :private] do
+       when type in [:public, :private, :delegate] do
     fragment = Document.fragment(document, entry.range.start, entry.range.end)
 
     prefix =
-      if type == :public do
-        "def "
-      else
-        "defp "
+      case type do
+        :public -> "def "
+        :private -> "defp "
+        :delegate -> "defdelegate "
       end
 
     {prefix <> fragment, entry.type}

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/symbols_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/symbols_test.exs
@@ -174,6 +174,37 @@ defmodule Lexical.RemoteControl.CodeIntelligence.SymbolsTest do
       assert decorate(doc, function.detail_range) =~ " def «my_fn» do"
     end
 
+    test "public functions created with defdelegate are found" do
+      {[module], doc} =
+        ~q[
+          defmodule Module do
+            defdelegate map(enumerable, func), to: Enum
+          end
+        ]
+        |> document_symbols()
+
+      assert [function] = module.children
+      assert function.type == {:function, :delegate}
+
+      assert decorate(doc, function.detail_range) =~
+               "  defdelegate «map(enumerable, func)», to: Enum"
+    end
+
+    test "public functions created with defdelegate using as are found" do
+      {[module], doc} =
+        ~q[
+          defmodule Module do
+            defdelegate collect(enumerable, func), to: Enum, as: :map
+          end
+        ]
+        |> document_symbols()
+
+      assert [function] = module.children
+
+      assert decorate(doc, function.detail_range) =~
+               "  defdelegate «collect(enumerable, func)», to: Enum, as: :map"
+    end
+
     test "private function definitions are found" do
       {[module], doc} =
         ~q[


### PR DESCRIPTION
Functions created with defdelegate weren't being indexed, so they weren't showing up in find references, document symbols,  or go to definition.

This change emits two entries when it encounters a `defdelegate` call, one for the local function definition in the calling module, and a function reference to the delegated module. One possibly strange thing is that the function that's being created by defdelegate shows up as `def` in document symbols. This is technically correct, you're defining a public function, but it might be confusing in the UI.

Fixes #724