### PR TITLE
Show syntax macro completions when `Kernel.` is prefixed to the cursor.

### DIFF
--- a/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
+++ b/apps/server/lib/lexical/server/code_intelligence/completion/translations/callable.ex
@@ -8,9 +8,13 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.Callable do
 
   @syntax_macros ~w(= == == === =~ .. ..// ! != !== &&)
 
-  def completion(%_callable_module{name: name}, _env)
+  def completion(%_callable_module{name: name} = callable, %Env{} = env)
       when name in @syntax_macros do
-    :skip
+    if String.ends_with?(env.prefix, "Kernel.") do
+      do_completion(callable, env)
+    else
+      :skip
+    end
   end
 
   def completion(%callable_module{arity: 0} = callable, %Env{} = env)

--- a/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
+++ b/apps/server/test/lexical/server/code_intelligence/completion/translations/macro_test.exs
@@ -906,14 +906,23 @@ defmodule Lexical.Server.CodeIntelligence.Completion.Translations.MacroTest do
              inside_exunit_context("describe \"${1:message}\" do\n  $0\nend")
   end
 
-  test "syntax macros", %{project: project} do
-    assert [] = complete(project, "a =|")
-    assert [] = complete(project, "a ==|")
-    assert [] = complete(project, "a ..|")
-    assert [] = complete(project, "a !|")
-    assert [] = complete(project, "a !=|")
-    assert [] = complete(project, "a !==|")
-    assert [] = complete(project, "a &&|")
+  describe "syntax macros" do
+    test "completions are skipped for syntax macros", %{project: project} do
+      assert [] = complete(project, "a =|")
+      assert [] = complete(project, "a ==|")
+      assert [] = complete(project, "a ..|")
+      assert [] = complete(project, "a !|")
+      assert [] = complete(project, "a !=|")
+      assert [] = complete(project, "a !==|")
+      assert [] = complete(project, "a &&|")
+    end
+
+    test "completions are shown for syntax macros when `Kernel.|` is prefixed.", %{
+      project: project
+    } do
+      completions = complete(project, ":some_expression && Kernel.|")
+      assert length(completions) > 0
+    end
   end
 
   defp inside_exunit_context(text) do


### PR DESCRIPTION
Closes #832.

This solution is imperfect because it requires the prefix to end exactly with `Kernel.`

However it works in most cases because:
* Completions are usually requested at the point of `Kernel.|`
* Completions are cached by clients for the next few characters.

In the exceptional rare case where a user copy/pastes something like `Kernel.=|` and requests a completion, these won't show. Not a perfectly correct solution, but our handling of syntax macros is already a matter of taste, so ¯\\\_(ツ)\_/¯