### PR TITLE
Fix crashes on OTP 27 by disabling ETS table compression

### DIFF
--- a/apps/common/lib/elixir/features.ex
+++ b/apps/common/lib/elixir/features.ex
@@ -28,10 +28,12 @@ defmodule Elixir.Features do
   @doc """
   Whether the `:compressed` ETS table option can be safely used.
 
-  A bug in at least Erlang/OTP 27.0.0 and 27.0.1 can cause a segfault
-  when traversing the entire table with something like `:ets.foldl/3`
-  if the `:compressed` table option is used. When this is fixed, we can
-  change the version check to `"< 27.0.0 or >= 27.X"`.
+  A bug in Erlang/OTP 27.0.0 and 27.0.1 can cause a segfault when
+  traversing the entire table with something like `:ets.foldl/3` if the
+  `:compressed` table option is used. When this is fixed, we can change
+  the version check to `"< 27.0.0 or >= 27.X"`.
+
+  Issue to track: https://github.com/erlang/otp/issues/8682
   """
   def can_use_compressed_ets_table? do
     Version.match?(Versions.current().erlang, "< 27.0.0")

--- a/apps/common/lib/elixir/features.ex
+++ b/apps/common/lib/elixir/features.ex
@@ -36,6 +36,8 @@ defmodule Elixir.Features do
   Issue to track: https://github.com/erlang/otp/issues/8682
   """
   def can_use_compressed_ets_table? do
-    Version.match?(Versions.current().erlang, "< 27.0.0")
+    %{erlang: erlang_version} = Versions.to_versions(Versions.current())
+
+    Version.match?(erlang_version, "< 27.0.0")
   end
 end

--- a/apps/common/lib/elixir/features.ex
+++ b/apps/common/lib/elixir/features.ex
@@ -1,4 +1,6 @@
 defmodule Elixir.Features do
+  alias Lexical.VM.Versions
+
   def with_diagnostics? do
     function_exported?(Code, :with_diagnostics, 1)
   end
@@ -21,5 +23,17 @@ defmodule Elixir.Features do
 
   def contains_set_theoretic_types? do
     Version.match?(System.version(), ">= 1.17.0")
+  end
+
+  @doc """
+  Whether the `:compressed` ETS table option can be safely used.
+
+  A bug in at least Erlang/OTP 27.0.0 and 27.0.1 can cause a segfault
+  when traversing the entire table with something like `:ets.foldl/3`
+  if the `:compressed` table option is used. When this is fixed, we can
+  change the version check to `"< 27.0.0 or >= 27.X"`.
+  """
+  def can_use_compressed_ets_table? do
+    Version.match?(Versions.current().erlang, "< 27.0.0")
   end
 end

--- a/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v3.ex
+++ b/apps/remote_control/lib/lexical/remote_control/search/store/backends/ets/schemas/v3.ex
@@ -68,7 +68,11 @@ defmodule Lexical.RemoteControl.Search.Store.Backends.Ets.Schemas.V3 do
   end
 
   def table_options do
-    [:named_table, :ordered_set, :compressed]
+    if Features.can_use_compressed_ets_table?() do
+      [:named_table, :ordered_set, :compressed]
+    else
+      [:named_table, :ordered_set]
+    end
   end
 
   def to_subject(charlist) when is_list(charlist), do: charlist


### PR DESCRIPTION
Fixes #788.

We've had mysterious OTP 27 crashes for quite some time now, but I was finally able to track it down to what I believe is a bug in `:ets`. When the `:compressed` table option is used, the system either segfaults or crashes with a memory-related error on any call that traverses the entire table. In our case, it was a call to `:ets.foldl/3`, but other full traversals like `:ets.tab2list/1` or `:ets.tab2file/2` also crash.

The temporary fix to get things working is to just not use `:compressed` on OTP 27. Unfortunately, this has a *very* sizeable impact on memory:

```elixir
# memory usage after indexing Lexical itself
# using :erlang.memory()

# OTP 26
[
  total: 200081864,
  processes: 97217168,
  processes_used: 97187736,
  system: 102864696,
  atom: 1466705,
  atom_used: 1452046,
  binary: 2958496,
  code: 35956838,
  ets: 14065992 # 14MB
]

# OTP 27
[
  total: 481878632,
  processes: 79210832,
  processes_used: 79184048,
  system: 402667800,
  atom: 1360193,
  atom_used: 1358458,
  binary: 50157968,
  code: 26346438,
  ets: 279298656 # 279MB
]
```

We may want to add user-level configuration to disable indexing for those who have to run OTP 27 on very large projects, but I think that should go in another PR.

---

One final note: I haven't reported this upstream yet because I was trying to create a more minimal reproduction, but I've unfortunately not been able to. I'm going to spend a bit more time this morning trying to reproduce, but I'll likely submit a bug report later regardless; perhaps someone more familiar with ETS will have suggestions for how to minimally recreate the environment that's causing the crash.