### PR TITLE
Show syntax macro completions when `Kernel.` is prefixed to the cursor.

### DIFF
--- a/apps/remote_control/lib/lexical/remote_control/build/project.ex
+++ b/apps/remote_control/lib/lexical/remote_control/build/project.ex
@@ -91,8 +91,10 @@ defmodule Lexical.RemoteControl.Build.Project do
       Mix.Task.run(:loadconfig)
     end
 
-    with_progress "mix deps.compile", fn ->
-      Mix.Task.run("deps.safe_compile", ~w(--skip-umbrella-children))
+    unless Elixir.Features.compile_keeps_current_directory?() do
+      with_progress "mix deps.compile", fn ->
+        Mix.Task.run("deps.safe_compile", ~w(--skip-umbrella-children))
+      end
     end
 
     with_progress "loading plugins", fn ->

--- a/apps/remote_control/lib/lexical/remote_control/completion.ex
+++ b/apps/remote_control/lib/lexical/remote_control/completion.ex
@@ -8,6 +8,7 @@ defmodule Lexical.RemoteControl.Completion do
   alias Lexical.RemoteControl.Completion.Candidate
 
   import Document.Line
+  import Lexical.Debug
 
   def elixir_sense_expand(%Env{} = env) do
     {doc_string, position} = strip_struct_operator(env)
@@ -19,11 +20,22 @@ defmodule Lexical.RemoteControl.Completion do
     if String.trim(hint) == "" do
       []
     else
-      {_formatter, opts} = Format.formatter_for_file(env.project, env.document.path)
+      {_formatter, opts} =
+        log_timed("formatter for file", fn ->
+          Format.formatter_for_file(env.project, env.document.path)
+        end)
+
+
       locals_without_parens = Keyword.fetch!(opts, :locals_without_parens)
 
-      for suggestion <- ElixirSense.suggestions(doc_string, line, character),
-          candidate = from_elixir_sense(suggestion, locals_without_parens),
+      for suggestion <-
+            log_timed("ES suggestions", fn ->
+              ElixirSense.suggestions(doc_string, line, character)
+            end),
+          candidate =
+            log_timed("from_elixir_sense", fn ->
+              from_elixir_sense(suggestion, locals_without_parens)
+            end),
           candidate != nil do
         candidate
       end

--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
@@ -8,9 +8,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
 
   @syntax_macros ~w(= == == === =~ .. ..// ! != !== &&)
 
-  def completion(%_callable_module{name: name}, _env)
+  def completion(%_callable_module{name: name} = callable, %Env{} = env)
       when name in @syntax_macros do
-    :skip
+    if String.ends_with?(env.prefix, "Kernel.") do
+      do_completion(callable, env)
+    else
+      :skip
+    end
   end
 
   def completion(%callable_module{arity: 0} = callable, %Env{} = env)

--- a/apps/server/lib/lexical/server/task_queue.ex
+++ b/apps/server/lib/lexical/server/task_queue.ex
@@ -3,6 +3,7 @@ defmodule Lexical.Server.TaskQueue do
     alias Lexical.Proto.Convert
     alias Lexical.Proto.LspTypes.ResponseError
     alias Lexical.Server.Transport
+    import Lexical.Debug
     require Logger
 
     defstruct ids_to_tasks: %{}, pids_to_ids: %{}
@@ -55,6 +56,7 @@ defmodule Lexical.Server.TaskQueue do
           state
 
         {request_id, new_pids_to_ids} ->
+          log_task_run_time(state.ids_to_tasks[request_id], :success)
           maybe_log_task(reason, request_id)
 
           %__MODULE__{
@@ -93,11 +95,11 @@ defmodule Lexical.Server.TaskQueue do
         end
       end
 
-      run_task(handler)
+      run_task(handler, {m, f, a})
     end
 
     defp write_reply(response) do
-      case Convert.to_lsp(response) do
+      case log_timed("convert", fn -> Convert.to_lsp(response) end) do
         {:ok, lsp_response} ->
           Transport.write(lsp_response)
 
@@ -124,13 +126,30 @@ defmodule Lexical.Server.TaskQueue do
       Transport.write(%{id: id, error: error})
     end
 
-    defp run_task(fun) when is_function(fun) do
-      Task.Supervisor.async_nolink(task_supervisor_name(), fun)
+    defp run_task(fun, mfa) when is_function(fun) do
+      task_supervisor_name()
+      |> Task.Supervisor.async_nolink(fun)
+      |> Map.merge(%{started_at: System.system_time(:microsecond), mfa: mfa})
     end
 
     defp cancel_task(%Task{} = task) do
+      log_task_run_time(task, :canceled)
       Process.exit(task.pid, :canceled)
       :ok
+    end
+
+    defp log_task_run_time(%Task{} = task, result) do
+      case task do
+        %{started_at: ts, mfa: {m, f, a}} ->
+          elapsed = System.system_time(:microsecond) - ts
+
+          Logger.warning(
+            "Task #{m}.#{f}/#{length(a)} ran for  #{Lexical.Formats.time(elapsed)}. Result #{inspect(result)}"
+          )
+
+        _ ->
+          :ok
+      end
     end
   end
 

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
@@ -906,14 +906,23 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
              inside_exunit_context("describe \"${1:message}\" do\n  $0\nend")
   end
 
-  test "syntax macros", %{project: project} do
-    assert [] = complete(project, "a =|")
-    assert [] = complete(project, "a ==|")
-    assert [] = complete(project, "a ..|")
-    assert [] = complete(project, "a !|")
-    assert [] = complete(project, "a !=|")
-    assert [] = complete(project, "a !==|")
-    assert [] = complete(project, "a &&|")
+  describe "syntax macros" do
+    test "completions are skipped for syntax macros", %{project: project} do
+      assert [] = complete(project, "a =|")
+      assert [] = complete(project, "a ==|")
+      assert [] = complete(project, "a ..|")
+      assert [] = complete(project, "a !|")
+      assert [] = complete(project, "a !=|")
+      assert [] = complete(project, "a !==|")
+      assert [] = complete(project, "a &&|")
+    end
+
+    test "completions are shown for syntax macros when `Kernel.|` is prefixed.", %{
+      project: project
+    } do
+      completions = complete(project, ":some_expression && Kernel.|")
+      assert length(completions) > 0
+    end
   end
 
   defp inside_exunit_context(text) do

--- a/projects/lexical_shared/lib/lexical/debug.ex
+++ b/projects/lexical_shared/lib/lexical/debug.ex
@@ -1,0 +1,32 @@
+defmodule Lexical.Debug do
+  require Logger
+
+  defmacro timed(label, do: block) do
+    if enabled?() do
+      quote do
+        log_timed(unquote(label), fn -> unquote(block) end)
+      end
+    else
+      block
+    end
+  end
+
+  def log_timed(label, threshold_ms \\ 1, function) when is_function(function, 0) do
+    if enabled?() do
+      {elapsed_us, result} = :timer.tc(function)
+      elapsed_ms = elapsed_us / 1000
+
+      if elapsed_ms >= threshold_ms do
+        Logger.info("#{label} took #{Lexical.Formats.time(elapsed_us)}")
+      end
+
+      result
+    else
+      function.()
+    end
+  end
+
+  defp enabled? do
+    true
+  end
+end


### PR DESCRIPTION
Closes #832.

This solution is imperfect because it requires the prefix to end exactly with `Kernel.`

However it works in most cases because:
* Completions are usually requested at the point of `Kernel.|`
* Completions are cached by clients for the next few characters.

In the exceptional rare case where a user copy/pastes something like `Kernel.=|` and requests a completion, these won't show. Not a perfectly correct solution, but our handling of syntax macros is already a matter of taste, so ¯\\\_(ツ)\_/¯