### PR TITLE
Upgrade elixir_sense

### DIFF
--- a/apps/remote_control/mix.exs
+++ b/apps/remote_control/mix.exs
@@ -44,7 +44,7 @@ defmodule Lexical.RemoteControl.MixProject do
     [
       {:benchee, "~> 1.1", only: :test},
       {:common, in_umbrella: true},
-      {:elixir_sense, git: "https://github.com/elixir-lsp/elixir_sense.git"},
+      {:elixir_sense, github: "elixir-lsp/elixir_sense"},
       {:lexical_plugin, path: "../../projects/lexical_plugin"},
       {:lexical_shared, path: "../../projects/lexical_shared"},
       {:lexical_test, path: "../../projects/lexical_test", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "dialyxir": {:hex, :dialyxir, "1.4.3", "edd0124f358f0b9e95bfe53a9fcf806d615d8f838e2202a9f430d59566b6b53b", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "bf2cfb75cd5c5006bec30141b131663299c661a864ec7fbbc72dfa557487a986"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.32", "fa739a0ecfa34493de19426681b23f6814573faee95dfd4b4aafe15a7b5b32c6", [:mix], [], "hexpm", "b8b0dd77d60373e77a3d7e8afa598f325e49e8663a51bcc2b88ef41838cca755"},
-  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "4adfc55dc6902f56e6d070e14fba768a0ff05bd3", []},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "0c98e656cf60d4b693376a2013a312039560b95d", []},
   "erlex": {:hex, :erlex, "0.2.7", "810e8725f96ab74d17aac676e748627a07bc87eb950d2b83acd29dc047a30595", [:mix], [], "hexpm", "3ed95f79d1a844c3f6bf0cea61e0d5612a42ce56da9c03f01df538685365efb0"},
   "ex_doc": {:hex, :ex_doc, "0.29.4", "6257ecbb20c7396b1fe5accd55b7b0d23f44b6aa18017b415cb4c2b91d997729", [:mix], [{:earmark_parser, "~> 1.4.31", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "2c6699a737ae46cb61e4ed012af931b57b699643b24dabe2400a8168414bc4f5"},
   "file_system": {:hex, :file_system, "1.0.0", "b689cc7dcee665f774de94b5a832e578bd7963c8e637ef940cd44327db7de2cd", [:mix], [], "hexpm", "6752092d66aec5a10e662aefeed8ddb9531d79db0bc145bb8c40325ca1d8536d"},


### PR DESCRIPTION
Elixir sense was doing a compile-time check for a certain feature, and since Lexical is built on an older version of elixir than it often runs on, the check ended up being wrong. We submitted a PR to elixir_sense and now can fix the bug.