### PR TITLE
Refactor: Pass env into completion in remote control

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/api.ex
+++ b/apps/remote_control/lib/lexical/remote_control/api.ex
@@ -1,5 +1,6 @@
 defmodule Lexical.RemoteControl.Api do
   alias Lexical.Ast.Analysis
+  alias Lexical.Ast.Env
   alias Lexical.Document
   alias Lexical.Document.Position
   alias Lexical.Document.Range
@@ -47,18 +48,9 @@ defmodule Lexical.RemoteControl.Api do
     RemoteControl.call(project, CodeAction, :for_range, [document, range, diagnostics, kinds])
   end
 
-  def complete(%Project{} = project, %Document{} = document, %Position{} = position) do
-    document_string = Document.to_string(document)
-    complete(project, document_string, position)
-  end
-
-  def complete(%Project{} = project, document_string, %Position{} = position) do
-    Logger.info("Completion for #{inspect(position)}")
-
-    RemoteControl.call(project, RemoteControl.Completion, :elixir_sense_expand, [
-      document_string,
-      position
-    ])
+  def complete(%Project{} = project, %Env{} = env) do
+    Logger.info("Completion for #{inspect(env.position)}")
+    RemoteControl.call(project, RemoteControl.Completion, :elixir_sense_expand, [env])
   end
 
   def complete_struct_fields(%Project{} = project, %Analysis{} = analysis, %Position{} = position) do

--- a/apps/remote_control/test/lexical/remote_control/completion_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/completion_test.exs
@@ -1,13 +1,16 @@
 defmodule Lexical.RemoteControl.CompletionTest do
   alias Lexical.Ast
+  alias Lexical.Ast.Env
   alias Lexical.Document
   alias Lexical.RemoteControl.Completion
 
-  import Lexical.Test.CursorSupport
   import Lexical.Test.CodeSigil
+  import Lexical.Test.CursorSupport
+  import Lexical.Test.Fixtures
   import Lexical.Test.Quiet
 
   use ExUnit.Case, async: true
+  use Patch
 
   describe "struct_fields/2" do
     test "returns the field completion for current module" do
@@ -87,6 +90,115 @@ defmodule Lexical.RemoteControl.CompletionTest do
     end
   end
 
+  def expose_strip_struct_operator(_) do
+    Patch.expose(Completion, strip_struct_operator: 1)
+    :ok
+  end
+
+  describe "strip_struct_operator/1" do
+    setup [:expose_strip_struct_operator]
+
+    test "with a reference followed by  __" do
+      {doc, _position} =
+        "%__"
+        |> new_env()
+        |> private(Completion.strip_struct_operator())
+
+      assert doc == "__"
+    end
+
+    test "with a reference followed by a module name" do
+      {doc, _position} =
+        "%Module"
+        |> new_env()
+        |> private(Completion.strip_struct_operator())
+
+      assert doc == "Module"
+    end
+
+    test "with a reference followed by a module and a dot" do
+      {doc, _position} =
+        "%Module."
+        |> new_env()
+        |> private(Completion.strip_struct_operator())
+
+      assert doc == "Module."
+    end
+
+    test "with a reference followed by a nested module" do
+      {doc, _position} =
+        "%Module.Sub"
+        |> new_env()
+        |> private(Completion.strip_struct_operator())
+
+      assert doc == "Module.Sub"
+    end
+
+    test "with a reference followed by an alias" do
+      code = ~q[
+        alias Something.Else
+        %El|
+      ]t
+
+      {doc, _position} =
+        code
+        |> new_env()
+        |> private(Completion.strip_struct_operator())
+
+      assert doc == "alias Something.Else\nEl"
+    end
+
+    test "on a line with two references, replacing the first" do
+      {doc, _position} =
+        "%First{} = %Se"
+        |> new_env()
+        |> private(Completion.strip_struct_operator())
+
+      assert doc == "%First{} = Se"
+    end
+
+    test "on a line with two references, replacing the second" do
+      {doc, _position} =
+        "%Fir| = %Second{}"
+        |> new_env()
+        |> private(Completion.strip_struct_operator())
+
+      assert doc == "Fir = %Second{}"
+    end
+
+    test "with a plain module" do
+      env = new_env("Module")
+      {doc, _position} = private(Completion.strip_struct_operator(env))
+
+      assert doc == Document.to_string(env.document)
+    end
+
+    test "with a plain module strip_struct_reference a dot" do
+      env = new_env("Module.")
+      {doc, _position} = private(Completion.strip_struct_operator(env))
+
+      assert doc == Document.to_string(env.document)
+    end
+
+    test "leaves leading spaces in place" do
+      {doc, _position} =
+        "     %Some"
+        |> new_env()
+        |> private(Completion.strip_struct_operator())
+
+      assert doc == "     Some"
+    end
+
+    test "works in a function definition" do
+      {doc, _position} =
+        "def my_function(%Lo|)"
+        |> new_env()
+        |> private(Completion.strip_struct_operator())
+
+      assert doc == "def my_function(Lo)"
+    end
+  end
+
   defp struct_fields(source) do
     {position, document} = pop_cursor(source, as: :document)
     text = Document.to_string(document)
@@ -101,5 +213,13 @@ defmodule Lexical.RemoteControl.CompletionTest do
       |> Ast.reanalyze_to(position)
 
     Completion.struct_fields(analysis, position)
+  end
+
+  def new_env(text) do
+    project = project()
+    {position, document} = pop_cursor(text, as: :document)
+    analysis = Ast.analyze(document)
+    {:ok, env} = Env.new(project, analysis, position)
+    env
   end
 end

--- a/apps/server/lib/lexical/server/code_intelligence/completion.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion.ex
@@ -71,10 +71,8 @@ defmodule Lexical.Server.CodeIntelligence.Completion do
         |> Enum.map(&Translatable.translate(&1, Builder, env))
 
       true ->
-        {stripped, position} = Builder.strip_struct_operator_for_elixir_sense(env)
-
         project
-        |> RemoteControl.Api.complete(stripped, position)
+        |> RemoteControl.Api.complete(env)
         |> to_completion_items(project, env, context)
     end
   end

--- a/apps/server/test/lexical/server/code_intelligence/completion/builder_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/builder_test.exs
@@ -7,7 +7,6 @@ defmodule Lexical.Server.CodeIntelligence.Completion.BuilderTest do
   use ExUnit.Case, async: true
 
   import Lexical.Server.CodeIntelligence.Completion.Builder
-  import Lexical.Test.CodeSigil
   import Lexical.Test.CursorSupport
   import Lexical.Test.Fixtures
 
@@ -64,108 +63,6 @@ defmodule Lexical.Server.CodeIntelligence.Completion.BuilderTest do
       iii_low = set_sort_scope(item("c"), SortScope.remote(false, 2))
 
       assert [^i, ^ii, ^iii_low, ^i_deprecated] = sort_items([i_deprecated, i, ii, iii_low])
-    end
-  end
-
-  describe "strip_struct_operator_for_elixir_sense/1" do
-    test "with a reference followed by  __" do
-      {doc, _position} =
-        "%__"
-        |> new_env()
-        |> strip_struct_operator_for_elixir_sense()
-
-      assert doc == "__"
-    end
-
-    test "with a reference followed by a module name" do
-      {doc, _position} =
-        "%Module"
-        |> new_env()
-        |> strip_struct_operator_for_elixir_sense()
-
-      assert doc == "Module"
-    end
-
-    test "with a reference followed by a module and a dot" do
-      {doc, _position} =
-        "%Module."
-        |> new_env()
-        |> strip_struct_operator_for_elixir_sense()
-
-      assert doc == "Module."
-    end
-
-    test "with a reference followed by a nested module" do
-      {doc, _position} =
-        "%Module.Sub"
-        |> new_env()
-        |> strip_struct_operator_for_elixir_sense()
-
-      assert doc == "Module.Sub"
-    end
-
-    test "with a reference followed by an alias" do
-      code = ~q[
-        alias Something.Else
-        %El|
-      ]t
-
-      {doc, _position} =
-        code
-        |> new_env()
-        |> strip_struct_operator_for_elixir_sense()
-
-      assert doc == "alias Something.Else\nEl"
-    end
-
-    test "on a line with two references, replacing the first" do
-      {doc, _position} =
-        "%First{} = %Se"
-        |> new_env()
-        |> strip_struct_operator_for_elixir_sense()
-
-      assert doc == "%First{} = Se"
-    end
-
-    test "on a line with two references, replacing the second" do
-      {doc, _position} =
-        "%Fir| = %Second{}"
-        |> new_env()
-        |> strip_struct_operator_for_elixir_sense()
-
-      assert doc == "Fir = %Second{}"
-    end
-
-    test "with a plain module" do
-      env = new_env("Module")
-      {doc, _position} = strip_struct_operator_for_elixir_sense(env)
-
-      assert doc == env.document
-    end
-
-    test "with a plain module strip_struct_reference a dot" do
-      env = new_env("Module.")
-      {doc, _position} = strip_struct_operator_for_elixir_sense(env)
-
-      assert doc == env.document
-    end
-
-    test "leaves leading spaces in place" do
-      {doc, _position} =
-        "     %Some"
-        |> new_env()
-        |> strip_struct_operator_for_elixir_sense()
-
-      assert doc == "     Some"
-    end
-
-    test "works in a function definition" do
-      {doc, _position} =
-        "def my_function(%Lo|)"
-        |> new_env()
-        |> strip_struct_operator_for_elixir_sense()
-
-      assert doc == "def my_function(Lo)"
     end
   end
 end


### PR DESCRIPTION
In preparation for suggesting modules to import, it became apparent we'd need mroe than just the document string going into the completion call. The completion environment seems like a good choice, as it offers the document, analysis, and a host of other features related to figuring out which context you're in.

This also allowed us to push elixir_sense specific logic into the completions module in remote control, further locating it closer to its call site.