### PR TITLE
Fix: give proper argument to `TaskQueue.add/2` in Server.handle_message

### DIFF
--- a/apps/server/lib/lexical/server.ex
+++ b/apps/server/lib/lexical/server.ex
@@ -132,7 +132,7 @@ defmodule Lexical.Server do
   def handle_message(%_{} = request, %State{} = state) do
     with {:ok, handler} <- fetch_handler(request),
          {:ok, req} <- Convert.to_native(request) do
-      TaskQueue.add(request.id, {handler, :handle, [req, state.configuration.project]})
+      TaskQueue.add(request.id, {handler, :handle, [req, state.configuration]})
     else
       {:error, {:unhandled, _}} ->
         Logger.info("Unhandled request: #{request.method}")

--- a/apps/server/lib/lexical/server.ex
+++ b/apps/server/lib/lexical/server.ex
@@ -51,7 +51,7 @@ defmodule Lexical.Server do
 
   def handle_call({:server_request, request, on_response}, _from, %State{} = state) do
     new_state = State.add_request(state, request, on_response)
-    {:reply, :okk, new_state}
+    {:reply, :ok, new_state}
   end
 
   def handle_cast({:protocol_message, message}, %State{} = state) do

--- a/apps/server/test/lexical/server/task_queue_test.exs
+++ b/apps/server/test/lexical/server/task_queue_test.exs
@@ -28,7 +28,11 @@ defmodule Lexical.Server.TaskQueueTest do
     id = System.unique_integer([:positive])
 
     patch(Lexical.Server, :handler_for, fn _ -> {:ok, Handlers.Completion} end)
-    patch(Handlers.Completion, :handle, fn request, ^config -> func.(request, config) end)
+
+    patch(Handlers.Completion, :handle, fn request, %Configuration{} = ^config ->
+      func.(request, config)
+    end)
+
     patch(Requests.Completion, :to_elixir, fn req -> {:ok, req} end)
 
     request = Requests.Completion.new(id: id, text_document: nil, position: nil, context: nil)


### PR DESCRIPTION
This will fix the issue that appears in lexical.log
```
10:02:38.610 [error] ** (FunctionClauseError) no function clause matching in LXical.Server.Provider.Handlers.DocumentSymbols.handle/2 
    (lx_server 0.5.0) lib/lexical/server/provider/handlers/document_symbols.ex:13: LXical.Server.Provider.Handlers.DocumentSymbols.handle...
    (lx_server 0.5.0) lib/lexical/server/task_queue.ex:77: anonymous fn/4 in LXical.Server.TaskQueue.State.as_task/2
    (elixir 1.17.1) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
    (elixir 1.17.1) lib/task/supervised.ex:36: Task.Supervised.reply/4
```