### PR TITLE
[feat] Loosen find_references

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/code_intelligence/references.ex
+++ b/apps/remote_control/lib/lexical/remote_control/code_intelligence/references.ex
@@ -35,15 +35,18 @@ defmodule Lexical.RemoteControl.CodeIntelligence.References do
   end
 
   defp find_references(
-         {:call, module, function_name, arity},
+         {:call, module, function_name, _arity},
          _analysis,
          _position,
          include_definitions?
        ) do
-    subject = Subject.mfa(module, function_name, arity)
+    subject = Subject.mfa(module, function_name, "")
     subtype = subtype(include_definitions?)
 
-    query(subject, type: {:function, :_}, subtype: subtype)
+    case Store.prefix(subject, type: {:function, :_}, subtype: subtype) do
+      {:ok, entries} -> Enum.map(entries, &to_location/1)
+      _ -> []
+    end
   end
 
   defp find_references(


### PR DESCRIPTION
Prior, find references would take the arity into account. This was because in elixir, a function is defined by its name and its arity. However in practice, you more than not want to see a all the calls of a function with a given name rather than a specific head. This is especially true for functions with default arguments.

As a result, this change looks for functions with a given name and any arity.