### PR TITLE
Update server's project after remote control init

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -16,6 +16,10 @@ defmodule Lexical.RemoteControl.Api do
   defdelegate schedule_compile(project, force?), to: Build
   defdelegate compile_document(project, document), to: Build
 
+  def get_project(%Project{} = project) do
+    RemoteControl.call(project, RemoteControl, :get_project, [])
+  end
+
   def expand_alias(
         %Project{} = project,
         segments_or_module,

--- a/apps/server/lib/lexical/server/configuration.ex
+++ b/apps/server/lib/lexical/server/configuration.ex
@@ -31,8 +31,15 @@ defmodule Lexical.Server.Configuration do
 
   @dialyzer {:nowarn_function, set_dialyzer_enabled: 2}
 
+  @spec from_initialize(Requests.Initialize.t()) :: t()
+  def from_initialize(%Requests.Initialize{lsp: %Requests.Initialize.LSP{} = event}) do
+    %{capabilities: capabilities, root_uri: root_uri} = event
+    client_name = get_in(event, [:client_info, :name])
+    new(root_uri, capabilities, client_name)
+  end
+
   @spec new(Lexical.uri(), map(), String.t() | nil) :: t
-  def new(root_uri, %ClientCapabilities{} = client_capabilities, client_name) do
+  defp new(root_uri, %ClientCapabilities{} = client_capabilities, client_name) do
     support = Support.new(client_capabilities)
     project = Project.new(root_uri)
 
@@ -41,7 +48,7 @@ defmodule Lexical.Server.Configuration do
   end
 
   @spec new() :: t
-  def new do
+  defp new do
     %__MODULE__{support: Support.new()}
   end
 

--- a/apps/server/lib/lexical/server/configuration.ex
+++ b/apps/server/lib/lexical/server/configuration.ex
@@ -59,6 +59,12 @@ defmodule Lexical.Server.Configuration do
     client_supports?(get().support, key)
   end
 
+  @spec update_project(t(), Project.t()) :: t()
+  def update_project(%__MODULE__{} = config, %Project{} = project) do
+    %__MODULE__{config | project: project}
+    |> tap(&set/1)
+  end
+
   defp client_supports?(%Support{} = client_support, key) do
     case Map.fetch(client_support, key) do
       {:ok, value} -> value

--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -68,8 +68,10 @@ defmodule Lexical.Server.State do
 
     Transport.write(registrations())
 
-    Project.Supervisor.start(config.project)
-    {:ok, new_state}
+    with {:ok, _} <- Project.Supervisor.start(config.project),
+         %Lexical.Project{} = project <- RemoteControl.Api.get_project(config.project) do
+      {:ok, %__MODULE__{new_state | configuration: Configuration.update_project(config, project)}}
+    end
   end
 
   def initialize(%__MODULE__{initialized?: true}, %Initialize{}) do

--- a/apps/server/lib/lexical/server/state.ex
+++ b/apps/server/lib/lexical/server/state.ex
@@ -49,20 +49,12 @@ defmodule Lexical.Server.State do
     %__MODULE__{}
   end
 
-  def initialize(%__MODULE__{initialized?: false} = state, %Initialize{
-        lsp: %Initialize.LSP{} = event
-      }) do
-    client_name =
-      case event.client_info do
-        %{name: name} -> name
-        _ -> nil
-      end
-
-    config = Configuration.new(event.root_uri, event.capabilities, client_name)
+  def initialize(%__MODULE__{initialized?: false} = state, %Initialize{} = initialize) do
+    config = Configuration.from_initialize(initialize)
     new_state = %__MODULE__{state | configuration: config, initialized?: true}
     Logger.info("Starting project at uri #{config.project.root_uri}")
 
-    event.id
+    initialize.lsp.id
     |> initialize_result()
     |> Transport.write()
 


### PR DESCRIPTION
When remote_control bootstraps, it modifies the project struct with information about the mix project that it discovers. However, this update is not reflected in the server's project in its config, which is used whenever we make a call. Thus the two can differ, which is a bad thing.

This change fetches the project from remote control and updates it in the server's configuration after the bootstrap process has completed on the project node. They should be equal after this.

Fixes #727