### PR TITLE
Returns two definitions for delegate function's definition

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/definition.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/definition.ex
@@ -51,12 +51,12 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Definition do
 
     definitions =
       mfa
-      |> exact(subtype: :definition)
+      |> query_search_index(subtype: :definition)
       |> Enum.flat_map(fn entry ->
         case entry do
           %Entry{type: {:function, :delegate}} ->
             mfa = get_in(entry, [:metadata, :original_mfa])
-            exact(mfa, subtype: :definition) ++ [entry]
+            query_search_index(mfa, subtype: :definition) ++ [entry]
 
           _ ->
             [entry]
@@ -171,7 +171,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Definition do
     end
   end
 
-  defp exact(subject, condition) do
+  defp query_search_index(subject, condition) do
     case Store.exact(subject, condition) do
       {:ok, entries} ->
         entries

--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/definition.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/definition.ex
@@ -6,9 +6,13 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Definition do
   alias Lexical.Document.Location
   alias Lexical.Document.Position
   alias Lexical.Formats
+  alias Lexical.RemoteControl.Analyzer
   alias Lexical.RemoteControl.CodeIntelligence.Entity
+  alias Lexical.RemoteControl.Search.Indexer.Entry
   alias Lexical.RemoteControl.Search.Store
   alias Lexical.Text
+
+  alias Sourceror.Zipper
   require Logger
 
   @spec definition(Document.t(), Position.t()) :: {:ok, [Location.t()]} | {:error, String.t()}
@@ -19,7 +23,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Definition do
     end
   end
 
-  defp fetch_definition({type, entity}, %Analysis{} = analysis, %Position{} = position)
+  defp fetch_definition({type, entity} = resolved, %Analysis{} = analysis, %Position{} = position)
        when type in [:struct, :module] do
     module = Formats.module(entity)
 
@@ -37,11 +41,48 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Definition do
           []
       end
 
+    maybe_fallback_to_elixir_sense(resolved, locations, analysis, position)
+  end
+
+  defp fetch_definition(
+         {:call, module, function, arity} = resolved,
+         %Analysis{} = analysis,
+         %Position{} = position
+       ) do
+    mfa = Formats.mfa(module, function, arity)
+
+    definitions =
+      mfa
+      |> exact(subtype: :definition)
+      |> Enum.flat_map(fn entry ->
+        with %Entry{type: {:function, :delegate}} <- entry,
+             {:ok, mfa} <- fetch_delegated_mfa(entry.path, entry.range.start) do
+          exact(mfa, subtype: :definition) ++ [entry]
+        else
+          _ ->
+            [entry]
+        end
+      end)
+
+    locations =
+      for entry <- definitions,
+          result = to_location(entry),
+          match?({:ok, _}, result) do
+        {:ok, location} = result
+        location
+      end
+
+    maybe_fallback_to_elixir_sense(resolved, locations, analysis, position)
+  end
+
+  defp fetch_definition(_, %Analysis{} = analysis, %Position{} = position) do
+    elixir_sense_definition(analysis, position)
+  end
+
+  defp maybe_fallback_to_elixir_sense(resolved, locations, analysis, position) do
     case locations do
       [] ->
-        Logger.info(
-          "No definition found for #{to_string(type)}: #{inspect(module)} with Indexer."
-        )
+        Logger.info("No definition found for #{inspect(resolved)} with Indexer.")
 
         elixir_sense_definition(analysis, position)
 
@@ -53,15 +94,45 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Definition do
     end
   end
 
-  defp fetch_definition(_, %Analysis{} = analysis, %Position{} = position) do
-    elixir_sense_definition(analysis, position)
-  end
-
   defp elixir_sense_definition(%Analysis{} = analysis, %Position{} = position) do
     analysis.document
     |> Document.to_string()
     |> ElixirSense.definition(position.line, position.character)
     |> parse_location(analysis.document)
+  end
+
+  defp fetch_delegated_mfa(path, position) do
+    uri = Document.Path.ensure_uri(path)
+
+    with {:ok, document} <- Document.Store.open_temporary(uri),
+         analysis = Ast.analyze(document),
+         {:ok, zipper} <- Ast.zipper_at(analysis.document, position),
+         %Zipper{node: {:defdelegate, _, _}} = zipper <- Zipper.prev(zipper) do
+      {_, _, [call, keywords]} = zipper.node
+      {function_name, args} = Macro.decompose_call(call)
+      arity = length(args)
+
+      {_, keyword_args} =
+        Macro.prewalk(keywords, [], fn
+          {{:__block__, _, [:to]}, {:__aliases__, _, delegated_module}} = ast, acc ->
+            {ast, [{:to, delegated_module} | acc]}
+
+          {{:__block__, _, [:as]}, {:__block__, _, [remote_fun_name]}} = ast, acc ->
+            {ast, [{:as, remote_fun_name} | acc]}
+
+          ast, acc ->
+            {ast, acc}
+        end)
+
+      delegated_module = keyword_args[:to]
+      function_name = Keyword.get(keyword_args, :as, function_name) || function_name
+      {:ok, module} = Analyzer.expand_alias(delegated_module, analysis, position)
+      mfa = Formats.mfa(module, function_name, arity)
+      {:ok, mfa}
+    else
+      _ ->
+        :error
+    end
   end
 
   defp parse_location(%ElixirSense.Location{} = location, document) do
@@ -132,6 +203,16 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Definition do
 
       _ ->
         :error
+    end
+  end
+
+  defp exact(subject, condition) do
+    case Store.exact(subject, condition) do
+      {:ok, entries} ->
+        entries
+
+      _ ->
+        []
     end
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/entry.ex
@@ -32,7 +32,8 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
     :range,
     :subject,
     :subtype,
-    :type
+    :type,
+    :metadata
   ]
 
   @type t :: %__MODULE__{
@@ -43,7 +44,8 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
           path: Path.t(),
           range: Lexical.Document.Range.t(),
           subtype: entry_subtype(),
-          type: entry_type()
+          type: entry_type(),
+          metadata: nil | map()
         }
   @type datetime_format :: :erl | :unix | :datetime
   @type date_type :: :calendar.datetime() | integer() | DateTime.t()
@@ -145,5 +147,9 @@ defmodule Lexical.RemoteControl.Search.Indexer.Entry do
 
   def updated_at(%__MODULE__{}, _format) do
     nil
+  end
+
+  def put_metadata(%__MODULE__{} = entry, metadata) do
+    %__MODULE__{entry | metadata: metadata}
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_definition.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_definition.ex
@@ -31,13 +31,16 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinition do
     end
   end
 
-  def extract({:defdelegate, _, [call, _]}, %Reducer{} = reducer) do
+  def extract({:defdelegate, _, [call, _]} = node, %Reducer{} = reducer) do
     document = reducer.analysis.document
 
     with {:ok, detail_range} <- Ast.Range.fetch(call, document),
-         {:ok, module} <- Analyzer.current_module(reducer.analysis, detail_range.start) do
+         {:ok, module} <- Analyzer.current_module(reducer.analysis, detail_range.start),
+         {:ok, {delegated_module, delegated_name, _delegated_arity}} <-
+           fetch_delegated_mfa(node, reducer.analysis, detail_range.start) do
       {delegate_name, args} = Macro.decompose_call(call)
       arity = length(args)
+      metadata = %{original_mfa: Subject.mfa(delegated_module, delegated_name, arity)}
 
       entry =
         Entry.definition(
@@ -49,7 +52,7 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinition do
           Application.get_application(module)
         )
 
-      {:ok, entry}
+      {:ok, Entry.put_metadata(entry, metadata)}
     else
       _ ->
         :ignored
@@ -58,6 +61,31 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinition do
 
   def extract(_ast, _reducer) do
     :ignored
+  end
+
+  def fetch_delegated_mfa(node, analysis, position) do
+    {:defdelegate, _, [call | keywords]} = node
+
+    {_, keyword_args} =
+      Macro.prewalk(keywords, [], fn
+        {{:__block__, _, [:to]}, {:__aliases__, _, delegated_module}} = ast, acc ->
+          {ast, [{:to, delegated_module} | acc]}
+
+        {{:__block__, _, [:as]}, {:__block__, _, [remote_fun_name]}} = ast, acc ->
+          {ast, [{:as, remote_fun_name} | acc]}
+
+        ast, acc ->
+          {ast, acc}
+      end)
+
+    {function_name, args} = Macro.decompose_call(call)
+    function_name = Keyword.get(keyword_args, :as, function_name)
+    delegated_module = keyword_args[:to]
+
+    case Analyzer.expand_alias(delegated_module, analysis, position) do
+      {:ok, module} -> {:ok, {module, function_name, length(args)}}
+      _ -> :error
+    end
   end
 
   defp type(:def), do: {:function, :public}

--- a/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_definition.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/indexer/extractors/function_definition.ex
@@ -67,10 +67,10 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinition do
     {_, keyword_args} =
       Macro.prewalk(keywords, [], fn
         {{:__block__, _, [:to]}, {:__aliases__, _, delegated_module}} = ast, acc ->
-          {ast, [{:to, delegated_module} | acc]}
+          {ast, Keyword.put(acc, :to, delegated_module)}
 
         {{:__block__, _, [:as]}, {:__block__, _, [remote_fun_name]}} = ast, acc ->
-          {ast, [{:as, remote_fun_name} | acc]}
+          {ast, Keyword.put(acc, :as, remote_fun_name)}
 
         ast, acc ->
           {ast, acc}

--- a/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/function_definition_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/search/indexer/extractors/function_definition_test.exs
@@ -196,6 +196,15 @@ defmodule Lexical.RemoteControl.Search.Indexer.Extractors.FunctionDefinitionTest
       assert decorate(doc, function.range) =~ "defdelegate «map(enumerable, other)», to: Child"
     end
 
+    test "skip quoted function defined with defdelegate" do
+      assert {:ok, [], _doc} =
+               ~q[
+          quote do
+            defdelegate unquote(symbol)(enumerable, other), to: Enum
+          end
+        ] |> index_functions()
+    end
+
     test "finds functions defined with defdelegate and as" do
       {:ok, [function | _], doc} =
         ~q[


### PR DESCRIPTION
And change `go to definition` from elixir-sense to Indexer for functions.


## Peek definition
![CleanShot 2024-05-18 at 11 00 45@2x](https://github.com/lexical-lsp/lexical/assets/12830256/5740d9ac-842a-46d7-83e7-7834ef7e80c4)

## Go to definition
![CleanShot 2024-05-18 at 11 01 00@2x](https://github.com/lexical-lsp/lexical/assets/12830256/7d4c9f66-2630-4d84-955d-14d245c8dd2f)
