### PR TITLE
Improve performance under batch operations

### DIFF
--- a/apps/remote_control/test/lexical/remote_control/build/state_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/state_test.exs
@@ -76,9 +76,8 @@ defmodule Lexical.RemoteControl.Build.StateTest do
     setup [:with_metadata_project, :with_a_valid_document, :with_patched_compilation]
 
     test "it doesn't compile immediately", %{state: state, document: document} do
-      new_state = State.on_file_compile(state, document)
+      State.on_file_compile(state, document)
 
-      assert State.compile_scheduled?(new_state, document.uri)
       refute_called(Build.Document.compile(document))
       refute_called(Build.Project.compile(_, _))
     end

--- a/apps/remote_control/test/lexical/remote_control/build/state_test.exs
+++ b/apps/remote_control/test/lexical/remote_control/build/state_test.exs
@@ -6,7 +6,6 @@ defmodule Lexical.RemoteControl.Build.StateTest do
   alias Lexical.RemoteControl.Build.State
   alias Lexical.RemoteControl.Plugin
 
-  import Lexical.Test.EventualAssertions
   import Lexical.Test.Fixtures
 
   use ExUnit.Case, async: false
@@ -67,22 +66,89 @@ defmodule Lexical.RemoteControl.Build.StateTest do
     {:ok, document: document}
   end
 
-  describe "throttled compilation" do
-    setup [:with_metadata_project, :with_a_valid_document]
+  def with_patched_compilation(_) do
+    patch(Build.Document, :compile, :ok)
+    patch(Build.Project, :compile, :ok)
+    :ok
+  end
+
+  describe "throttled document compilation" do
+    setup [:with_metadata_project, :with_a_valid_document, :with_patched_compilation]
 
     test "it doesn't compile immediately", %{state: state, document: document} do
-      new_state =
-        state
-        |> State.on_file_compile(document)
-        |> State.on_tick()
+      new_state = State.on_file_compile(state, document)
 
       assert State.compile_scheduled?(new_state, document.uri)
+      refute_called(Build.Document.compile(document))
+      refute_called(Build.Project.compile(_, _))
     end
 
-    test "it compiles after a timeout", %{state: state, document: document} do
-      state = State.on_file_compile(state, document)
+    test "it compiles files when on_timeout is called", %{state: state, document: document} do
+      state
+      |> State.on_file_compile(document)
+      |> State.on_timeout()
 
-      refute_eventually(State.compile_scheduled?(State.on_tick(state), document.uri), 500)
+      assert_called(Build.Document.compile(document))
+      refute_called(Build.Project.compile(_, _))
+    end
+  end
+
+  describe "throttled project compilation" do
+    setup [:with_metadata_project, :with_a_valid_document, :with_patched_compilation]
+
+    test "doesn't compile immediately if forced", %{state: state} do
+      State.on_project_compile(state, true)
+      refute_called(Build.Project.compile(_, _))
+    end
+
+    test "doesn't compile immediately", %{state: state} do
+      State.on_project_compile(state, false)
+      refute_called(Build.Project.compile(_, _))
+    end
+
+    test "compiles if force is true after on_timeout is called", %{state: state} do
+      state
+      |> State.on_project_compile(true)
+      |> State.on_timeout()
+
+      assert_called(Build.Project.compile(_, true))
+    end
+
+    test "compiles after on_timeout is called", %{state: state} do
+      state
+      |> State.on_project_compile(false)
+      |> State.on_timeout()
+
+      assert_called(Build.Project.compile(_, false))
+    end
+  end
+
+  describe "mixed compilation" do
+    setup [:with_metadata_project, :with_a_valid_document, :with_patched_compilation]
+
+    test "doesn't compile if both documents and projects are added", %{
+      state: state,
+      document: document
+    } do
+      state
+      |> State.on_project_compile(false)
+      |> State.on_file_compile(document)
+
+      refute_called(Build.Document.compile(_))
+      refute_called(Build.Project.compile(_, _))
+    end
+
+    test "compiles when on_timeout is called if both documents and projects are added", %{
+      state: state,
+      document: document
+    } do
+      state
+      |> State.on_project_compile(false)
+      |> State.on_file_compile(document)
+      |> State.on_timeout()
+
+      assert_called(Build.Document.compile(_))
+      assert_called(Build.Project.compile(_, _))
     end
   end
 end

--- a/apps/server/lib/lexical/convertibles/lexical.plugin.diagnostic.result.ex
+++ b/apps/server/lib/lexical/convertibles/lexical.plugin.diagnostic.result.ex
@@ -41,10 +41,14 @@ defimpl Lexical.Convertible, for: Lexical.Plugin.V1.Diagnostic.Result do
     Conversions.to_lsp(range)
   end
 
-  defp lsp_range(%Diagnostic.Result{} = diagnostic) do
-    with {:ok, document} <- Document.Store.open_temporary(diagnostic.uri) do
+  defp lsp_range(%Diagnostic.Result{uri: uri} = diagnostic) when is_binary(uri) do
+    with {:ok, document} <- Document.Store.open_temporary(uri) do
       position_to_range(document, diagnostic.position)
     end
+  end
+
+  defp lsp_range(%Diagnostic.Result{}) do
+    {:error, :no_uri}
   end
 
   defp position_to_range(%Document{} = document, {start_line, start_column, end_line, end_column}) do

--- a/projects/lexical_shared/lib/lexical/document/store.ex
+++ b/projects/lexical_shared/lib/lexical/document/store.ex
@@ -268,7 +268,7 @@ defmodule Lexical.Document.Store do
 
   @spec open_temporary(Lexical.uri() | Path.t(), timeout()) ::
           {:ok, Document.t()} | {:error, term()}
-  def open_temporary(uri, timeout \\ 5000) do
+  def open_temporary(uri, timeout \\ 5000) when is_binary(uri) do
     ProcessCache.trans(uri, 50, fn ->
       GenServer.call(name(), {:open_temporarily, uri, timeout})
     end)


### PR DESCRIPTION
This commit seeks to improve the performance under batch operations by holding off compilations until after a period of quiescence. Prior, we were building every 100 or so milliseconds, but this would cause builds to happen during batch operations.

Instead, this PR dramatically simplifies the build process to utilize timeouts to detect a quiet period after which builds can commence.

I also found a missed case while transforming diagnostics into elixir that caused crashes that took down the project node. I was unaware that the uri of a diagnostic can be nil (how?!?).

Prior to this PR, mass renames would never finish in emacs, and now they can.