### PR TITLE
Fixed: Go to definitions crashes on modules defined via a macro

### DIFF
--- a/apps/remote_control/test/fixtures/navigations/lib/macro_struct.ex
+++ b/apps/remote_control/test/fixtures/navigations/lib/macro_struct.ex
@@ -1,0 +1,32 @@
+defmodule MacroStruct do
+  defmacro __using__(_) do
+    Module.register_attribute(__CALLER__.module, :field_names, accumulate: true)
+
+    quote do
+      import(unquote(__MODULE__), only: [field: 2, typedstruct: 2])
+    end
+  end
+
+  defmacro __before_compile__(_) do
+    fields = __CALLER__.module |> Module.get_attribute(:field_names) |> List.wrap()
+
+    quote do
+      defstruct unquote(fields)
+    end
+  end
+
+  defmacro typedstruct(opts, do: body) do
+    Module.put_attribute(__CALLER__.module, :opts, opts)
+
+    quote do
+      defmodule unquote(opts[:module]) do
+        @before_compile unquote(__MODULE__)
+        unquote(body)
+      end
+    end
+  end
+
+  defmacro field(name, _type) do
+    Module.put_attribute(__CALLER__.module, :field_names, name)
+  end
+end

--- a/apps/remote_control/test/fixtures/navigations/lib/struct.ex
+++ b/apps/remote_control/test/fixtures/navigations/lib/struct.ex
@@ -1,0 +1,11 @@
+defmodule NormalStruct do
+  defstruct [:variant]
+end
+
+defmodule TypedStructs do
+  use MacroStruct
+
+  typedstruct enforce: true, module: MacroBasedStruct do
+    field(:contract_id, String.t())
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/code_intelligence/definition_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_intelligence/definition_test.exs
@@ -421,8 +421,7 @@ defmodule Lexical.RemoteControl.CodeIntelligence.DefinitionTest do
         end
       ]
 
-      {:ok, [location1, location2]} =
-        definition(project, subject_module, [uri, subject_uri])
+      {:ok, [location1, location2]} = definition(project, subject_module, [uri, subject_uri])
 
       {referenced_uri, definition_line} = location1
       assert definition_line =~ ~S[  def «greet(name)» do]
@@ -431,6 +430,21 @@ defmodule Lexical.RemoteControl.CodeIntelligence.DefinitionTest do
       {referenced_uri, definition_line} = location2
       assert definition_line == ~S[  defdelegate «greet(name)», to: MyDefinition]
       assert referenced_uri == subject_uri
+    end
+  end
+
+  describe "edge cases" do
+    setup [:with_referenced_file]
+
+    test "doesn't crash with structs defined with DSLs", %{project: project, uri: uri} do
+      subject_module = ~q[
+      defmodule MyTest do
+        def my_test(%TypedStructs.MacroBased|Struct{}) do
+        end
+      end
+      ]
+
+      assert {:ok, _file, _definition} = definition(project, subject_module, [uri])
     end
   end
 


### PR DESCRIPTION
Typedstruct has an alternate syntax for defining a module (whaa?) and we would crash when we didn't recognize this syntax as being related to a module.

Fixes #750