### PR TITLE
Server bottlenecks

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/mix.ex
+++ b/apps/remote_control/lib/lexical/remote_control/mix.ex
@@ -1,7 +1,6 @@
 defmodule Lexical.RemoteControl.Mix do
   alias Lexical.Project
   alias Lexical.RemoteControl
-  alias Lexical.RemoteControl.Build
 
   def in_project(fun) do
     if RemoteControl.project_node?() do
@@ -17,7 +16,7 @@ defmodule Lexical.RemoteControl.Mix do
 
     old_cwd = File.cwd!()
 
-    Build.with_lock(fn ->
+    with_lock(fn ->
       try do
         Mix.ProjectStack.post_config(prune_code_paths: false)
 
@@ -47,5 +46,9 @@ defmodule Lexical.RemoteControl.Mix do
         File.cd!(old_cwd)
       end
     end)
+  end
+
+  defp with_lock(fun) do
+    RemoteControl.with_lock(__MODULE__, fun)
   end
 end

--- a/apps/server/lib/lexical/server/task_queue.ex
+++ b/apps/server/lib/lexical/server/task_queue.ex
@@ -119,11 +119,7 @@ defmodule Lexical.Server.TaskQueue do
     end
 
     defp write_error(id, message, code \\ :internal_error) do
-      error =
-        ResponseError.new(
-          code: code,
-          message: message
-        )
+      error = ResponseError.new(code: code, message: message)
 
       Transport.write(%{id: id, error: error})
     end
@@ -133,7 +129,8 @@ defmodule Lexical.Server.TaskQueue do
     end
 
     defp cancel_task(%Task{} = task) do
-      Task.Supervisor.terminate_child(task_supervisor_name(), task.pid)
+      Process.exit(task.pid, :canceled)
+      :ok
     end
   end
 


### PR DESCRIPTION
Fixed two bottlenecks in the server. 

1. The mix lock was using a much more contentious build lock rather than its own lock.
2. Using `Task.Supervisor.terminate_child` was causing timeouts when bulk operations happen.