### PR TITLE
Convert all exceptions in config files into diagnostics

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build/error.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/error.ex
@@ -146,7 +146,7 @@ defmodule Lexical.RemoteControl.Build.Error do
         mfa = {module, function, arity}
         mfa_to_position(mfa, quoted_ast)
       else
-        stack_to_position(stack)
+        Location.stack_to_position(stack)
       end
 
     Result.new(source.uri, position, message, :error, @elixir_source)
@@ -182,7 +182,7 @@ defmodule Lexical.RemoteControl.Build.Error do
       if pipe_or_struct? or expanding? do
         Location.context_to_position(context)
       else
-        stack_to_position(stack)
+        Location.stack_to_position(stack)
       end
 
     Result.new(source.uri, position, message, :error, @elixir_source)
@@ -195,7 +195,7 @@ defmodule Lexical.RemoteControl.Build.Error do
              ExUnit.DuplicateDescribeError
            ] do
     message = Exception.message(exception)
-    position = stack_to_position(stack)
+    position = Location.stack_to_position(stack)
     Result.new(source.uri, position, message, :error, @elixir_source)
   end
 
@@ -279,20 +279,6 @@ defmodule Lexical.RemoteControl.Build.Error do
       {:elixir, segments} -> segments
       {:erlang, [erlang_module]} -> erlang_module
     end
-  end
-
-  defp stack_to_position([{_, target, _, _} | rest])
-       when target not in [:__FILE__, :__MODULE__] do
-    stack_to_position(rest)
-  end
-
-  defp stack_to_position([{_, target, _, context} | _rest])
-       when target in [:__FILE__, :__MODULE__] do
-    Location.context_to_position(context)
-  end
-
-  defp stack_to_position([]) do
-    nil
   end
 
   defp do_message_to_diagnostic(_, "") do

--- a/apps/remote_control/lib/lexical/remote_control/build/error/location.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/error/location.ex
@@ -6,6 +6,20 @@ defmodule Lexical.RemoteControl.Build.Error.Location do
 
   require Logger
 
+  def stack_to_position([{_, target, _, _} | rest])
+      when target not in [:__FILE__, :__MODULE__] do
+    stack_to_position(rest)
+  end
+
+  def stack_to_position([{_, target, _, context} | _rest])
+      when target in [:__FILE__, :__MODULE__] do
+    context_to_position(context)
+  end
+
+  def stack_to_position([]) do
+    nil
+  end
+
   def context_to_position(context) do
     case {context[:line], context[:column]} do
       {nil, nil} ->

--- a/apps/remote_control/test/lexical/remote_control/build/document/compilers/config_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/document/compilers/config_test.exs
@@ -121,6 +121,25 @@ defmodule Lexical.RemoteControl.Build.Document.Compilers.ConfigTest do
       assert result.source == "Elixir"
     end
 
+    test "it produces diagnostics for arbitrary exceptions" do
+      assert {:error, [result]} =
+               ~q[
+                 import Config
+
+                 System.fetch_env!("_LEXICAL_NON_EXISTING_ENV_VAR_")
+               ]
+               |> document()
+               |> compile()
+
+      assert result.message =~ "could not fetch environment variable"
+      assert result.severity == :error
+      assert result.source == "Elixir"
+
+      if Features.with_diagnostics?() do
+        assert result.position == 3
+      end
+    end
+
     test "it produces no diagnostics on success" do
       assert {:ok, []} =
                ~q[

--- a/integration/boot/set_up_mise.sh
+++ b/integration/boot/set_up_mise.sh
@@ -27,7 +27,6 @@ chmod +x ./mise
 eval "$(./mise activate bash)"
 
 export KERL_CONFIGURE_OPTIONS="--disable-debug --without-javac --without-termcap --without-wx"
-./mise plugin install -y erlang
 ./mise use --global "erlang@$ERLANG_VERSION"
 
 ./mise plugins install -y elixir


### PR DESCRIPTION
Only some exceptions raised when evaluating a config file using `Config.Reader.eval!/3` were being converted into diagnostics -- any others would result in a function clause error in the config compiler's private `to_result/2`. This function clause error would then be caught and result in another function clause error down the line, the eventual result of which was that diagnostics for config files would be incorrect. 