### PR TITLE
Sorted bang functions after non-bang variants

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
@@ -186,7 +186,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
       |> Integer.to_string()
       |> String.pad_leading(3, "0")
 
-    "#{name}:#{normalized_arity}"
+    # we used to use : as a separator between the name and
+    # arity, but this  caused bang functions to sort
+    # before non-bang variants, which is incorrect.
+    # Using a space sorts correctly, as it's the only ascii
+    # character lower than bang
+
+    "#{name} #{normalized_arity}"
   end
 
   defp build_docs(%{summary: summary, spec: spec})

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/function_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/function_test.exs
@@ -12,6 +12,16 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.FunctionTest d
       assert [:deprecated] = completion.tags
     end
 
+    test "bang functions are sorted after non-bang functions", %{project: project} do
+      {:ok, [normal, bang]} =
+        project
+        |> complete("Map.fetc|")
+        |> fetch_completion("fetch")
+
+      assert normal.label == "fetch(map, key)"
+      assert bang.label == "fetch!(map, key)"
+    end
+
     test "suggest arity 0 functions if not in a pipeline", %{project: project} do
       {:ok, completion} =
         project
@@ -177,7 +187,7 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.FunctionTest d
         |> Enum.filter(fn completion ->
           sort_text = completion.sort_text
           # arity 1 and is is_map
-          String.contains?(sort_text, ":001") and
+          String.ends_with?(sort_text, "001") and
             String.contains?(sort_text, "is_map")
         end)
 


### PR DESCRIPTION
Bang functions were being sorted after non-bang functions because ! is a very low character (the only other printable character smaller is a space). This means that "003_my_function!:002" would be sorted before "003_my_function:002", which isn't really what we want. Changing the separator between the name and arity to space fixes the problem.