### PR TITLE
simplify default config

### DIFF
--- a/pages/installation.md
+++ b/pages/installation.md
@@ -176,30 +176,15 @@ of whether you are using mason or others, you can use this
 configuration below as a reference:
 
 ```lua
-    local lspconfig = require("lspconfig")
-    local configs = require("lspconfig.configs")
-
-    local lexical_config = {
-      filetypes = { "elixir", "eelixir", "heex" },
-      cmd = { "/my/home/projects/_build/dev/package/lexical/bin/start_lexical.sh" },
-      settings = {},
-    }
-
-    if not configs.lexical then
-      configs.lexical = {
-        default_config = {
-          filetypes = lexical_config.filetypes,
-          cmd = lexical_config.cmd,
-          root_dir = function(fname)
-            return lspconfig.util.root_pattern("mix.exs", ".git")(fname) or vim.loop.os_homedir()
-          end,
-          -- optional settings
-          settings = lexical_config.settings,
-        },
-      }
-    end
-
-    lspconfig.lexical.setup({})
+require('lspconfig').lexical.setup {
+  cmd = { "my/home/projects/_build/dev/package/lexical/bin/start_lexical.sh" },
+  root_dir = function(fname)
+    return util.root_pattern("mix.exs", ".git")(fname) or vim.loop.cwd()
+  end,
+  filetypes = { "elixir", "eelixir", "heex" },
+  -- optional settings
+  settings = {}
+}
 ```
 
 If the configuration above doesn't work for you, please try this minimal [neovim configuration](https://github.com/scottming/nvim-mini-for-lexical), It can eliminate other plugin factors.


### PR DESCRIPTION
related to: https://github.com/lexical-lsp/lexical/issues/803

i was looking around for an optimal pattern (for example [here](https://github.com/neovim/nvim-lspconfig/blob/ff97d376b1d22b2eaf9274605531babf0cd0cf21/doc/lspconfig.txt#L355) and [here](https://github.com/neovim/nvim-lspconfig/blob/ff97d376b1d22b2eaf9274605531babf0cd0cf21/doc/server_configurations.md)) any my conclusion as of now is:

- it's quite hard to avoid opinionated example.
- for what it's worth, majority of example configs are rather simple.
- good example configuration probably should target first-time user (more experienced user will likely have their own patterns to follow and experience to implement those).

i did some basic testing with `v0.7.0` compiled against `Elixir 1.17.0 (compiled with Erlang/OTP 27)`.