### PR TITLE
Update the Nix hash on PR, not on the main branch

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -14,8 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
-      - run: |
-          nix run .#update-hash | tee nix/hash
-          git config user.email ""
-          git config user.name "GitHub Action Bot"
-          git commit -m 'Update Nix hash of Mix deps' nix/hash && git push || true
+      - run: nix run .#update-hash | tee nix/hash
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'Update Nix hash of Mix deps'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,3 +19,4 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'Update Nix hash of Mix deps'
+      - run: nix build

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -3,6 +3,7 @@ name: Nix derivation checks
 on:
   pull_request:
     paths: ["mix.lock"]
+  workflow_dispatch:
 
 jobs:
   auto-update-nix-hash:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,8 +1,7 @@
 name: Nix derivation checks
 
 on:
-  push:
-    branches: ["main"]
+  pull_request:
     paths: ["mix.lock"]
 
 jobs:


### PR DESCRIPTION
Fixes #816. 

Also, `nix build` is run on the last step, to ensure the Nix package can be built successfully.