### PR TITLE
Fix go to definition behavior for same-name, same-arity functions by directing to the first function

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/definition.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/definition.ex
@@ -52,7 +52,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Definition do
     definitions =
       mfa
       |> query_search_index(subtype: :definition)
-      |> Enum.flat_map(fn entry ->
+      |> Stream.flat_map(fn entry ->
         case entry do
           %Entry{type: {:function, :delegate}} ->
             mfa = get_in(entry, [:metadata, :original_mfa])
@@ -62,6 +62,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.Definition do
             [entry]
         end
       end)
+      |> Stream.uniq_by(& &1.subject)
 
     locations =
       for entry <- definitions,

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/definition_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/definition_test.exs
@@ -309,6 +309,31 @@ defmodule Lexical.RemoteControl.CodeIntelligence.DefinitionTest do
       assert referenced_uri =~ "navigations/lib/my_module.ex"
     end
 
+    test "find only one function when there are multiple same arity functions", %{
+      project: project,
+      subject_uri: subject_uri
+    } do
+      subject_module = ~q[
+        defmodule UsesOwnFunction do
+          def greet(name) when is_atom(name) do
+            IO.inspect(name)
+          end
+
+          def greet(name) do
+            name
+          end
+
+          def uses_greet do
+            gree|t("World")
+          end
+        end
+      ]
+
+      {:ok, referenced_uri, definition_line} = definition(project, subject_module, subject_uri)
+      assert definition_line == ~S[  def «greet(name) when is_atom(name)» do]
+      assert referenced_uri == subject_uri
+    end
+
     test "find the attribute", %{project: project, subject_uri: subject_uri} do
       subject_module = ~q[
         defmodule UsesAttribute do


### PR DESCRIPTION

After this PR #744 was merged, I spent a whole day using the latest features. In the case of delegates, returning multiple definitions is undoubtedly useful, but in another scenario, such as when there are when clauses, returning multiple definitions is undoubtedly a distraction (in Neovim, I need to press the keys twice more and think about it). Therefore, the solution in this PR is to directly jump to the position of the first function for such cases where there are same-name, same-arity functions in the same file.