### PR TITLE
Track uses and requires

### DIFF
--- a/apps/common/lib/lexical/ast/analysis/require.ex
+++ b/apps/common/lib/lexical/ast/analysis/require.ex
@@ -1,0 +1,10 @@
+defmodule Lexical.Ast.Analysis.Require do
+  alias Lexical.Ast
+  alias Lexical.Document
+  defstruct [:module, :as, :range]
+
+  def new(%Document{} = document, ast, module, as \\ nil) when is_list(module) do
+    range = Ast.Range.get(ast, document)
+    %__MODULE__{module: module, as: as || module, range: range}
+  end
+end

--- a/apps/common/lib/lexical/ast/analysis/scope.ex
+++ b/apps/common/lib/lexical/ast/analysis/scope.ex
@@ -8,7 +8,9 @@ defmodule Lexical.Ast.Analysis.Scope do
     :range,
     module: [],
     aliases: [],
-    imports: []
+    imports: [],
+    requires: [],
+    uses: []
   ]
 
   @type import_mfa :: {module(), atom(), non_neg_integer()}
@@ -23,12 +25,22 @@ defmodule Lexical.Ast.Analysis.Scope do
         }
 
   def new(%__MODULE__{} = parent_scope, id, %Range{} = range, module \\ []) do
+    uses =
+      if module == parent_scope.module do
+        # if we're still in the same module, we have the same uses
+        parent_scope.uses
+      else
+        []
+      end
+
     %__MODULE__{
       id: id,
       aliases: parent_scope.aliases,
       imports: parent_scope.imports,
+      requires: parent_scope.requires,
       module: module,
-      range: range
+      range: range,
+      uses: uses
     }
   end
 

--- a/apps/common/lib/lexical/ast/analysis/state.ex
+++ b/apps/common/lib/lexical/ast/analysis/state.ex
@@ -2,7 +2,9 @@ defmodule Lexical.Ast.Analysis.State do
   alias Lexical.Ast.Analysis
   alias Lexical.Ast.Analysis.Alias
   alias Lexical.Ast.Analysis.Import
+  alias Lexical.Ast.Analysis.Require
   alias Lexical.Ast.Analysis.Scope
+  alias Lexical.Ast.Analysis.Use
   alias Lexical.Document
   alias Lexical.Document.Position
   alias Lexical.Document.Range
@@ -85,6 +87,18 @@ defmodule Lexical.Ast.Analysis.State do
   def push_import(%__MODULE__{} = state, %Import{} = import) do
     update_current_scope(state, fn %Scope{} = scope ->
       Map.update!(scope, :imports, &[import | &1])
+    end)
+  end
+
+  def push_require(%__MODULE__{} = state, %Require{} = require) do
+    update_current_scope(state, fn %Scope{} = scope ->
+      Map.update!(scope, :requires, &[require | &1])
+    end)
+  end
+
+  def push_use(%__MODULE__{} = state, %Use{} = use) do
+    update_current_scope(state, fn %Scope{} = scope ->
+      Map.update!(scope, :uses, &[use | &1])
     end)
   end
 

--- a/apps/common/lib/lexical/ast/analysis/use.ex
+++ b/apps/common/lib/lexical/ast/analysis/use.ex
@@ -1,0 +1,10 @@
+defmodule Lexical.Ast.Analysis.Use do
+  alias Lexical.Ast
+  alias Lexical.Document
+  defstruct [:module, :range, :opts]
+
+  def new(%Document{} = document, ast, module, opts) do
+    range = Ast.Range.get(ast, document)
+    %__MODULE__{range: range, module: module, opts: opts}
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/analyzer/requires.ex
+++ b/apps/remote_control/lib/lexical/remote_control/analyzer/requires.ex
@@ -1,0 +1,26 @@
+defmodule Lexical.RemoteControl.Analyzer.Requires do
+  alias Lexical.Ast.Analysis
+  alias Lexical.Ast.Analysis.Require
+  alias Lexical.Ast.Analysis.Scope
+  alias Lexical.Document.Position
+
+  def at(%Analysis{} = analysis, %Position{} = position) do
+    case Analysis.scopes_at(analysis, position) do
+      [%Scope{} = scope | _] ->
+        scope.requires
+        |> Enum.filter(fn %Require{} = require ->
+          require_end = require.range.end
+
+          if require_end.line == position.line do
+            require_end.character <= position.character
+          else
+            require_end.line < position.line
+          end
+        end)
+        |> Enum.uniq_by(& &1.as)
+
+      _ ->
+        []
+    end
+  end
+end

--- a/apps/remote_control/lib/lexical/remote_control/analyzer/uses.ex
+++ b/apps/remote_control/lib/lexical/remote_control/analyzer/uses.ex
@@ -1,0 +1,23 @@
+defmodule Lexical.RemoteControl.Analyzer.Uses do
+  alias Lexical.Ast.Analysis
+  alias Lexical.Ast.Analysis.Scope
+  alias Lexical.Document.Position
+
+  def at(%Analysis{} = analysis, %Position{} = position) do
+    case Analysis.scopes_at(analysis, position) do
+      [%Scope{} = scope | _] ->
+        Enum.filter(scope.uses, fn use ->
+          use_end = use.range.end
+
+          if position.line == use_end.line do
+            position.character >= use_end.character
+          else
+            position.line > use_end.line
+          end
+        end)
+
+      _ ->
+        []
+    end
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/analyzer/requires_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/analyzer/requires_test.exs
@@ -1,0 +1,107 @@
+defmodule Lexical.RemoteControl.Analyzer.RequiresTest do
+  alias Lexical.Ast
+  alias Lexical.RemoteControl.Analyzer
+
+  import Lexical.Test.CursorSupport
+  import Lexical.Test.CodeSigil
+
+  use ExUnit.Case
+
+  def requires_at_cursor(text) do
+    {position, document} = pop_cursor(text, as: :document)
+
+    document
+    |> Ast.analyze()
+    |> Analyzer.requires_at(position)
+  end
+
+  describe "requires at the top level" do
+    test "are not present before the require statement" do
+      requires = requires_at_cursor("|require OtherModule")
+
+      assert Enum.empty?(requires)
+    end
+
+    test "work for a single require" do
+      requires = requires_at_cursor("require OtherModule|")
+
+      assert requires == [OtherModule]
+    end
+
+    test "handles aliased modules" do
+      requires =
+        ~q[
+        alias Other.MyModule
+        require MyModule|
+        ]
+        |> requires_at_cursor()
+
+      assert requires == [Other.MyModule]
+    end
+
+    test "handles as" do
+      requires =
+        ~q[
+        require Other.Module, as: ReqMod
+        |
+        ]
+        |> requires_at_cursor()
+
+      assert requires == [Other.Module]
+    end
+
+    test "work for a multiple require" do
+      requires =
+        ~q[
+        require First
+        require Second
+        require Third
+        |
+        ]
+        |> requires_at_cursor()
+
+      assert requires == [First, Second, Third]
+    end
+  end
+
+  describe "in modules" do
+    test "begin after the require statement" do
+      requires =
+        ~q[
+        defmodule Outer do
+          require Required|
+        end
+        ]
+        |> requires_at_cursor()
+
+      assert requires == [Required]
+    end
+
+    test "ends after the module" do
+      requires =
+        ~q[
+        defmodule Outer do
+          require Required
+        end|
+        ]
+        |> requires_at_cursor()
+
+      assert requires == []
+    end
+
+    test "carries over to nested modules" do
+      requires =
+        ~q[
+        defmodule Outer do
+          require Required
+          defmodule Inner do
+           |
+          end
+        end
+        ]
+        |> requires_at_cursor()
+
+      assert requires == [Required]
+    end
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/analyzer/uses_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/analyzer/uses_test.exs
@@ -1,0 +1,122 @@
+defmodule Lexical.RemoteControl.Analyzer.UsesTest do
+  alias Lexical.Ast
+  alias Lexical.RemoteControl.Analyzer
+
+  import Lexical.Test.CursorSupport
+  import Lexical.Test.CodeSigil
+
+  use ExUnit.Case
+
+  def uses_at_cursor(text) do
+    {position, document} = pop_cursor(text, as: :document)
+
+    document
+    |> Ast.analyze()
+    |> Analyzer.uses_at(position)
+  end
+
+  describe "uses at the top level" do
+    test "are not present before the use statement" do
+      uses = uses_at_cursor("|use OtherModule")
+
+      assert Enum.empty?(uses)
+    end
+
+    test "are present after the use statement" do
+      uses = uses_at_cursor("use OtherModule |")
+
+      assert uses == [OtherModule]
+    end
+
+    test "handles aliased modules" do
+      uses =
+        ~q[
+        alias Other.MyModule
+        use MyModule
+        |
+        ]
+        |> uses_at_cursor()
+
+      assert uses == [Other.MyModule]
+    end
+
+    test "handles options" do
+      uses =
+        ~q[
+         use Other.Module, key: :value, other_key: :other_value
+        |
+        ]
+        |> uses_at_cursor()
+
+      assert uses == [Other.Module]
+    end
+
+    test "handles multiple uses" do
+      uses =
+        ~q[
+        use FirstModule
+        use SecondModule
+        ]
+        |> uses_at_cursor()
+
+      assert uses == [FirstModule, SecondModule]
+    end
+  end
+
+  describe "in modules" do
+    test "begin after the use statement" do
+      uses =
+        ~q[
+        defmodule Outer do
+           use Used|
+        end
+        ]
+        |> uses_at_cursor()
+
+      assert uses == [Used]
+    end
+
+    test "ends after the module" do
+      uses =
+        ~q[
+        defmodule Outer do
+           use Used
+        end|
+        ]
+        |> uses_at_cursor()
+
+      assert uses == []
+    end
+
+    test "are available in their module's functions" do
+      uses =
+        ~q[
+        defmodule Outer do
+          use Used
+
+          def my_function(a, b) do
+          |
+          end
+        end
+        ]
+        |> uses_at_cursor()
+
+      assert uses == [Used]
+    end
+
+    test "are not available in submodules" do
+      uses =
+        ~q[
+        defmodule Outer do
+          use Used
+          defmodule Inner do
+           |
+          end
+        end
+        ]
+        |> uses_at_cursor()
+
+      assert uses == []
+    end
+  end
+end


### PR DESCRIPTION
For the ecto PR, it would be great to only extract schemas if the `Ecto.Schema` module is used, so to help with that, this PR adds uses and requires to the metadata in the analyzer