### PR TITLE
Stopped passing the server project over to remote_control

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -34,7 +34,7 @@ defmodule Lexical.RemoteControl.Api do
   end
 
   def format(%Project{} = project, %Document{} = document) do
-    RemoteControl.call(project, CodeMod.Format, :edits, [project, document])
+    RemoteControl.call(project, CodeMod.Format, :edits, [document])
   end
 
   def code_actions(
@@ -116,7 +116,7 @@ defmodule Lexical.RemoteControl.Api do
   end
 
   def reindex(%Project{} = project) do
-    RemoteControl.call(project, Commands.Reindex, :perform, [project])
+    RemoteControl.call(project, Commands.Reindex, :perform, [])
   end
 
   def index_running?(%Project{} = project) do

--- a/apps/remote_control/lib/lexical/remote_control/code_mod/format.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_mod/format.ex
@@ -10,8 +10,10 @@ defmodule Lexical.RemoteControl.CodeMod.Format do
 
   @type formatter_function :: (String.t() -> any) | nil
 
-  @spec edits(Project.t(), Document.t()) :: {:ok, Changes.t()} | {:error, any}
-  def edits(%Project{} = project, %Document{} = document) do
+  @spec edits(Document.t()) :: {:ok, Changes.t()} | {:error, any}
+  def edits(%Document{} = document) do
+    project = RemoteControl.get_project()
+
     with :ok <- Build.compile_document(project, document),
          {:ok, formatted} <- do_format(project, document) do
       edits = Diff.diff(document, formatted)

--- a/apps/remote_control/lib/lexical/remote_control/commands/reindex.ex
+++ b/apps/remote_control/lib/lexical/remote_control/commands/reindex.ex
@@ -72,6 +72,7 @@ defmodule Lexical.RemoteControl.Commands.Reindex do
 
   alias Lexical.Document
   alias Lexical.Project
+  alias Lexical.RemoteControl
   alias Lexical.RemoteControl.Api
   alias Lexical.RemoteControl.Dispatch
   alias Lexical.RemoteControl.Search
@@ -89,6 +90,10 @@ defmodule Lexical.RemoteControl.Commands.Reindex do
 
   def uri(uri) do
     GenServer.cast(__MODULE__, {:reindex_uri, uri})
+  end
+
+  def perform do
+    perform(RemoteControl.get_project())
   end
 
   def perform(%Project{} = project) do

--- a/apps/remote_control/test/lexical/remote_control/code_mod/format_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_mod/format_test.exs
@@ -19,7 +19,7 @@ defmodule Lexical.RemoteControl.CodeMod.FormatTest do
       |> Keyword.get(:file_path, file_path(project))
       |> maybe_uri()
 
-    with {:ok, document_edits} <- Format.edits(project, document(file_uri, text)) do
+    with {:ok, document_edits} <- Format.edits(document(file_uri, text)) do
       {:ok, document_edits.edits}
     end
   end
@@ -67,6 +67,7 @@ defmodule Lexical.RemoteControl.CodeMod.FormatTest do
 
   setup do
     project = project()
+    RemoteControl.set_project(project)
     {:ok, project: project}
   end
 


### PR DESCRIPTION
RemoteControl has a global project object that's been augmented with extra information, but sometimes we pass server's project over to remote control. The server doesn't have this extra information, and in cases of compilation, it can cause spurious failures, like not being able to find a project's `.formatter.exs`

Fixes #727