### PR TITLE
add Mix.ensure_application!(:observer) to .iex.exs

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,1 +1,7 @@
 use Lexical.Server.IEx.Helpers
+
+try do
+  Mix.ensure_application!(:observer)
+rescue
+  _ -> nil
+end


### PR DESCRIPTION
Ensures that `:observer` can be started from iex. Wrapped in try rescue in case the erlang install being used doesn't have wx/observer.