### PR TITLE
[chore] Allow compression for erlang >= 27.1

### DIFF
--- a/apps/common/lib/elixir/features.ex
+++ b/apps/common/lib/elixir/features.ex
@@ -30,14 +30,13 @@ defmodule Elixir.Features do
 
   A bug in Erlang/OTP 27.0.0 and 27.0.1 can cause a segfault when
   traversing the entire table with something like `:ets.foldl/3` if the
-  `:compressed` table option is used. When this is fixed, we can change
-  the version check to `"< 27.0.0 or >= 27.X"`.
+  `:compressed` table option is used. The issue was fixed in Erlang 27.1
 
-  Issue to track: https://github.com/erlang/otp/issues/8682
+  Relevant issue: https://github.com/erlang/otp/issues/8682
   """
   def can_use_compressed_ets_table? do
     %{erlang: erlang_version} = Versions.to_versions(Versions.current())
 
-    Version.match?(erlang_version, "< 27.0.0")
+    Version.match?(erlang_version, "< 27.0.0 or >= 27.1")
   end
 end

--- a/apps/common/lib/elixir/features.ex
+++ b/apps/common/lib/elixir/features.ex
@@ -37,6 +37,6 @@ defmodule Elixir.Features do
   def can_use_compressed_ets_table? do
     %{erlang: erlang_version} = Versions.to_versions(Versions.current())
 
-    Version.match?(erlang_version, "< 27.0.0 or >= 27.1")
+    Version.match?(erlang_version, "< 27.0.0 or >= 27.1.0")
   end
 end


### PR DESCRIPTION
Re enables compression for erlang 27.1, as the bug with ets compression was fixed.