### PR TITLE
Improved store error handling

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/definition.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/definition.ex
@@ -24,11 +24,17 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Definition do
     module = Formats.module(entity)
 
     locations =
-      for entry <- Store.exact(module, type: type, subtype: :definition),
-          result = to_location(entry),
-          match?({:ok, _}, result) do
-        {:ok, location} = result
-        location
+      case Store.exact(module, type: type, subtype: :definition) do
+        {:ok, entries} ->
+          for entry <- entries,
+              result = to_location(entry),
+              match?({:ok, _}, result) do
+            {:ok, location} = result
+            location
+          end
+
+        _ ->
+          []
       end
 
     case locations do

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/references.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/references.ex
@@ -86,7 +86,10 @@ defmodule Lexical.RemoteControl.CodeIntelligence.References do
   end
 
   defp query(subject, opts) do
-    subject |> Store.exact(opts) |> Enum.map(&to_location/1)
+    case Store.exact(subject, opts) do
+      {:ok, entries} -> Enum.map(entries, &to_location/1)
+      _ -> []
+    end
   end
 
   defp subtype(true = _include_definitions?), do: :_

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/structs.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/structs.ex
@@ -13,9 +13,15 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Structs do
   end
 
   defp structs_from_index do
-    for %Entry{subject: struct_module} <- Store.exact(type: :struct, subtype: :definition),
-        Loader.ensure_loaded?(struct_module) do
-      struct_module
+    case Store.exact(type: :struct, subtype: :definition) do
+      {:ok, entries} ->
+        for %Entry{subject: struct_module} <- entries,
+            Loader.ensure_loaded?(struct_module) do
+          struct_module
+        end
+
+      _ ->
+        []
     end
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/symbols.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/symbols.ex
@@ -32,9 +32,13 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Symbols do
   end
 
   def for_workspace(query) do
-    query
-    |> Search.Store.fuzzy([])
-    |> Enum.map(&Symbols.Workspace.from_entry/1)
+    case Search.Store.fuzzy(query, []) do
+      {:ok, entries} ->
+        Enum.map(entries, &Symbols.Workspace.from_entry/1)
+
+      _ ->
+        []
+    end
   end
 
   defp to_symbols(%Document{} = document, entries) do

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
@@ -17,6 +17,11 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
   @type version :: String.t()
   @type entry_id :: pos_integer() | nil
   @type block_id :: pos_integer() | :root
+  @type subject_query :: subject() | :_
+  @type entry_type_query :: entry_type() | :_
+  @type entry_subtype_query :: entry_subtype() | :_
+  @type constraint :: {:type, entry_type_query()} | {:subtype, entry_subtype_query()}
+  @type constraints :: [constraint()]
 
   defstruct [
     :application,

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/symbols_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/symbols_test.exs
@@ -30,7 +30,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.SymbolsTest do
       ])
 
     entries = Enum.reject(entries, &(&1.type == :metadata))
-    patch(Lexical.RemoteControl.Search.Store, :fuzzy, entries)
+    patch(Lexical.RemoteControl.Search.Store, :fuzzy, {:ok, entries})
     symbols = Symbols.for_workspace("")
     {symbols, doc}
   end

--- a/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/dispatch/handlers/indexer_test.exs
@@ -62,7 +62,7 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
 
       assert {:ok, _} = Indexing.on_event(file_compile_requested(uri: uri), state)
 
-      assert_eventually [entry] = Search.Store.exact("NewModule", [])
+      assert_eventually {:ok, [entry]} = Search.Store.exact("NewModule", [])
 
       assert entry.subject == NewModule
     end
@@ -86,9 +86,9 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
 
       assert {:ok, _} = Indexing.on_event(file_compile_requested(uri: uri), state)
 
-      assert_eventually [entry] = Search.Store.exact("UpdatedModule", [])
+      assert_eventually {:ok, [entry]} = Search.Store.exact("UpdatedModule", [])
       assert entry.subject == UpdatedModule
-      assert [] = Search.Store.exact("OldModule", [])
+      assert {:ok, []} = Search.Store.exact("OldModule", [])
     end
 
     test "only updates entries if the version of the document is the same as the version in the document store",
@@ -103,7 +103,7 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
         |> set_document!()
 
       assert {:ok, _} = Indexing.on_event(file_compile_requested(uri: uri), state)
-      assert [] = Search.Store.exact("Stale", [])
+      assert {:ok, []} = Search.Store.exact("Stale", [])
     end
   end
 
@@ -119,14 +119,14 @@ defmodule Lexical.RemoteControl.Dispatch.Handlers.IndexingTest do
       {:ok, entries} = Search.Indexer.Source.index(uri, source)
       Search.Store.update(uri, entries)
 
-      assert_eventually [_] = Search.Store.exact("ToDelete", [])
+      assert_eventually {:ok, [_]} = Search.Store.exact("ToDelete", [])
 
       Indexing.on_event(
         filesystem_event(project: project, uri: uri, event_type: :deleted),
         state
       )
 
-      assert_eventually [] = Search.Store.exact("ToDelete", [])
+      assert_eventually {:ok, []} = Search.Store.exact("ToDelete", [])
     end
   end
 

--- a/apps/remote_control/test/lexical/remote_control/search/store_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/store_test.exs
@@ -67,7 +67,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           reference(id: 3)
         ])
 
-        assert [ref] = Store.exact(subtype: :reference)
+        assert {:ok, [ref]} = Store.exact(subtype: :reference)
         assert ref.subtype == :reference
       end
 
@@ -78,7 +78,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           definition(subject: Foo.Bar.Baz)
         ])
 
-        assert [ref] = Store.exact("Foo.Bar.Baz", subtype: :reference)
+        assert {:ok, [ref]} = Store.exact("Foo.Bar.Baz", subtype: :reference)
 
         assert ref.subject == Foo.Bar.Baz
         assert ref.type == :module
@@ -91,7 +91,7 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           definition(id: 2, subject: Foo.Bar.Bak)
         ])
 
-        assert [entry] = Store.exact("Foo.Bar.Baz", type: :module, subtype: :definition)
+        assert {:ok, [entry]} = Store.exact("Foo.Bar.Baz", type: :module, subtype: :definition)
 
         assert entry.subject == Foo.Bar.Baz
         assert entry.id == 1
@@ -104,7 +104,8 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           definition(id: 3, subject: Foo.Bar.Baz)
         ])
 
-        assert [entry1, entry3] = Store.prefix("Foo.Bar", type: :module, subtype: :definition)
+        assert {:ok, [entry1, entry3]} =
+                 Store.prefix("Foo.Bar", type: :module, subtype: :definition)
 
         assert entry1.subject == Foo.Bar
         assert entry3.subject == Foo.Bar.Baz
@@ -120,7 +121,8 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           definition(id: 3, subject: Bad.Times.Now)
         ])
 
-        assert [entry_1, entry_2] = Store.fuzzy("Foo.Bar.B", type: :module, subtype: :definition)
+        assert {:ok, [entry_1, entry_2]} =
+                 Store.fuzzy("Foo.Bar.B", type: :module, subtype: :definition)
 
         assert entry_1.subject in [Foo.Bar.Baz, Foo.Bar.Bak]
         assert entry_2.subject in [Foo.Bar.Baz, Foo.Bar.Bak]
@@ -182,7 +184,9 @@ defmodule Lexical.RemoteControl.Search.StoreTest do
           definition(id: 2, subject: Present, path: path)
         ])
 
-        assert_eventually [found] = Store.fuzzy("Pres", type: :module, subtype: :definition)
+        assert_eventually {:ok, [found]} =
+                            Store.fuzzy("Pres", type: :module, subtype: :definition)
+
         assert found.id == 2
         assert found.subject == Present
       end


### PR DESCRIPTION
The store has a variety of states, and can return errors when it is not enabled. In light of this, we should return ok tuples when it is successful to keep the api consistent and make callers aware that they need to handle errors.

In addition, if loading / enabling takes a while, the store can time out when it's being queried, so unless it's enabled, queries will return empty results, and the enabled check uses persistent term.

Fixes #732 