### PR TITLE
Completion: show type spec for struct fields

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion/candidate.ex
@@ -159,7 +159,7 @@ defmodule Lexical.RemoteControl.Completion.Candidate do
 
   defmodule StructField do
     @moduledoc false
-    defstruct [:call?, :name, :origin]
+    defstruct [:call?, :name, :origin, :type_spec]
 
     def new(%{} = elixir_sense_map) do
       struct(__MODULE__, elixir_sense_map)

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct_field.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/struct_field.ex
@@ -36,7 +36,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructField do
 
   def translate(%Candidate.StructField{} = struct_field, builder, %Env{} = env) do
     builder.plain_text(env, struct_field.name,
-      detail: struct_field.name,
+      detail: struct_field.type_spec,
       label: struct_field.name,
       kind: :field
     )

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_field_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/struct_field_test.exs
@@ -12,7 +12,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructFieldTes
              |> complete(source)
              |> fetch_completion(kind: :field)
 
-    assert completion.detail == "first_name"
+    assert completion.detail == "String.t()"
     assert completion.label == "first_name"
   end
 
@@ -28,7 +28,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructFieldTes
              |> complete(source)
              |> fetch_completion(kind: :field)
 
-    assert completion.detail == "first_name"
+    assert completion.detail == "String.t()"
     assert completion.label == "first_name"
   end
 
@@ -44,7 +44,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructFieldTes
              |> complete(source)
              |> fetch_completion(kind: :field)
 
-    assert completion.detail == "first_name"
+    assert completion.detail == "String.t()"
     assert completion.label == "first_name"
     assert apply_completion(completion) =~ "struct.first_name"
   end
@@ -61,7 +61,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructFieldTes
              |> complete(source)
              |> fetch_completion(kind: :field)
 
-    assert completion.detail == "first_name"
+    assert completion.detail == "String.t()"
     assert completion.label == "first_name"
     assert apply_completion(completion) =~ "struct.first_name"
   end
@@ -81,7 +81,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.StructFieldTes
              |> complete(source)
              |> fetch_completion(kind: :field)
 
-    assert completion.detail == "first_name"
+    assert completion.detail == "String.t()"
     assert completion.label == "first_name"
     assert apply_completion(completion) =~ "user.first_name"
   end


### PR DESCRIPTION
Fixes #749 

`:type_spec` is already a part of the `elixir_sense_map`, so defining it in `defstruct` is enough.

If the struct doesn't have a type spec, it would show "Field" in my editor probably because that's how it handles `completion.detail == nil`

Let me know if it's more desirable to fall back to some string explicitly, e.g.:
```elixir
builder.plain_text(env, struct_field.name,
  detail: struct_field.type_spec || "Field",
  label: struct_field.name,
  kind: :field
)
```
