### PR TITLE
Fix the interference issue caused by organizing aliases.

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/code_action/handlers/organize_aliases.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_action/handlers/organize_aliases.ex
@@ -1,9 +1,12 @@
 defmodule Lexical.RemoteControl.CodeAction.Handlers.OrganizeAliases do
+  alias Lexical.Ast
   alias Lexical.Ast.Analysis
   alias Lexical.Ast.Analysis.Scope
   alias Lexical.Document
   alias Lexical.Document.Changes
+  alias Lexical.Document.Position
   alias Lexical.Document.Range
+  alias Lexical.RemoteControl
   alias Lexical.RemoteControl.CodeAction
   alias Lexical.RemoteControl.CodeMod
 
@@ -37,9 +40,32 @@ defmodule Lexical.RemoteControl.CodeAction.Handlers.OrganizeAliases do
   end
 
   defp check_aliases(%Document{}, %Analysis{} = analysis, %Range{} = range) do
-    case Analysis.module_scope(analysis, range) do
-      %Scope{aliases: [_ | _]} -> :ok
-      _ -> :error
+    with %Scope{aliases: [_ | _]} <- Analysis.module_scope(analysis, range),
+         true <-
+           ancestor_is_alias?(analysis, range.start) or
+             token_at_cursor_is_alias?(analysis, range.start) do
+      :ok
+    else
+      _ ->
+        :error
     end
+  end
+
+  defp ancestor_is_alias?(%Analysis{} = analysis, %Position{} = position) do
+    analysis
+    |> Ast.cursor_path(position)
+    |> Enum.any?(fn
+      {:alias, _, _} ->
+        true
+
+      _ ->
+        false
+    end)
+  end
+
+  defp token_at_cursor_is_alias?(%Analysis{} = analysis, %Position{} = position) do
+    project = RemoteControl.get_project()
+    {:ok, env} = Ast.Env.new(project, analysis, position)
+    (env.prefix <> env.suffix) |> String.trim_leading() |> String.starts_with?("alias")
   end
 end

--- a/apps/remote_control/test/lexical/remote_control/code_action/handlers/organize_aliases_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/code_action/handlers/organize_aliases_test.exs
@@ -324,6 +324,30 @@ defmodule Lexical.RemoteControl.CodeAction.Handlers.OrganizeAliasesTest do
   end
 
   describe "check the return conditions for the alias" do
+    test "returns organized aliases if the cursor's immediate parent is a module" do
+      patch(RemoteControl, :get_project, %Lexical.Project{})
+
+      {:ok, organized} =
+        ~q[
+          defmodule Outer do
+            alias Foo.Bar
+            alias A.B.C
+            alias D.E.F
+            | a
+          end] |> organize_aliases()
+
+      expected =
+        ~q[
+          defmodule Outer do
+            alias A.B.C
+            alias D.E.F
+            alias Foo.Bar
+             a
+          end]
+
+      assert expected == organized
+    end
+
     test "returns organized aliases if the cursor is at an alias" do
       patch(RemoteControl, :get_project, %Lexical.Project{})
 


### PR DESCRIPTION
When I'm writing functions, I occasionally need to handle unused variables, but I find that organizing aliases still returns results. This causes a lot of interference, especially when there's a bug in nvim, as pressing keys quickly can mess up my code.

![CleanShot 2024-06-01 at 10 19 06@2x](https://github.com/lexical-lsp/lexical/assets/12830256/78ee5f66-6cfe-4058-aa47-ebb8e10ebbc4)


We should not return the results of organizing aliases when the cursor is not on a line with an alias or when the current token is not an alias.