### PR TITLE
Alias `LXical` as `Lexical` in IEx

### DIFF
--- a/.iex.namespaced.exs
+++ b/.iex.namespaced.exs
@@ -1,1 +1,2 @@
 use LXical.Server.IEx.Helpers
+alias LXical, as: Lexical


### PR DESCRIPTION
This makes it just a little bit easier to run code in IEx when connected to a running project.