### PR TITLE
Handled formatting invalid module names

### DIFF
--- a/projects/lexical_shared/lib/lexical/formats.ex
+++ b/projects/lexical_shared/lib/lexical/formats.ex
@@ -68,15 +68,10 @@ defmodule Lexical.Formats do
     string_name = Atom.to_string(module_name)
 
     if String.contains?(string_name, ".") do
-      module_part =
-        case string_name do
-          "Elixir." <> rest -> rest
-          other -> other
-        end
-
-      module_part
-      |> String.split()
-      |> Enum.join(".")
+      case string_name do
+        "Elixir." <> rest -> rest
+        other -> other
+      end
     else
       # erlang module_name
       ":#{string_name}"

--- a/projects/lexical_shared/lib/lexical/formats.ex
+++ b/projects/lexical_shared/lib/lexical/formats.ex
@@ -68,8 +68,14 @@ defmodule Lexical.Formats do
     string_name = Atom.to_string(module_name)
 
     if String.contains?(string_name, ".") do
-      module_name
-      |> Module.split()
+      module_part =
+        case string_name do
+          "Elixir." <> rest -> rest
+          other -> other
+        end
+
+      module_part
+      |> String.split()
       |> Enum.join(".")
     else
       # erlang module_name

--- a/projects/lexical_shared/test/lexical/formats_test.exs
+++ b/projects/lexical_shared/test/lexical/formats_test.exs
@@ -15,6 +15,10 @@ defmodule Lexical.FormatsTest do
     test "it correctly handles an erlang module name" do
       assert ":ets" == Formats.module(:ets)
     end
+
+    test "it correctly handles an invalid elixir module" do
+      assert "This.Is.Not.A.Module" == Formats.module(:"This.Is.Not.A.Module")
+    end
   end
 
   describe "formatting time" do

--- a/projects/lexical_shared/test/lexical/formats_test.exs
+++ b/projects/lexical_shared/test/lexical/formats_test.exs
@@ -16,6 +16,10 @@ defmodule Lexical.FormatsTest do
       assert ":ets" == Formats.module(:ets)
     end
 
+    test "it drops any `Elixir.` prefix" do
+      assert "Kernel.SpecialForms" == Formats.module(Elixir.Kernel.SpecialForms)
+    end
+
     test "it correctly handles an invalid elixir module" do
       assert "This.Is.Not.A.Module" == Formats.module(:"This.Is.Not.A.Module")
     end


### PR DESCRIPTION
I'm working in a project that generates invalid module names, which would crash lexical due to lexical using Module.split, which causes a crash when it gets an invalid module name.

Switched to use `String.split` instead.