### PR TITLE
Code Action: Add alias

### DIFF
--- a/apps/common/lib/lexical/ast/analysis/scope.ex
+++ b/apps/common/lib/lexical/ast/analysis/scope.ex
@@ -64,6 +64,7 @@ defmodule Lexical.Ast.Analysis.Scope do
     end
   end
 
+  def empty?(%__MODULE__{id: :global}), do: false
   def empty?(%__MODULE__{aliases: [], imports: []}), do: true
   def empty?(%__MODULE__{}), do: false
 

--- a/apps/remote_control/lib/lexical/remote_control/code_action.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_action.ex
@@ -28,7 +28,8 @@ defmodule Lexical.RemoteControl.CodeAction do
   @handlers [
     Handlers.ReplaceRemoteFunction,
     Handlers.ReplaceWithUnderscore,
-    Handlers.OrganizeAliases
+    Handlers.OrganizeAliases,
+    Handlers.AddAlias
   ]
 
   @spec new(Lexical.uri(), String.t(), code_action_kind(), Changes.t()) :: t()

--- a/apps/remote_control/lib/lexical/remote_control/code_action/handlers/add_alias.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_action/handlers/add_alias.ex
@@ -1,0 +1,201 @@
+defmodule Lexical.RemoteControl.CodeAction.Handlers.AddAlias do
+  alias Lexical.Ast
+  alias Lexical.Ast.Analysis
+  alias Lexical.Ast.Analysis.Alias
+  alias Lexical.Ast.Analysis.Scope
+  alias Lexical.Document
+  alias Lexical.Document.Changes
+  alias Lexical.Document.Position
+  alias Lexical.Document.Range
+  alias Lexical.Formats
+  alias Lexical.RemoteControl.Analyzer
+  alias Lexical.RemoteControl.CodeAction
+  alias Lexical.RemoteControl.CodeIntelligence.Entity
+  alias Lexical.RemoteControl.CodeMod
+  alias Lexical.RemoteControl.Modules
+  alias Lexical.RemoteControl.Search
+  alias Lexical.RemoteControl.Search.Indexer.Entry
+  alias Sourceror.Zipper
+
+  require Logger
+  @behaviour CodeAction.Handler
+
+  @impl CodeAction.Handler
+  def actions(%Document{} = doc, %Range{} = range, _diagnostics) do
+    with {:ok, _doc, %Analysis{valid?: true} = analysis} <-
+           Document.Store.fetch(doc.uri, :analysis),
+         {:ok, resolved, _} <- Entity.resolve(analysis, range.start),
+         {:ok, unaliased_module} <- fetch_unaliased_module(analysis, range.start, resolved) do
+      current_aliases = CodeMod.Aliases.in_scope(analysis, range)
+
+      unaliased_module
+      |> possible_aliases()
+      |> filter_by_resolution(resolved)
+      |> Enum.map(&build_code_action(analysis, range, current_aliases, &1))
+    else
+      _ ->
+        []
+    end
+  end
+
+  @impl CodeAction.Handler
+  def kinds do
+    [:quick_fix]
+  end
+
+  defp build_code_action(%Analysis{} = analysis, range, current_aliases, potential_alias_module) do
+    {insert_position, trailer} = insert_position_and_trailer(current_aliases, analysis, range)
+    split_alias = potential_alias_module |> Module.split() |> Enum.map(&String.to_atom/1)
+    alias_to_add = %Alias{module: split_alias, as: List.last(split_alias), explicit?: true}
+    replace_current_alias = get_current_replacement(analysis, range, split_alias)
+
+    alias_edits =
+      CodeMod.Aliases.to_edits(
+        [alias_to_add | current_aliases],
+        insert_position,
+        trailer
+      )
+
+    changes = Changes.new(analysis.document, replace_current_alias ++ alias_edits)
+
+    CodeAction.new(
+      analysis.document.uri,
+      "alias #{Formats.module(potential_alias_module)}",
+      :quick_fix,
+      changes
+    )
+  end
+
+  def fetch_unaliased_module(%Analysis{} = analysis, %Position{} = position, resolved) do
+    with {:ok, module} <- fetch_module(resolved),
+         %{} = aliases <- Analyzer.aliases_at(analysis, position),
+         false <- module in Map.values(aliases) do
+      {:ok, module}
+    else
+      _ ->
+        :error
+    end
+  end
+
+  defp fetch_module({:module, module}), do: {:ok, module}
+  defp fetch_module({:struct, module}), do: {:ok, module}
+  defp fetch_module({:call, module, _function, _arity}), do: {:ok, module}
+  defp fetch_module(_), do: :error
+
+  defp get_current_replacement(%Analysis{} = analysis, %Range{} = range, split_alias) do
+    with {:ok, patches} <- replace_full_module_on_line(analysis, range.start.line, split_alias),
+         {:ok, edits} <- Ast.patches_to_edits(analysis.document, patches) do
+      edits
+    else
+      _ ->
+        []
+    end
+  end
+
+  defp replace_full_module_on_line(%Analysis{} = analysis, line, split_alias) do
+    aliased_module =
+      split_alias
+      |> List.last()
+      |> List.wrap()
+      |> Module.concat()
+      |> Formats.module()
+
+    analysis.document
+    |> Ast.traverse_line(line, [], fn
+      %Zipper{node: {:__aliases__, _, ^split_alias}} = zipper, patches ->
+        range = Sourceror.get_range(zipper.node)
+
+        patch = %{range: range, change: aliased_module}
+        {zipper, [patch | patches]}
+
+      zipper, acc ->
+        {zipper, acc}
+    end)
+    |> case do
+      {:ok, _, patches} -> {:ok, patches}
+      error -> error
+    end
+  end
+
+  @similarity_threshold 0.75
+  defp similar?(a, b), do: String.jaro_distance(a, b) >= @similarity_threshold
+
+  defp filter_by_resolution(modules_stream, {:call, _module, function, _arity}) do
+    query_function = Atom.to_string(function)
+
+    Stream.filter(modules_stream, fn module ->
+      case Modules.fetch_functions(module) do
+        {:ok, functions} ->
+          Enum.any?(functions, fn {name, _arity} ->
+            module_function = Atom.to_string(name)
+            similar?(module_function, query_function)
+          end)
+
+        _ ->
+          false
+      end
+    end)
+  end
+
+  defp filter_by_resolution(modules_stream, {:struct, _}) do
+    Stream.filter(modules_stream, fn module ->
+      case Modules.fetch_functions(module) do
+        {:ok, functions} -> Keyword.has_key?(functions, :__struct__)
+        _ -> false
+      end
+    end)
+  end
+
+  defp filter_by_resolution(modules_stream, _) do
+    modules_stream
+  end
+
+  defp possible_aliases(unaliased_module) do
+    unaliased_strings = Module.split(unaliased_module)
+
+    unaliased_module
+    |> Formats.module()
+    |> Search.Store.fuzzy(type: :module, subtype: :definition)
+    |> Stream.uniq_by(& &1.subject)
+    |> Stream.filter(fn %Entry{} = entry ->
+      split = Module.split(entry.subject)
+
+      head_module = split |> List.first() |> List.wrap() |> Module.concat()
+      tail_module = split |> List.last()
+
+      protocol? = function_exported?(head_module, :__protocol__, 1)
+
+      if protocol? do
+        false
+      else
+        Enum.any?(unaliased_strings, &similar?(&1, tail_module))
+      end
+    end)
+    |> Stream.map(& &1.subject)
+  end
+
+  defp insert_position_and_trailer([%Alias{} = first | _], _, _) do
+    {first.range.start, nil}
+  end
+
+  defp insert_position_and_trailer([], %Analysis{} = analysis, range) do
+    case Analysis.module_scope(analysis, range) do
+      %Scope{id: :global} = scope ->
+        {scope.range.start, "\n"}
+
+      %Scope{} = scope ->
+        start_pos = scope.range.start
+        # we use the end position here because the start position is right after
+        # the do for modules, which puts it well into the line. The end position
+        # is before the end, which is equal to the indent of the scope.
+        end_pos = scope.range.end
+
+        start_pos =
+          start_pos
+          |> put_in([:line], start_pos.line + 1)
+          |> put_in([:character], end_pos.character + 2)
+
+        {start_pos, "\n"}
+    end
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/code_action/handlers/organize_aliases.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_action/handlers/organize_aliases.ex
@@ -4,10 +4,9 @@ defmodule Lexical.RemoteControl.CodeAction.Handlers.OrganizeAliases do
   alias Lexical.Ast.Analysis.Scope
   alias Lexical.Document
   alias Lexical.Document.Changes
-  alias Lexical.Document.Edit
-  alias Lexical.Document.Position
   alias Lexical.Document.Range
   alias Lexical.RemoteControl.CodeAction
+  alias Lexical.RemoteControl.CodeMod
 
   require Logger
 
@@ -17,13 +16,9 @@ defmodule Lexical.RemoteControl.CodeAction.Handlers.OrganizeAliases do
   def actions(%Document{} = doc, %Range{} = range, _diagnostics) do
     with {:ok, _doc, analysis} <- Document.Store.fetch(doc.uri, :analysis),
          :ok <- check_aliases(doc, analysis, range) do
-      edits =
-        analysis
-        |> Analysis.scopes_at(range.start)
-        |> enclosing_scopes(range)
-        |> narrorwest_scope(range.start)
-        |> aliases_in_scope()
-        |> aliases_to_edits()
+      aliases = CodeMod.Aliases.in_scope(analysis, range)
+      insert_position = first_alias_position(aliases)
+      edits = CodeMod.Aliases.to_edits(aliases, insert_position)
 
       if Enum.empty?(edits) do
         []
@@ -42,132 +37,24 @@ defmodule Lexical.RemoteControl.CodeAction.Handlers.OrganizeAliases do
     [:source, :source_organize_imports]
   end
 
-  defp aliases_to_edits([]), do: []
-
-  defp aliases_to_edits(aliases) do
-    first_alias_start = first_alias_range(aliases).start
-    initial_spaces = first_alias_start.character - 1
-
-    alias_text =
-      aliases
-      # get rid of duplicate aliases
-      |> Enum.uniq_by(& &1.module)
-      |> Enum.map_join("\n", fn %Alias{} = a ->
-        text =
-          if List.last(a.module) == a.as do
-            "alias #{join(a.module)}"
-          else
-            "alias #{join(a.module)}, as: #{join(List.wrap(a.as))}"
-          end
-
-        indent(text, initial_spaces)
-      end)
-      |> String.trim_trailing()
-
-    zeroed_start = %Position{first_alias_start | character: 1}
-    new_alias_range = Range.new(zeroed_start, zeroed_start)
-    edits = remove_old_aliases(aliases)
-
-    edits ++
-      [Edit.new(alias_text, new_alias_range)]
-  end
-
-  defp remove_old_aliases(aliases) do
-    ranges =
-      aliases
-      # iterating back to start means we won't have prior edits
-      # clobber subsequent edits
-      |> Enum.sort_by(& &1.range.start.line, :desc)
-      |> Enum.uniq_by(& &1.range)
-      |> Enum.map(fn %Alias{} = alias ->
-        orig_range = alias.range
-
-        orig_range
-        |> put_in([:start, :character], 1)
-        |> update_in([:end], fn %Position{} = pos ->
-          %Position{pos | character: 1, line: pos.line + 1}
-        end)
-      end)
-
-    first_alias_index = length(ranges) - 1
-
-    ranges
-    |> Enum.with_index()
-    |> Enum.map(fn
-      {range, ^first_alias_index} ->
-        # add a new line where the first alias was to make space
-        # for the rewritten aliases
-        Edit.new("\n", range)
-
-      {range, _} ->
-        Edit.new("", range)
-    end)
-  end
-
   defp check_aliases(%Document{}, %Analysis{} = analysis, %Range{} = range) do
-    narroest_scope =
-      analysis
-      |> Analysis.scopes_at(range.start)
-      |> narrorwest_scope(range.start)
-
-    with %Scope{} <- narroest_scope,
-         false <- Enum.empty?(narroest_scope.aliases) do
-      :ok
-    else
-      _ ->
-        :error
+    case Analysis.module_scope(analysis, range) do
+      %Scope{aliases: [_ | _]} -> :ok
+      _ -> :error
     end
   end
 
-  defp aliases_in_scope(%Scope{} = scope) do
-    scope.aliases
-    |> Enum.filter(fn %Alias{} = scope_alias ->
-      scope_alias.explicit? and Range.contains?(scope.range, scope_alias.range.start)
-    end)
-    |> Enum.sort_by(fn %Alias{} = scope_alias ->
-      Enum.map(scope_alias.module, fn elem -> elem |> Atom.to_string() |> String.downcase() end)
-    end)
+  defp first_alias_position([]) do
   end
 
-  defp aliases_in_scope(_) do
-    []
-  end
+  defp first_alias_position(aliases) do
+    alias =
+      aliases
+      |> Enum.reject(&is_nil(&1.range))
+      |> Enum.min_by(fn %Alias{} = a ->
+        {a.range.start.line, a.range.start.character}
+      end)
 
-  defp enclosing_scopes(scopes, range) do
-    Enum.filter(scopes, fn scope ->
-      Range.contains?(scope.range, range.start)
-    end)
-  end
-
-  defp first_alias_range(aliases) do
-    aliases
-    |> Enum.min_by(fn %Alias{} = a ->
-      {a.range.start.line, a.range.start.character}
-    end)
-    |> Map.get(:range)
-  end
-
-  defp join(module) do
-    Enum.join(module, ".")
-  end
-
-  defp indent(text, spaces) do
-    String.duplicate(" ", spaces) <> text
-  end
-
-  defp narrorwest_scope(scope_list, %Position{} = position) do
-    Enum.reduce(scope_list, nil, fn
-      scope, nil ->
-        scope
-
-      %Scope{id: :global}, %Scope{} = current ->
-        current
-
-      %Scope{} = next_scope, %Scope{} = current_scope ->
-        Enum.min_by([next_scope, current_scope], fn %Scope{} = scope ->
-          scope_start = scope.range.start
-          position.line - scope_start.line
-        end)
-    end)
+    alias.range.start
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/code_mod/aliases.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_mod/aliases.ex
@@ -1,0 +1,122 @@
+defmodule Lexical.RemoteControl.CodeMod.Aliases do
+  alias Lexical.Ast.Analysis
+  alias Lexical.Ast.Analysis.Alias
+  alias Lexical.Ast.Analysis.Scope
+  alias Lexical.Document.Edit
+  alias Lexical.Document.Position
+  alias Lexical.Document.Range
+
+  @doc """
+  Returns the aliases that are in scope at the given range.
+  """
+  @spec in_scope(Analysis.t(), Range.t()) :: [Alias.t()]
+  def in_scope(%Analysis{} = analysis, %Range{} = range) do
+    analysis
+    |> Analysis.module_scope(range)
+    |> aliases_in_scope()
+  end
+
+  @doc """
+  Sorts the given aliases according to our rules
+  """
+  @spec sort(Enumerable.t(Alias.t())) :: [Alias.t()]
+  def sort(aliases) do
+    Enum.sort_by(aliases, fn %Alias{} = scope_alias ->
+      Enum.map(scope_alias.module, fn elem -> elem |> to_string() |> String.downcase() end)
+    end)
+  end
+
+  @doc """
+  Turns a list of aliases into aliases into edits
+  """
+  @spec to_edits([Alias.t()], Position.t(), trailer :: String.t() | nil) :: [Edit.t()]
+
+  def to_edits(aliases, position, trailer \\ nil)
+  def to_edits([], _, _), do: []
+
+  def to_edits(aliases, %Position{} = insert_position, trailer) do
+    aliases = sort(aliases)
+    initial_spaces = insert_position.character - 1
+
+    alias_text =
+      aliases
+      # get rid of duplicate aliases
+      |> Enum.uniq_by(& &1.module)
+      |> Enum.map_join("\n", fn %Alias{} = a ->
+        text =
+          if List.last(a.module) == a.as do
+            "alias #{join(a.module)}"
+          else
+            "alias #{join(a.module)}, as: #{join(List.wrap(a.as))}"
+          end
+
+        indent(text, initial_spaces)
+      end)
+      |> String.trim_trailing()
+
+    zeroed = put_in(insert_position.character, 1)
+    new_alias_range = Range.new(zeroed, zeroed)
+
+    alias_text =
+      if is_binary(trailer) do
+        alias_text <> trailer
+      else
+        alias_text
+      end
+
+    edits = remove_old_aliases(aliases)
+
+    edits ++
+      [Edit.new(alias_text, new_alias_range)]
+  end
+
+  defp aliases_in_scope(%Scope{} = scope) do
+    scope.aliases
+    |> Enum.filter(fn %Alias{} = scope_alias ->
+      scope_alias.explicit? and Range.contains?(scope.range, scope_alias.range.start)
+    end)
+    |> sort()
+  end
+
+  defp join(module) do
+    Enum.join(module, ".")
+  end
+
+  defp indent(text, spaces) do
+    String.duplicate(" ", spaces) <> text
+  end
+
+  defp remove_old_aliases(aliases) do
+    ranges =
+      aliases
+      # Reject new aliases that don't have a range
+      |> Enum.reject(&is_nil(&1.range))
+      # iterating back to start means we won't have prior edits
+      # clobber subsequent edits
+      |> Enum.sort_by(& &1.range.start.line, :desc)
+      |> Enum.uniq_by(& &1.range)
+      |> Enum.map(fn %Alias{} = alias ->
+        orig_range = alias.range
+
+        orig_range
+        |> put_in([:start, :character], 1)
+        |> update_in([:end], fn %Position{} = pos ->
+          %Position{pos | character: 1, line: pos.line + 1}
+        end)
+      end)
+
+    first_alias_index = length(ranges) - 1
+
+    ranges
+    |> Enum.with_index()
+    |> Enum.map(fn
+      {range, ^first_alias_index} ->
+        # add a new line where the first alias was to make space
+        # for the rewritten aliases
+        Edit.new("\n", range)
+
+      {range, _} ->
+        Edit.new("", range)
+    end)
+  end
+end

--- a/apps/remote_control/lib/mix/tasks/namespace/module.ex
+++ b/apps/remote_control/lib/mix/tasks/namespace/module.ex
@@ -33,6 +33,10 @@ defmodule Mix.Tasks.Namespace.Module do
   def prefixed?("lx_" <> _),
     do: true
 
+  def prefixed?([?l, ?x, ?_ | _]), do: true
+  def prefixed?([?E, ?l, ?i, ?x, ?i, ?r, ?., ?L, ?X | _]), do: true
+  def prefixed?([?L, ?X | _]), do: true
+
   def prefixed?(_),
     do: false
 

--- a/apps/remote_control/test/lexical/remote_control/code_action/handlers/add_alias_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_action/handlers/add_alias_test.exs
@@ -53,7 +53,7 @@ defmodule Lexical.RemoteControl.CodeAction.Handlers.AddAliasTest do
           %Entry{subject: module, range: range, type: :module, subtype: :definition}
       end)
 
-    patch(Store, :fuzzy, returns)
+    patch(Store, :fuzzy, {:ok, returns})
   end
 
   describe "in an existing module with no aliases" do

--- a/apps/remote_control/test/lexical/remote_control/code_action/handlers/add_alias_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_action/handlers/add_alias_test.exs
@@ -1,0 +1,261 @@
+defmodule Lexical.RemoteControl.CodeAction.Handlers.AddAliasTest do
+  alias Lexical.Ast.Analysis.Scope
+  alias Lexical.CodeUnit
+  alias Lexical.Completion.SortScope
+  alias Lexical.Document
+  alias Lexical.Document.Line
+  alias Lexical.Document.Range
+  alias Lexical.RemoteControl
+  alias Lexical.RemoteControl.CodeAction.Handlers.AddAlias
+  alias Lexical.RemoteControl.Search.Indexer.Entry
+  alias Lexical.RemoteControl.Search.Store
+
+  import Lexical.Test.CursorSupport
+  import Lexical.Test.CodeSigil
+
+  use Lexical.Test.CodeMod.Case, enable_ast_conversion: false
+  use Patch
+
+  setup do
+    start_supervised!({Document.Store, derive: [analysis: &Lexical.Ast.analyze/1]})
+    :ok
+  end
+
+  def apply_code_mod(text, _ast, options) do
+    range = options[:range]
+    uri = "file:///file.ex"
+    :ok = Document.Store.open(uri, text, 1)
+    {:ok, document} = Document.Store.fetch(uri)
+
+    edits =
+      case AddAlias.actions(document, range, []) do
+        [action] -> action.changes.edits
+        _ -> []
+      end
+
+    {:ok, edits}
+  end
+
+  def add_alias(original_text, modules_to_return) do
+    {position, stripped_text} = pop_cursor(original_text)
+    range = Range.new(position, position)
+    patch_store(range, modules_to_return)
+    modify(stripped_text, range: range)
+  end
+
+  def patch_store(range, modules_to_return) do
+    returns =
+      Enum.map(modules_to_return, fn
+        %Entry{} = entry ->
+          entry
+
+        module ->
+          %Entry{subject: module, range: range, type: :module, subtype: :definition}
+      end)
+
+    patch(Store, :fuzzy, returns)
+  end
+
+  describe "adding an alias based off of a module" do
+    test "does nothing on an invalid document" do
+      {:ok, added} = add_alias("%Lexical.RemoteControl.Search.", [Lexical.RemoteControl.Search])
+
+      assert added == "%Lexical.RemoteControl.Search."
+    end
+
+    test "outside of a module with aliases" do
+      {:ok, added} =
+        ~q[
+          alias ZZ.XX.YY
+          Lines|
+        ]
+        |> add_alias([Line])
+
+      expected = ~q[
+      alias Lexical.Document.Line
+      alias ZZ.XX.YY
+      Lines
+      ]t
+
+      assert added == expected
+    end
+
+    test "when a full module name is given" do
+      {:ok, added} =
+        ~q[
+        Lexical.RemoteControl.Search.Store.Backend|
+        ]
+        |> add_alias([Store.Backend])
+
+      expected = ~q[
+        alias Lexical.RemoteControl.Search.Store.Backend
+        Backend
+      ]t
+
+      assert added == expected
+    end
+
+    test "when a full module name is given in a module function" do
+      {:ok, added} =
+        ~q[
+        defmodule MyModule do
+          def my_fun do
+            result = Lexical.RemoteControl.Search.Store|
+          end
+        end
+        ]
+        |> add_alias([Store])
+
+      expected = ~q[
+        defmodule MyModule do
+          alias Lexical.RemoteControl.Search.Store
+          def my_fun do
+            result = Store
+          end
+        end
+      ]t
+
+      assert added =~ expected
+    end
+
+    test "outside of a module with no aliases" do
+      {:ok, added} =
+        ~q[Lines|]
+        |> add_alias([Line])
+
+      expected = ~q[
+       alias Lexical.Document.Line
+       Lines
+      ]t
+
+      assert added == expected
+    end
+
+    test "in a module with no aliases" do
+      {:ok, added} =
+        ~q[
+        defmodule MyModule do
+          def my_fun do
+            Line|
+          end
+        end
+        ]
+        |> add_alias([Line])
+
+      expected = ~q[
+      defmodule MyModule do
+        alias Lexical.Document.Line
+        def my_fun do
+          Line
+        end
+      end
+      ]t
+
+      assert added =~ expected
+    end
+
+    test "outside of functions" do
+      {:ok, added} =
+        ~q[
+        defmodule MyModule do
+          alias Something.Else
+          Lines|
+        end
+        ]
+        |> add_alias([Line])
+
+      expected = ~q[
+      defmodule MyModule do
+        alias Lexical.Document.Line
+        alias Something.Else
+        Lines
+      end
+      ]
+
+      assert expected =~ added
+    end
+
+    test "inside a function" do
+      {:ok, added} =
+        ~q[
+        defmodule MyModule do
+          alias Something.Else
+          def my_fn do
+            Lines|
+          end
+        end
+        ]
+        |> add_alias([Line])
+
+      expected = ~q[
+      defmodule MyModule do
+        alias Lexical.Document.Line
+        alias Something.Else
+        def my_fn do
+          Lines
+        end
+      end
+      ]
+      assert expected =~ added
+    end
+
+    test "inside a nested module" do
+      {:ok, added} =
+        ~q[
+          defmodule Parent do
+            alias Top.Level
+            defmodule Child do
+              alias Some.Other
+              Lines|
+            end
+          end
+        ]
+        |> add_alias([Line])
+
+      expected = ~q[
+      defmodule Parent do
+        alias Top.Level
+        defmodule Child do
+          alias Lexical.Document.Line
+          alias Some.Other
+          Lines
+        end
+      end
+      ]t
+
+      assert added =~ expected
+    end
+
+    test "aliases for struct references don't include non-struct modules" do
+      {:ok, added} = add_alias("%Scope|{}", [SortScope, Scope])
+
+      expected = ~q[
+      alias Lexical.Ast.Analysis.Scope
+      %Scope
+      ]t
+
+      assert added =~ expected
+    end
+
+    test "only modules with a similarly named function will be included in aliases" do
+      {:ok, added} = add_alias("Document.fetch|", [Document, RemoteControl])
+
+      expected = ~q[
+      alias Lexical.Document
+      Document.fetch
+      ]t
+
+      assert added =~ expected
+    end
+
+    test "protocols are excluded" do
+      {:ok, added} = add_alias("Co|", [Collectable, CodeUnit])
+      expected = ~q[
+      alias Lexical.CodeUnit
+      Co
+      ]t
+
+      assert added =~ expected
+    end
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/code_action/handlers/add_alias_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_action/handlers/add_alias_test.exs
@@ -287,5 +287,21 @@ defmodule Lexical.RemoteControl.CodeAction.Handlers.AddAliasTest do
 
       assert added =~ expected
     end
+
+    test "protocol implementations are excluded" do
+      {:ok, added} =
+        add_alias("Lin|", [Lexical.Document.Lines, Enumerable.Lexical.Document.Lines])
+
+      expected = ~q[
+        alias Lexical.Document.Lines
+        Lin
+      ]t
+      assert added =~ expected
+    end
+
+    test "erlang modules are excluded" do
+      {:ok, added} = add_alias(":ets|", [:ets])
+      assert added =~ ":ets"
+    end
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/code_action/handlers/add_alias_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_action/handlers/add_alias_test.exs
@@ -56,7 +56,37 @@ defmodule Lexical.RemoteControl.CodeAction.Handlers.AddAliasTest do
     patch(Store, :fuzzy, returns)
   end
 
-  describe "adding an alias based off of a module" do
+  describe "in an existing module with no aliases" do
+    test "aliases are added at the top of the module" do
+      {:ok, added} =
+        ~q[
+        defmodule MyModule do
+          def my_fn do
+            Line|
+          end
+        end
+        ]
+        |> add_alias([Line])
+
+      expected = ~q[
+      defmodule MyModule do
+        alias Lexical.Document.Line
+        def my_fn do
+          Line
+        end
+      end
+      ]t
+      assert added =~ expected
+    end
+  end
+
+  describe "in an existing module" do
+  end
+
+  describe "in the root context" do
+  end
+
+  describe "adding an alias" do
     test "does nothing on an invalid document" do
       {:ok, added} = add_alias("%Lexical.RemoteControl.Search.", [Lexical.RemoteControl.Search])
 

--- a/apps/remote_control/test/lexical/remote_control/code_mod/aliases_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_mod/aliases_test.exs
@@ -1,0 +1,197 @@
+defmodule Lexical.RemoteControl.CodeMod.AliasesTest do
+  alias Lexical.Ast
+  alias Lexical.RemoteControl.CodeMod.Aliases
+
+  use Lexical.Test.CodeMod.Case
+  import Lexical.Test.CursorSupport
+
+  def insert_position(orig) do
+    {cursor, document} = pop_cursor(orig, as: :document)
+    analysis = Ast.analyze(document)
+    {position, _trailer} = Aliases.insert_position(analysis, cursor)
+
+    {:ok, document, position}
+  end
+
+  describe "insert_position" do
+    test "is directly after a module's definition if there are no aliases present" do
+      {:ok, document, position} =
+        ~q[
+        defmodule MyModule do|
+        end
+        ]
+        |> insert_position()
+
+      assert decorate_cursor(document, position) =~ ~q[
+      defmodule MyModule do
+      |end
+      ]
+    end
+
+    test "is after the moduledoc if no aliases are present" do
+      {:ok, document, position} =
+        ~q[
+        defmodule MyModule do|
+          @moduledoc """
+          This is my funny moduledoc
+          """
+        end
+        ]
+        |> insert_position()
+
+      assert decorate_cursor(document, position) =~ ~q[
+      defmodule MyModule do
+        @moduledoc """
+        This is my funny moduledoc
+        """
+      |end
+      ]
+    end
+
+    test "is before use statements" do
+      {:ok, document, position} =
+        ~q[
+        defmodule MyModule do|
+          use Something.That.Exists
+        end
+        ]
+        |> insert_position()
+
+      expected = ~q[
+        defmodule MyModule do
+          |use Something.That.Exists
+        end
+      ]
+      assert decorate_cursor(document, position) =~ expected
+    end
+
+    test "is before require statements" do
+      {:ok, document, position} =
+        ~q[
+        defmodule MyModule do|
+          require Something.That.Exists
+        end
+        ]
+        |> insert_position()
+
+      expected = ~q[
+        defmodule MyModule do
+          |require Something.That.Exists
+        end
+      ]
+      assert decorate_cursor(document, position) =~ expected
+    end
+
+    test "is before import statements" do
+      {:ok, document, position} =
+        ~q[
+        defmodule MyModule do|
+          import Something.That.Exists
+        end
+        ]
+        |> insert_position()
+
+      expected = ~q[
+        defmodule MyModule do
+          |import Something.That.Exists
+        end
+      ]
+      assert decorate_cursor(document, position) =~ expected
+    end
+
+    test "is where existing aliases are" do
+      {:ok, document, position} =
+        ~q[
+        defmodule MyModule do|
+          alias Something.That.Exists
+        end
+        ]
+        |> insert_position()
+
+      expected = ~q[
+        defmodule MyModule do
+          |alias Something.That.Exists
+        end
+      ]
+      assert decorate_cursor(document, position) =~ expected
+    end
+
+    test "in nested empty modules" do
+      {:ok, document, position} =
+        ~q[
+        defmodule Outer do
+          defmodule Inner do|
+          end
+        end
+        ]
+        |> insert_position()
+
+      expected = ~q[
+        defmodule Outer do
+          defmodule Inner do
+          |end
+        end
+      ]t
+
+      assert decorate_cursor(document, position) =~ expected
+    end
+
+    test "in nested modules that both have existing aliases" do
+      {:ok, document, position} =
+        ~q[
+        defmodule Outer do
+          alias First.Thing
+
+          defmodule Inner do|
+            alias Second.Person
+          end
+        end
+        ]
+        |> insert_position()
+
+      expected = ~q[
+        defmodule Outer do
+          alias First.Thing
+
+          defmodule Inner do
+            |alias Second.Person
+          end
+        end
+      ]t
+
+      assert decorate_cursor(document, position) =~ expected
+    end
+
+    test "is after moduledocs in nested modules" do
+      {:ok, document, position} =
+        ~q[
+        defmodule Outer do
+          alias First.Thing
+
+          defmodule Inner do|
+            @moduledoc """
+            This is my documentation, it
+            spans multiple lines
+            """
+          end
+        end
+        ]
+        |> insert_position()
+
+      expected = ~q[
+        defmodule Outer do
+          alias First.Thing
+
+          defmodule Inner do
+            @moduledoc """
+            This is my documentation, it
+            spans multiple lines
+            """
+          |end
+        end
+      ]t
+
+      assert decorate_cursor(document, position) =~ expected
+    end
+  end
+end

--- a/projects/lexical_test/lib/lexical/test/cursor_support.ex
+++ b/projects/lexical_test/lib/lexical/test/cursor_support.ex
@@ -4,8 +4,11 @@ defmodule Lexical.Test.CursorSupport do
   """
 
   alias Lexical.Document
+  alias Lexical.Document.Line
   alias Lexical.Document.Position
   alias Lexical.Test.PositionSupport
+
+  import Line
 
   @default_cursor "|"
   @starting_line 1
@@ -102,6 +105,24 @@ defmodule Lexical.Test.CursorSupport do
       end)
 
     IO.iodata_to_binary(iodata)
+  end
+
+  def decorate_cursor(%Document{} = document, %Position{} = position) do
+    replace_line = position.line
+
+    document.lines
+    |> Enum.map(fn
+      line(line_number: ^replace_line, text: text, ending: ending) ->
+        {leading, trailing} = String.split_at(text, position.character - 1)
+
+        leading = String.pad_leading(leading, position.character - 1)
+
+        [leading, "|", trailing, ending]
+
+      line(text: text, ending: ending) ->
+        [text, ending]
+    end)
+    |> IO.iodata_to_binary()
   end
 
   defp cursor_position(text, opts) do


### PR DESCRIPTION
When coding, it is more convenient to type what you mean, and then come back later and clean up things like aliases. This change implements a code action that understands your current editing context and adds aliases as you type. It finds suggestions using our fuzzy matcher (though it has a bit stricter fuzziness), then provides code actions for each suggestion.

It will fix the following alias types:

  `Foo.Bar.Baz|` will result in aliases for modules similar to `Baz`
  `%Foo.Bar.Baz|{}` will result in aliases similar to `Baz`, but only
those that have structs defined in them
  `Foo.Bar.baz.function|` will result in aliases for modules with a
  function with a name similar to `function`

This PR also pulled a bunch of common code out of `orgaize_aliases` and moved it to a code mod file, which resulted in `organize_aliases` having very little code left in it.

Fixes #716