### PR TITLE
Fix: Crash when typing english

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion/builder.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/builder.ex
@@ -111,6 +111,12 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Builder do
         |> List.last()
         |> length()
 
+      {:alias, {:local_or_var, _}, alias_charlist} ->
+        length(alias_charlist)
+
+      {:alias, {:module_attribute, _}, alias_charlist} ->
+        length(alias_charlist)
+
       {:dot, _inside_dot, charlist} ->
         length(charlist)
 

--- a/apps/server/test/lexical/server/code_intelligence/completion/builder_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/builder_test.exs
@@ -65,4 +65,20 @@ defmodule Lexical.Server.CodeIntelligence.Completion.BuilderTest do
       assert [^i, ^ii, ^iii_low, ^i_deprecated] = sort_items([i_deprecated, i, ii, iii_low])
     end
   end
+
+  describe "snippet edge cases" do
+    # The following would crash due to missing case clauses
+    # in `prefix_length/1`
+    test "handles aliases inside locals" do
+      "before __MODULE__.Submodule|"
+      |> new_env()
+      |> snippet("", label: "")
+    end
+
+    test "handles locals inside a module attribute" do
+      "@hello.Submodule"
+      |> new_env()
+      |> snippet("", label: "")
+    end
+  end
 end


### PR DESCRIPTION
Sometimes, it is possible for a normal sentence fragment to be valid elixir, as one of our interpid users recently found out, and lexical would crash due to a missing case statement in the completion builder.

Fixes #741