### PR TITLE
Use non-deprecated `:net_kernel.start/2`

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control.ex
+++ b/apps/remote_control/lib/lexical/remote_control.ex
@@ -104,7 +104,8 @@ defmodule Lexical.RemoteControl do
   end
 
   defp start_net_kernel(%Project{} = project) do
-    :net_kernel.start([manager_node_name(project)])
+    manager = manager_node_name(project)
+    :net_kernel.start(manager, %{name_domain: :longnames})
   end
 
   defp ensure_apps_started(node, app_names) do

--- a/apps/remote_control/test/test_helper.exs
+++ b/apps/remote_control/test/test_helper.exs
@@ -3,7 +3,8 @@ Application.ensure_all_started(:snowflake)
 random_number = :rand.uniform(500)
 
 with :nonode@nohost <- Node.self() do
-  {:ok, _pid} = :net_kernel.start([:"testing-#{random_number}@127.0.0.1"])
+  {:ok, _pid} =
+    :net_kernel.start(:"testing-#{random_number}@127.0.0.1", %{name_domain: :longnames})
 end
 
 Lexical.RemoteControl.Module.Loader.start_link(nil)


### PR DESCRIPTION
`:net_kernel.start/1` [is deprecated](https://www.erlang.org/doc/apps/kernel/net_kernel.html#start/1) in favor of `:net_kernel.start/2`, which was introduced in OTP 24.3. As that's the oldest version of OTP we support, we can use the new version.

The defaults with the new 2-arity version are the same, so nothing really changes here.