### PR TITLE
Don't run top-level code in `.exs` files

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build/document/compilers/elixir.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document/compilers/elixir.ex
@@ -11,8 +11,9 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.Elixir do
   @behaviour Build.Document.Compiler
 
   @impl true
-  def recognizes?(%Document{language_id: "elixir"}), do: true
-  def recognizes?(_), do: false
+  def recognizes?(%Document{} = doc) do
+    doc.language_id in ["elixir", "elixir-script"]
+  end
 
   @impl true
   def enabled?, do: true

--- a/apps/remote_control/lib/lexical/remote_control/build/document/compilers/quoted.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document/compilers/quoted.ex
@@ -1,5 +1,6 @@
 defmodule Lexical.RemoteControl.Build.Document.Compilers.Quoted do
   alias Elixir.Features
+  alias Lexical.Ast
   alias Lexical.Document
   alias Lexical.RemoteControl.Build
   alias Lexical.RemoteControl.ModuleMappings
@@ -138,38 +139,144 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.Quoted do
     Map.put(result, :source, source)
   end
 
-  defp wrap_top_level_forms({:__block__, meta, nodes}) do
-    chunks =
+  @doc false
+  def wrap_top_level_forms({:__block__, meta, nodes}) do
+    {chunks, _vars} =
       nodes
       |> Enum.chunk_by(&should_wrap?/1)
-      |> Enum.with_index(fn [node | _] = nodes, i ->
+      |> Enum.with_index()
+      |> Enum.flat_map_reduce([], fn {[node | _] = nodes, i}, vars ->
         if should_wrap?(node) do
-          wrap_nodes(nodes, i)
+          {wrapped, vars} = wrap_nodes(nodes, vars, i)
+          {[wrapped], vars}
         else
-          nodes
+          {nodes, vars}
         end
       end)
 
     {:__block__, meta, chunks}
   end
 
-  defp wrap_top_level_forms(ast) do
+  def wrap_top_level_forms(ast) do
     wrap_top_level_forms({:__block__, [], [ast]})
   end
 
-  defp wrap_nodes(nodes, i) do
+  defp wrap_nodes(nodes, vars, i) do
     module_name = :"lexical_wrapper_#{i}"
+    {nodes, new_vars} = suppress_and_extract_vars(nodes)
 
-    quote do
-      defmodule unquote(module_name) do
-        def __lexical_wrapper__ do
-          (unquote_splicing(nodes))
+    quoted =
+      quote do
+        defmodule unquote(module_name) do
+          def __lexical_wrapper__([unquote_splicing(vars)]) do
+            (unquote_splicing(nodes))
+          end
         end
       end
-    end
+
+    {quoted, new_vars ++ vars}
   end
 
   @allowed_top_level [:defmodule, :alias, :import, :require, :use]
   defp should_wrap?({allowed, _, _}) when allowed in @allowed_top_level, do: false
   defp should_wrap?(_), do: true
+
+  @doc false
+  # This function replaces all unused variables with `_` in order
+  # to suppress warnings while accumulating those vars. The approach
+  # here is bottom-up, starting from the last expression and working
+  # back to the beginning:
+  #
+  #   - If the expression is an assignment, collect vars from the LHS,
+  #     replacing them with `_` if they haven't been referenced, then
+  #     collect references from the RHS.
+  #   - If the expression isn't an assignment, just collect references.
+  #   - Note that pinned vars on the LHS of an assignment are references.
+  #
+  def suppress_and_extract_vars(quoted)
+
+  def suppress_and_extract_vars(list) when is_list(list) do
+    list
+    |> Enum.reverse()
+    |> do_suppress_and_extract_vars()
+  end
+
+  def suppress_and_extract_vars({:__block__, meta, nodes}) do
+    {nodes, vars} = suppress_and_extract_vars(nodes)
+    {{:__block__, meta, nodes}, vars}
+  end
+
+  def suppress_and_extract_vars(expr) do
+    {[expr], vars} = suppress_and_extract_vars([expr])
+    {expr, vars}
+  end
+
+  defp do_suppress_and_extract_vars(list, acc \\ [], references \\ [], vars \\ [])
+
+  defp do_suppress_and_extract_vars([expr | rest], acc, references, vars) do
+    {expr, new_vars} = suppress_and_extract_vars_from_expr(expr, references)
+    new_references = extract_references_from_expr(expr)
+
+    do_suppress_and_extract_vars(
+      rest,
+      [expr | acc],
+      new_references ++ references,
+      new_vars ++ vars
+    )
+  end
+
+  defp do_suppress_and_extract_vars([], acc, _references, vars) do
+    {acc, vars}
+  end
+
+  defp suppress_and_extract_vars_from_expr({:=, meta, [left, right]}, references) do
+    {left, left_vars} =
+      Ast.prewalk_vars(left, [], fn
+        {:^, _, _} = pinned, acc ->
+          {pinned, acc}
+
+        {name, meta, context} = var, acc ->
+          if Ast.has_var?(references, name, context) do
+            {var, [{name, [], context} | acc]}
+          else
+            {{:_, meta, nil}, [var | acc]}
+          end
+      end)
+
+    {right, right_vars} = suppress_and_extract_vars_from_expr(right, references)
+
+    {{:=, meta, [left, right]}, left_vars ++ right_vars}
+  end
+
+  defp suppress_and_extract_vars_from_expr(other, _references) do
+    {other, []}
+  end
+
+  defp extract_references_from_expr({:=, _, [left, right]}) do
+    {_, left_references} =
+      Ast.prewalk_vars(left, [], fn
+        {:^, _, [referenced_var]}, acc ->
+          {:ok, [referenced_var | acc]}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    right_references = extract_references_from_expr(right)
+
+    left_references ++ right_references
+  end
+
+  defp extract_references_from_expr(expr) do
+    {_, references} =
+      Ast.prewalk_vars(expr, [], fn
+        {:^, _, _}, acc ->
+          {:ok, acc}
+
+        var, acc ->
+          {:ok, [var | acc]}
+      end)
+
+    references
+  end
 end

--- a/apps/remote_control/lib/lexical/remote_control/build/document/compilers/quoted.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/document/compilers/quoted.ex
@@ -9,6 +9,13 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.Quoted do
   def compile(%Document{} = document, quoted_ast, compiler_name) do
     prepare_compile(document.path)
 
+    quoted_ast =
+      if document.language_id == "elixir-script" do
+        wrap_top_level_forms(quoted_ast)
+      else
+        quoted_ast
+      end
+
     {status, diagnostics} =
       if Features.with_diagnostics?() do
         do_compile(quoted_ast, document)
@@ -130,4 +137,39 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.Quoted do
   defp replace_source(result, source) do
     Map.put(result, :source, source)
   end
+
+  defp wrap_top_level_forms({:__block__, meta, nodes}) do
+    chunks =
+      nodes
+      |> Enum.chunk_by(&should_wrap?/1)
+      |> Enum.with_index(fn [node | _] = nodes, i ->
+        if should_wrap?(node) do
+          wrap_nodes(nodes, i)
+        else
+          nodes
+        end
+      end)
+
+    {:__block__, meta, chunks}
+  end
+
+  defp wrap_top_level_forms(ast) do
+    wrap_top_level_forms({:__block__, [], [ast]})
+  end
+
+  defp wrap_nodes(nodes, i) do
+    module_name = :"lexical_wrapper_#{i}"
+
+    quote do
+      defmodule unquote(module_name) do
+        def __lexical_wrapper__ do
+          (unquote_splicing(nodes))
+        end
+      end
+    end
+  end
+
+  @allowed_top_level [:defmodule, :alias, :import, :require, :use]
+  defp should_wrap?({allowed, _, _}) when allowed in @allowed_top_level, do: false
+  defp should_wrap?(_), do: true
 end

--- a/apps/remote_control/test/lexical/remote_control/build/document/compilers/quoted_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/document/compilers/quoted_test.exs
@@ -1,0 +1,137 @@
+defmodule Lexical.RemoteControl.Build.Document.Compilers.QuotedTest do
+  alias Lexical.RemoteControl.Build.Document.Compilers.Quoted
+
+  import Lexical.Test.CodeSigil
+
+  use ExUnit.Case, async: true
+
+  defp parse!(code) do
+    Code.string_to_quoted!(code, columns: true, token_metadata: true)
+  end
+
+  describe "wrap_top_level_forms/1" do
+    test "chunks and wraps unsafe top-level forms" do
+      quoted =
+        ~q[
+          foo = 1
+          bar = foo + 1
+
+          import Something
+
+          defmodule MyModule do
+            :ok
+          end
+
+          baz = bar + foo
+        ]
+        |> parse!()
+
+      assert quoted |> Quoted.wrap_top_level_forms() |> Macro.to_string() == """
+             defmodule :lexical_wrapper_0 do
+               def __lexical_wrapper__([]) do
+                 foo = 1
+                 _ = foo + 1
+               end
+             end
+
+             import Something
+
+             defmodule MyModule do
+               :ok
+             end
+
+             defmodule :lexical_wrapper_2 do
+               def __lexical_wrapper__([foo, bar]) do
+                 _ = bar + foo
+               end
+             end\
+             """
+    end
+  end
+
+  describe "suppress_and_extract_vars/1" do
+    test "suppresses and extracts unused vars" do
+      quoted =
+        ~q[
+          foo = 1
+          bar = 2
+        ]
+        |> parse!()
+
+      assert {suppressed, [{:foo, _, nil}, {:bar, _, nil}]} =
+               Quoted.suppress_and_extract_vars(quoted)
+
+      assert Macro.to_string(suppressed) == """
+             _ = 1
+             _ = 2\
+             """
+    end
+
+    test "suppresses and extracts unused vars in nested assignments" do
+      quoted =
+        ~q[
+          foo = bar = 1
+          baz = qux = 2
+        ]
+        |> parse!()
+
+      assert {suppressed, [{:foo, _, nil}, {:bar, _, nil}, {:baz, _, nil}, {:qux, _, nil}]} =
+               Quoted.suppress_and_extract_vars(quoted)
+
+      assert Macro.to_string(suppressed) == """
+             _ = _ = 1
+             _ = _ = 2\
+             """
+    end
+
+    test "suppresses vars only referenced in RHS" do
+      quoted = ~q[foo = foo + 1] |> parse!()
+
+      assert {suppressed, [{:foo, _, nil}]} = Quoted.suppress_and_extract_vars(quoted)
+
+      assert Macro.to_string(suppressed) == "_ = foo + 1"
+    end
+
+    test "suppresses deeply nested vars" do
+      quoted = ~q[{foo, {bar, %{baz: baz}}} = call()] |> parse!()
+
+      assert {suppressed, [{:baz, _, nil}, {:bar, _, nil}, {:foo, _, nil}]} =
+               Quoted.suppress_and_extract_vars(quoted)
+
+      assert Macro.to_string(suppressed) == "{_, {_, %{baz: _}}} = call()"
+    end
+
+    test "does not suppress vars referenced in a later expression" do
+      quoted =
+        ~q[
+          foo = 1
+          bar = foo + 1
+        ]
+        |> parse!()
+
+      assert {suppressed, [{:foo, _, nil}, {:bar, _, nil}]} =
+               Quoted.suppress_and_extract_vars(quoted)
+
+      assert Macro.to_string(suppressed) == """
+             foo = 1
+             _ = foo + 1\
+             """
+    end
+
+    test "does not suppress vars referenced with pin operator in a later assignment" do
+      quoted =
+        ~q[
+          foo = 1
+          %{^foo => 2} = call()
+        ]
+        |> parse!()
+
+      assert {suppressed, [{:foo, _, nil}]} = Quoted.suppress_and_extract_vars(quoted)
+
+      assert Macro.to_string(suppressed) == """
+             foo = 1
+             %{^foo => 2} = call()\
+             """
+    end
+  end
+end

--- a/apps/remote_control/test/lexical/remote_control/build_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build_test.exs
@@ -24,7 +24,7 @@ defmodule Lexical.BuildTest do
         project
         |> Project.root_path()
         |> Path.join(to_string(sequence))
-        |> Path.join("file.exs")
+        |> Path.join("file.ex")
         |> Document.Path.to_uri()
       end
 

--- a/apps/remote_control/test/lexical/remote_control/build_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build_test.exs
@@ -647,6 +647,30 @@ defmodule Lexical.BuildTest do
     end
   end
 
+  describe ".exs files" do
+    setup do
+      start_supervised!(RemoteControl.Dispatch)
+      start_supervised!(RemoteControl.ModuleMappings)
+      start_supervised!(Build.CaptureServer)
+      :ok
+    end
+
+    test "should not run top-level forms" do
+      source = ~S[
+        IO.puts("fail")
+      ]
+
+      doc = Document.new("file:///file.exs", source, 0)
+
+      captured =
+        ExUnit.CaptureIO.capture_io(fn ->
+          Build.Document.compile(doc)
+        end)
+
+      refute captured =~ "fail"
+    end
+  end
+
   if Features.after_verify?() do
     describe "exceptions during compilation" do
       test "compiling a project with callback errors" do

--- a/projects/lexical_shared/lib/lexical/document.ex
+++ b/projects/lexical_shared/lib/lexical/document.ex
@@ -48,7 +48,12 @@ defmodule Lexical.Document do
     uri = DocumentPath.ensure_uri(maybe_uri)
     path = DocumentPath.from_uri(uri)
 
-    language_id = language_id || language_id_from_path(path)
+    language_id =
+      if String.ends_with?(path, ".exs") do
+        "elixir-script"
+      else
+        language_id || language_id_from_path(path)
+      end
 
     %__MODULE__{
       uri: uri,
@@ -233,7 +238,7 @@ defmodule Lexical.Document do
         "elixir"
 
       ".exs" ->
-        "elixir"
+        "elixir-script"
 
       ".eex" ->
         "eex"


### PR DESCRIPTION
Lexical's as-you-type compilation and error reporting works by parsing the AST after a small period of quiescence and then compiling it with `Code.compile_quoted/2`. This runs top-level forms, however, so a `.exs` script that performs side-effects when run, e.g. creating or deleting a file, would have them run repeatedly unless you wrap them in a `def` inside a module.

The goal, then, becomes reporting on as many errors/warnings as possible without running top-level forms.

The current approach here is to chunk all top-level forms into "safe" and "unsafe", where safe forms are only `defmodule/use/import/require/alias`. Safe forms stay at the top level, while unsafe forms are wrapped to prevent their execution. Concretely, this script:

```elixir
# my_script.exs

import Foo

call_1()

defmodule Bar do
  ...
end

call_2()
call_3()
```

would be transformed to this after parsing, but prior to compilation:

```elixir
# my_script.exs

import Foo

defmodule :lexical_wrapper_0 do
  def __lexical_wrapper__ do
    call_1()
  end
end

defmodule Bar do
  ...
end

defmodule :lexical_wrapper_2 do
  def __lexical_wrapper__ do
    call_2()
    call_3()
  end
end
```

## Issue 1: Incorrect unused/undefined var warnings

This isn't quite good enough, though. It means that if you, for instance, set some constants in your script at the top, you'd get warnings for any usage below if they're separated by a "safe" form. For instance:

```elixir
dir = "..."
import Something
call(dir)

# would transform into

defmodule :lexical_wrapper_0 do
  def __lexical_wrapper__ do
    dir = "..."
  end
end

import Something

defmodule :lexical_wrapper_2 do
  def __lexical_wrapper__ do
    call(dir)
  end
end
```

This would result in a warning where `dir` is assigned (unused variable) and an error where `dir` is used (undefined variable).

Potential solution: collect vars and references in each chunk of top-level code, replacing unused vars with `_var`. Then, for any later chunks, use those vars to build "stub parameters" in the wrapper def to avoid undefined variable errors.

```elixir
defmodule :lexical_wrapper_0 do
  def __lexical_wrapper__([]) do
    _dir = "..."
  end
end

import Something

defmodule :lexical_wrapper_2 do
  def __lexical_wrapper__([dir]) do
    call(dir)
  end
end
```

## Issue 2: Using top-level var as a module name

The approach above will break this code:

```elixir
module_name = My.Module
defmodule module_name do
  :ok
end
```

I'm personally okay with this as a "known defect" that perhaps could be tackled later on, though I'm not sure a perfect solution exists.

## Things this explicitly doesn't address

- `Mix.install`, which will require wider changes in order to support. Any usage of deps coming from the `Mix.install` will show "undefined" warnings. To actually support it, we'd need to consider that file its own project, because install doesn't work inside an existing mix project. I think this will be easier to support when we support multiple workspaces.